### PR TITLE
Fix Claude Code plugin manifest schema validation errors

### DIFF
--- a/.claude-plugin/agents/neo.md
+++ b/.claude-plugin/agents/neo.md
@@ -1,0 +1,52 @@
+# Neo - Semantic Reasoning Helper
+
+Semantic reasoning helper using multi-agent MapCoder approach with persistent memory.
+
+## Description
+
+Use this agent when you need to analyze code through semantic reasoning with multi-agent collaboration and persistent memory. Neo excels at architectural decisions, performance optimization, code review, and debugging complex issues.
+
+## Core Capabilities
+
+- **Multi-agent reasoning** using Solver, Critic, and Verifier agents
+- **Semantic memory** that learns from past solutions and failures
+- **Confidence scoring** for all recommendations
+- **Pattern recognition** for architectural patterns
+- **Reinforcement learning** to improve over time
+
+## When to Use Neo
+
+Use the Neo agent for:
+- Architectural guidance and design decisions
+- Performance optimization analysis
+- Code review with semantic pattern matching
+- Debugging complex or intermittent issues
+- Pattern extraction from codebase
+
+## Usage
+
+The Neo agent will:
+1. Gather relevant codebase context using Read, Grep, Glob tools
+2. Formulate a detailed query with context
+3. Execute Neo CLI with proper timeout (600s)
+4. Parse Neo's multi-agent reasoning output
+5. Present actionable recommendations with confidence scores
+
+## Example Invocations
+
+```
+Use the Neo agent to review this authentication code for security issues.
+
+Use the Neo agent to optimize the data processing pipeline.
+
+Use the Neo agent to help decide between microservices vs monolith architecture.
+
+Use the Neo agent to debug this race condition in the task processor.
+```
+
+## Important Notes
+
+- Neo queries take 5-30 seconds (uses LLM API calls)
+- Always verify low-confidence suggestions (<0.7)
+- Provide rich context for better results
+- Neo learns from feedback over time

--- a/.claude-plugin/commands/neo-architect.md
+++ b/.claude-plugin/commands/neo-architect.md
@@ -1,0 +1,37 @@
+# Command: /neo-architect
+
+Get architectural guidance from Neo on design decisions.
+
+## Usage
+
+```
+/neo-architect <your architectural question>
+```
+
+## Description
+
+Use this command when you need help making architectural decisions. Neo will analyze tradeoffs, provide confidence scores, and reference similar systems from its memory.
+
+## Examples
+
+```
+/neo-architect Should I use microservices or monolith for this project?
+
+/neo-architect What's the best way to handle real-time notifications? WebSockets vs SSE vs polling?
+
+/neo-architect How should I structure a multi-tenant SaaS database?
+```
+
+## What Happens
+
+Neo will:
+1. Analyze tradeoffs between different approaches
+2. Consider scalability, maintainability, and complexity
+3. Search memory for similar architectural decisions
+4. Provide recommendations with confidence scores and risk analysis
+
+## Parameters
+
+- `<question>` - Your architectural question (required)
+
+Include constraints: scalability needs, team size, infrastructure, timeline

--- a/.claude-plugin/commands/neo-debug.md
+++ b/.claude-plugin/commands/neo-debug.md
@@ -1,0 +1,37 @@
+# Command: /neo-debug
+
+Get debugging assistance from Neo.
+
+## Usage
+
+```
+/neo-debug <error message or bug description>
+```
+
+## Description
+
+Use this command when debugging complex issues, especially intermittent bugs or race conditions. Neo uses semantic pattern matching to identify likely root causes.
+
+## Examples
+
+```
+/neo-debug TypeError in data processing pipeline
+
+/neo-debug Race condition in concurrent task processor
+
+/neo-debug Memory leak happening after 1000+ requests
+```
+
+## What Happens
+
+Neo will:
+1. Analyze the error or bug description
+2. Identify likely root causes using semantic patterns
+3. Search memory for similar debugging scenarios
+4. Suggest debugging strategies and fixes with confidence scores
+
+## Parameters
+
+- `<description>` - Error message or bug description (required)
+
+Include: error messages, frequency, reproduction steps, environment details

--- a/.claude-plugin/commands/neo-optimize.md
+++ b/.claude-plugin/commands/neo-optimize.md
@@ -1,0 +1,37 @@
+# Command: /neo-optimize
+
+Get optimization suggestions from Neo.
+
+## Usage
+
+```
+/neo-optimize <file path or function name>
+```
+
+## Description
+
+Use this command to get performance optimization recommendations from Neo using semantic analysis and past optimization patterns.
+
+## Examples
+
+```
+/neo-optimize process_large_dataset function
+
+/neo-optimize src/data/processor.py
+
+/neo-optimize the search algorithm
+```
+
+## What Happens
+
+Neo will:
+1. Analyze the code for algorithmic complexity
+2. Identify bottlenecks and inefficiencies
+3. Search memory for similar optimization patterns
+4. Suggest improvements with confidence scores
+
+## Parameters
+
+- `<target>` - File path or function name (required)
+
+Optionally include performance requirements (e.g., "needs <2s for 10k records")

--- a/.claude-plugin/commands/neo-pattern.md
+++ b/.claude-plugin/commands/neo-pattern.md
@@ -1,0 +1,37 @@
+# Command: /neo-pattern
+
+Extract reusable patterns with Neo.
+
+## Usage
+
+```
+/neo-pattern <code area or pattern type>
+```
+
+## Description
+
+Use this command to extract reusable architectural patterns from your codebase. Neo will identify patterns, analyze their effectiveness, and suggest when to apply them.
+
+## Examples
+
+```
+/neo-pattern repository pattern implementation
+
+/neo-pattern error handling across the API
+
+/neo-pattern caching strategies in the codebase
+```
+
+## What Happens
+
+Neo will:
+1. Analyze code to identify the pattern
+2. Evaluate pattern effectiveness and consistency
+3. Search memory for similar patterns
+4. Suggest improvements or alternative patterns with confidence scores
+
+## Parameters
+
+- `<target>` - Code area or pattern type (required)
+
+Specify what pattern you want to analyze or where to look for patterns

--- a/.claude-plugin/commands/neo-review.md
+++ b/.claude-plugin/commands/neo-review.md
@@ -1,0 +1,37 @@
+# Command: /neo-review
+
+Get Neo's code review with semantic analysis.
+
+## Usage
+
+```
+/neo-review <file path or code description>
+```
+
+## Description
+
+Use this command to get Neo's code review with semantic pattern matching, security analysis, and optimization suggestions.
+
+## Examples
+
+```
+/neo-review src/api/handlers.py
+
+/neo-review authentication module
+
+/neo-review the payment processing code
+```
+
+## What Happens
+
+Neo will:
+1. Gather context from the specified file or module
+2. Analyze code for security vulnerabilities, edge cases, and performance issues
+3. Check semantic memory for similar code review patterns
+4. Provide improvements with confidence scores
+
+## Parameters
+
+- `<target>` - File path, module name, or code description (required)
+
+Focus areas: security, edge cases, error handling, performance

--- a/.claude-plugin/commands/neo.md
+++ b/.claude-plugin/commands/neo.md
@@ -1,0 +1,37 @@
+# Command: /neo
+
+Ask Neo for semantic reasoning and code suggestions.
+
+## Usage
+
+```
+/neo <your question or task>
+```
+
+## Description
+
+Use this command when you need Neo's semantic reasoning for general questions, code suggestions, or architectural guidance.
+
+## Examples
+
+```
+/neo How should I structure my new feature for user analytics?
+
+/neo What's the best caching strategy for this API?
+
+/neo Should I use REST or GraphQL for this data model?
+```
+
+## What Happens
+
+Neo will:
+1. Analyze your question using multi-agent reasoning (Solver, Critic, Verifier)
+2. Search semantic memory for similar problems
+3. Generate solutions with confidence scores
+4. Provide actionable recommendations
+
+## Parameters
+
+- `<question>` - Your question or task description (required)
+
+Provide as much context as possible for better results.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "neo",
-  "displayName": "Neo - Semantic Reasoning Helper",
-  "version": "0.7.0",
+  "version": "0.7.4",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"
@@ -19,73 +18,13 @@
     "memory",
     "patterns"
   ],
-  "categories": [
-    "code-quality",
-    "productivity",
-    "architecture"
-  ],
-  "requirements": {
-    "python": ">=3.9",
-    "packages": [
-      "neo-reasoner>=0.7.0"
-    ],
-    "dependencies": [
-      "fastembed",
-      "faiss-cpu"
-    ]
-  },
-  "installation": {
-    "type": "pip",
-    "package": "neo-reasoner",
-    "steps": [
-      "1. Install Neo: pip install neo-reasoner",
-      "2. Configure API key: neo --config set --config-key provider --config-value anthropic",
-      "3. Set your API key: neo --config set --config-key api_key --config-value YOUR_KEY",
-      "4. Verify installation: neo --version"
-    ],
-    "post_install": [
-      "echo '✓ Neo installed! Configure with: neo --config set --config-key api_key --config-value YOUR_KEY'"
-    ]
-  },
-  "agents": [
-    {
-      "name": "neo",
-      "path": ".claude/agents/neo.md",
-      "description": "Semantic reasoning helper using multi-agent MapCoder approach with persistent memory"
-    }
-  ],
+  "agents": ["./agents/neo.md"],
   "commands": [
-    {
-      "name": "neo",
-      "path": ".claude/commands/neo.md",
-      "description": "Ask Neo for semantic reasoning and code suggestions"
-    },
-    {
-      "name": "neo-review",
-      "path": ".claude/commands/neo-review.md",
-      "description": "Get Neo's code review with semantic analysis"
-    },
-    {
-      "name": "neo-optimize",
-      "path": ".claude/commands/neo-optimize.md",
-      "description": "Get optimization suggestions from Neo"
-    },
-    {
-      "name": "neo-architect",
-      "path": ".claude/commands/neo-architect.md",
-      "description": "Get architectural guidance from Neo on design decisions"
-    },
-    {
-      "name": "neo-debug",
-      "path": ".claude/commands/neo-debug.md",
-      "description": "Get debugging assistance from Neo"
-    },
-    {
-      "name": "neo-pattern",
-      "path": ".claude/commands/neo-pattern.md",
-      "description": "Extract reusable patterns with Neo"
-    }
-  ],
-  "documentation": "https://github.com/Parslee-ai/neo/blob/main/.claude-plugin/README.md",
-  "icon": "🧠"
+    "./commands/neo.md",
+    "./commands/neo-review.md",
+    "./commands/neo-optimize.md",
+    "./commands/neo-architect.md",
+    "./commands/neo-debug.md",
+    "./commands/neo-pattern.md"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes validation errors preventing Neo plugin installation in Claude Code.

**Error Fixed:**
```
Plugin has an invalid manifest file. Validation errors: commands: Invalid input, agents: Invalid input
```

## Changes

### Plugin Manifest (plugin.json)
- **Fix schema compliance**: Changed `agents` and `commands` from object arrays to string path arrays
- **Fix path prefixes**: Changed `.claude/` to `./` (required by schema)
- **Remove invalid fields**: Removed `requirements`, `installation`, `categories`, `displayName`, `documentation`, `icon`
- **Bump version**: 0.7.0 → 0.7.4

### New Files Created
- `agents/neo.md` - Neo agent definition
- `commands/neo.md` - General reasoning command
- `commands/neo-review.md` - Code review command  
- `commands/neo-optimize.md` - Optimization command
- `commands/neo-architect.md` - Architecture guidance command
- `commands/neo-debug.md` - Debugging assistance command
- `commands/neo-pattern.md` - Pattern extraction command

## Root Cause

The plugin.json used an invalid schema:

**Before (WRONG):**
```json
"agents": [
  {
    "name": "neo",
    "path": ".claude/agents/neo.md",
    "description": "..."
  }
]
```

**After (CORRECT):**
```json
"agents": ["./agents/neo.md"]
```

According to [Claude Code Plugins Reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), `agents` and `commands` must be string paths, not objects.

## Testing

Users can now install with:
```bash
/plugin marketplace add Parslee-ai/neo
```

The plugin will properly load:
- Neo agent for semantic reasoning
- 6 slash commands for common tasks
- All files reference correct paths

## Related Issues

This was discovered when users reported installation failures with the validation error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)