### PR TITLE
Release v0.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.16.0] - 2026-05-02
 
 ### Added
 - **Codex plugin** at `plugins/neo/` exposes the same six skills the Claude Code plugin offers (`$neo`, `$neo-review`, `$neo-optimize`, `$neo-architect`, `$neo-debug`, `$neo-pattern`), packaged via `.codex-plugin/plugin.json` plus a repo marketplace at `.agents/plugins/marketplace.json`. Skills wrap the local `neo` CLI; persistent memory in `~/.neo/` is shared across both plugins.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.15.5"
+version = "0.16.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.15.5"
+__version__ = "0.16.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Summary

Minor release covering this session's substantial new functionality:

- **gpt-5.5 default** — bumped from gpt-5.3-codex; `/v1/responses` routing already covers it
- **Memory-driven reasoning effort** for OpenAI gpt-5* models — sized per-query from memory hit strength (`low` for confident pattern matches, `high` for novel queries, `xhigh` for novel + hard difficulty). Cap with `NEO_REASONING_EFFORT`.
- **Code-smell detection** during context assembly — TODOs/FIXMEs/HACKs/XXX, Python stubs, bare/swallowed except, hardcoded credentials. Surfaces under "KNOWN ISSUES IN NEARBY CODE."
- **Project-local agent doc discovery** — automatically reads CLAUDE.md, AGENTS.md, .cursorrules, .cursor/rules, .github/copilot-instructions.md, .continue, .augment, .specify (Spec Kit), .aider, .codex, .codeium, .windsurfrules. Surfaces under "PROJECT-LOCAL AGENT CONTEXT."
- **Architectural quality delta** in outcome learning — at session save we snapshot import cycles, god files, and max nesting depth; at outcome detection we diff against current state and modulate confidence adjustments by ±0.1 based on whether the codebase regressed or improved. Confidence becomes a signal of "helped the codebase," not just "got accepted."
- **Codex plugin** — full plugin parity with the Claude Code plugin, packaged at `plugins/neo/` with `.codex-plugin/plugin.json` and six skills. Marketplace at `.agents/plugins/marketplace.json`.

Plus targeted documentation updates in README and CHANGELOG.

## Test plan
- [x] Full pytest suite green (562 passed, 46 skipped — 562 = 491 baseline + 71 net new this release across reasoning_effort, code_smells, agent_context, architecture_metrics, and arch-delta modulation tests)
- [x] Lint clean across all changed files
- [x] End-to-end neo CLI smoke test on a familiar query: logs `Reasoning effort: low (patterns=5, avg_conf=0.91)` — memory-driven effort selection working as designed
- [x] Agent doc discovery smoke test on neo's own repo: 8 docs found
- [x] Code smell scanner smoke test: all 5 detector categories fire on a synthetic mixed file
- [x] Architecture metrics smoke test: cycles + god files + nesting depth correctly identify regressions
- [x] Wheel + sdist built locally (260K + 413K, version 0.16.0)