### PR TITLE
chore: bump version to 0.15.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.15.4"
+version = "0.15.5"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.15.4"
+__version__ = "0.15.5"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release 0.15.5 to ship the feedback-loop revival fix (3df99f8) that landed after the 0.15.4 cut.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

N/A — release housekeeping.

## Motivation and Context

The fix in 3df99f8 ("revive the learning feedback loop") is on `main` but not yet released. Local installs on 0.15.4 still record near-zero successes (19 lifetime across 5,241 facts), so the loop only revives once users update to a release that contains the fix.

## How Has This Been Tested?

- [x] Full pytest suite passes locally (445 passed, 46 skipped)
- [x] Ruff lint clean

**Test Configuration**:
- Python version: 3.14.3
- OS: macOS (Darwin 25.4.0)
- Neo version: 0.15.5

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Includes since 0.15.4:
- 3df99f8 fix: revive the learning feedback loop