### PR TITLE
Release v0.7.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.6] - 2025-01-14
+
+### Fixed
+- Python 3.9 compatibility: Replaced Python 3.10+ union syntax (X | Y) with Optional/Union for broader compatibility (#21)
+- Added missing `source_context` field to ReasoningEntry dataclass (#20)
+
+### Documentation
+- Updated documentation files to latest standards
+
 ## [0.7.0] - 2025-01-10
 
 ### Added - ReasoningBank Implementation (Phases 2-5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.7.5"
+version = "0.7.6"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Summary

Release version 0.7.6 with bug fixes for Python 3.9 compatibility.

## Changes

### Fixed
- Python 3.9 compatibility: Replaced Python 3.10+ union syntax (X | Y) with Optional/Union for broader compatibility (#21)
- Added missing `source_context` field to ReasoningEntry dataclass (#20)

### Documentation
- Updated documentation files to latest standards

## Release Checklist

- [x] Version bumped in pyproject.toml
- [x] Version bumped in src/neo/__init__.py
- [x] Version bumped in .claude-plugin/plugin.json
- [x] CHANGELOG.md updated
- [x] Distributions built successfully

## Next Steps

After merge:
1. Create git tag `v0.7.6`
2. Create GitHub Release
3. Automated PyPI publication via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)