### PR TITLE
fix: disable exploration in ranking tests (eliminate last 3% flake)

### DIFF
--- a/tests/test_reasoningbank_end_to_end.py
+++ b/tests/test_reasoningbank_end_to_end.py
@@ -40,6 +40,14 @@ class TestReasoningBankImpact:
         """Create realistic memory with diverse patterns."""
         self.memory = PersistentReasoningMemory()
 
+        # These tests measure deterministic ranking behavior. The default
+        # exploration_rate (0.03) takes a `random.sample` branch in
+        # retrieve_relevant ~3% of the time, drawn from the stdlib `random`
+        # module's GLOBAL state — which is not seeded by our per-test numpy
+        # RandomState. Result: ~3% of CI runs flake when the lottery hits.
+        # Force exploration off for these specific tests.
+        self.memory.exploration_rate = 0.0
+
         # Clear any loaded entries for clean test environment
         self.memory.entries = []
 


### PR DESCRIPTION
## Summary

PR #86 fixed test-collection-order flakiness in \`test_reasoningbank_end_to_end.py\` by giving each test its own seeded numpy \`RandomState\`. That closed most of the gap, but CI on this morning's release-related branches surfaced the *next* layer: \`PersistentReasoningMemory.retrieve_relevant\` has a 3% exploration rate (persistent_reasoning.py:1213) that takes a \`random.sample\` branch using the **stdlib \`random\` module's global RNG** — which nothing in the test setup seeds.

So ~3% of CI runs would still flake when the lottery happened to hit. PR #86 narrowed the failure window enough that I missed this on the first pass.

## Fix

Force \`self.memory.exploration_rate = 0.0\` in \`setup_method\`. These tests measure deterministic ranking behavior — exploration randomness is exactly what they don't want. The one test that already disabled it (\`test_performance_consistency_across_retrievals\`) was doing the right thing; the other four were relying on the 3% lottery not firing.

## Test plan

- [x] \`pytest tests/test_reasoningbank_end_to_end.py\`: 7/7 pass
- [x] **Stress test**: 10 consecutive \`PYTHONHASHSEED=random pytest\` runs — 7/7 pass on every run

This is the actual fix that should have been part of PR #86. Sorry for the second pass.