### PR TITLE
Release v0.15.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.15.4] - 2026-04-14
+
+### Fixed
+- Raise the bar above the base LM by closing four reasoning gaps that caused Neo to collapse to "LLM + logging":
+  - Objective early-exit gate: require self-confidence >0.8 AND static checks actually ran clean AND simulation traces agree, instead of trusting self-reported confidence alone (was bailing in 47.7% of sessions)
+  - Share `success_bonus(n)` between `FactStore.retrieve_relevant` and `ContextAssembler._score_facts` via `memory.models`, so outcome learning influences ranking on the main retrieval path; cap bonus at 0.2 so a narrow historical winner can't dominate cosine similarity
+  - Wire `ConstraintVerifier.extract_constraints` into the engine's main path with typed constraints threaded as parameters (no instance state), marker dict keyed by `ConstraintType` enum, comment/string stripping before substring match
+  - Community-facts fallback in `_retrieve_context` so prompts always carry some memory-derived context when `FactStore` retrieval returns empty
+
+### Changed
+- Extracted `NeoEngine._finalize_output` as single exit point for both early-exit and full-pipeline paths (eliminates duplicated save/log/telemetry blocks)
+- Narrowed silent `except Exception` in community fallback to `(OSError, json.JSONDecodeError)`
+
+### Removed
+- Unsafe `ConstraintVerifier.verify_code` subprocess path (executed arbitrary generated code; never called)
+
 ## [0.15.3] - 2026-04-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.15.3"
+version = "0.15.4"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Summary

Bug-fix release focused on closing four structural gaps that caused Neo to collapse to "LLM + logging" rather than delivering above-base-model reasoning.

## Changes

### Fixed
- **Objective early-exit gate**: require self-confidence >0.8 AND static checks actually ran clean AND simulation traces agree. Prior gate trusted self-reported confidence alone (47.7% of sessions bailed without verification).
- **Outcome learning now reaches retrieval ranking**: shared `success_bonus(n)` between `FactStore.retrieve_relevant` and `ContextAssembler._score_facts`; capped at 0.2 so narrow historical winners can't dominate cosine similarity.
- **Constraint verification wired into main path**: typed constraints threaded explicitly (no instance state), marker dict keyed by `ConstraintType` enum, comment/string stripping before substring match.
- **Community-facts fallback**: prompts always carry some memory-derived context when `FactStore` retrieval returns empty.

### Changed
- Single `_finalize_output` exit point for early-exit and full-pipeline paths
- Narrowed silent `except Exception` in community fallback to `(OSError, json.JSONDecodeError)`

### Removed
- Unsafe `ConstraintVerifier.verify_code` subprocess path (executed arbitrary generated code; never called)

## Test plan
- [x] `pytest tests/` — 445 passed, 46 skipped
- [x] Ruff lint clean
- [x] Wheel + sdist build successfully
- [ ] Reviewer verifies CHANGELOG + version bumps in pyproject.toml, src/neo/__init__.py, .claude-plugin/plugin.json