### PR TITLE
Add missing plugin install step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ neo --version
 Neo is available as a **Claude Code plugin** with specialized agents and slash commands for seamless integration:
 
 ```bash
-# Install Neo as a Claude Code plugin
+# Add the marketplace
 /plugin marketplace add Parslee-ai/claude-code-plugins
+
+# Install Neo plugin
+/plugin install neo
 ```
 
 Once installed, you get:


### PR DESCRIPTION
## Summary

Adds the missing `/plugin install neo` step to the Claude Code plugin installation instructions in the README.

## Problem

Users were only seeing:
```bash
/plugin marketplace add Parslee-ai/claude-code-plugins
```

This adds the marketplace but doesn't actually install the Neo plugin. Users need to run a second command.

## Solution

Updated the installation instructions to show both steps:
```bash
# Add the marketplace
/plugin marketplace add Parslee-ai/claude-code-plugins

# Install Neo plugin
/plugin install neo
```

## Impact

- Improves clarity of installation process
- Prevents user confusion about why the plugin isn't working after adding marketplace
- Matches actual plugin installation workflow

## Changes

- Added `/plugin install neo` command to README.md line 168
- Added comment clarifying the two-step process

🤖 Generated with [Claude Code](https://claude.com/claude-code)