### PR TITLE
fix: route auto-update through the install method that owns neo

### DIFF
--- a/src/neo/update_checker.py
+++ b/src/neo/update_checker.py
@@ -7,12 +7,21 @@ hot path), and if the cache is older than UPDATE_CHECK_INTERVAL a
 background thread refreshes the cache so the *next* invocation has
 fresh data. Users on auto-update see new releases within ~1 hour
 of publication, instead of up to 24h with the old fixed interval.
+
+The auto-installer routes upgrades through whichever package manager
+actually owns this neo install (pipx / pip-venv / brew / system pip).
+Forcing pip into a foreign install (e.g. Homebrew Python's
+externally-managed site-packages) used to write a duplicate copy that
+importlib.metadata then resolved to the *old* version on next start —
+producing an infinite "upgrading from X to Y" loop. See
+_detect_install_method below.
 """
 
 import importlib.metadata
 import json
 import logging
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -28,32 +37,76 @@ UPDATE_CHECK_INTERVAL = 3600  # 1 hour in seconds. Was 24h, but with SWR
 # the per-invocation cost of a stale check is zero (background refresh),
 # so we can afford to be much more responsive to fresh releases.
 
+PYPI_PACKAGE_NAME = "neo-reasoner"
+PYPI_API_URL = f"https://pypi.org/pypi/{PYPI_PACKAGE_NAME}/json"
+REQUEST_TIMEOUT = 3  # seconds
+
+# Install-method tags returned by _detect_install_method().
+INSTALL_PIPX = "pipx"
+INSTALL_PIP_VENV = "pip-venv"
+INSTALL_BREW = "brew"
+INSTALL_EXTERNAL = "external"  # PEP-668 / system Python; pip-upgrade is unsafe
+
+_BREW_PREFIXES = ("/opt/homebrew/", "/usr/local/Cellar/", "/home/linuxbrew/")
+
+
+def _brew_owns(formula: str) -> bool:
+    """Return True if Homebrew has a formula with this name installed."""
+    try:
+        result = subprocess.run(
+            ["brew", "list", "--formula", formula],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _detect_install_method() -> str:
+    """Identify how the running neo was installed.
+
+    Returns one of INSTALL_PIPX / INSTALL_PIP_VENV / INSTALL_BREW /
+    INSTALL_EXTERNAL. The caller uses this to pick the correct upgrade
+    command — using pip on a brew install (or vice versa) leaves stale
+    metadata behind and breaks future auto-updates.
+    """
+    try:
+        import neo  # local import to avoid circular concerns
+        pkg_path = str(Path(neo.__file__).resolve())
+    except Exception:
+        return INSTALL_EXTERNAL
+
+    # pipx puts each app in its own venv under ~/.local/pipx/venvs/<app>/.
+    # Match POSIX and Windows separators.
+    if "/pipx/venvs/" in pkg_path or "\\pipx\\venvs\\" in pkg_path:
+        return INSTALL_PIPX
+
+    # An isolated, non-pipx venv: sys.prefix diverges from base_prefix and
+    # pip operates safely on its own site-packages.
+    if sys.prefix != sys.base_prefix:
+        return INSTALL_PIP_VENV
+
+    # Under a Homebrew prefix? Could still be "pip --break-system-packages
+    # into brew's Python", which is NOT a brew formula install — confirm
+    # with `brew list`.
+    if pkg_path.startswith(_BREW_PREFIXES) and _brew_owns(PYPI_PACKAGE_NAME):
+        return INSTALL_BREW
+
+    return INSTALL_EXTERNAL
+
 
 def _pip_install_cmd(package: str, quiet: bool = False) -> list[str]:
-    """Build a pip install command that works in PEP 668 environments.
+    """Build a pip install command for the *current* interpreter.
 
-    Detects externally-managed Python installs (Homebrew, system packages)
-    and adds --break-system-packages when needed. Also adds
-    --ignore-installed to work around broken dependency RECORD files
-    (e.g., Homebrew-managed pillow missing its RECORD).
+    Used only on the INSTALL_PIP_VENV path. Other install methods
+    (pipx, brew, external) route through their own helpers.
     """
     cmd = [sys.executable, "-m", "pip", "install", "--upgrade", package]
     if quiet:
         cmd.append("--quiet")
-
-    # Check for PEP 668 marker file
-    stdlib_path = Path(sys.prefix) / "lib"
-    externally_managed = list(stdlib_path.glob("python*/EXTERNALLY-MANAGED"))
-    if externally_managed:
-        cmd.append("--break-system-packages")
-        # Externally-managed envs often have packages without RECORD files,
-        # which causes "Cannot uninstall" errors during dependency resolution.
-        cmd.append("--ignore-installed")
-
     return cmd
-PYPI_PACKAGE_NAME = "neo-reasoner"
-PYPI_API_URL = f"https://pypi.org/pypi/{PYPI_PACKAGE_NAME}/json"
-REQUEST_TIMEOUT = 3  # seconds
 
 
 def _get_cache_file() -> Path:
@@ -254,93 +307,170 @@ def check_for_updates(suppress_output: bool = False, auto_install: bool = False)
 
 
 def _print_update_notification(current: str, latest: str) -> None:
-    """Print a user-friendly update notification."""
+    """Print a user-friendly update notification, tailored to install method."""
+    method = _detect_install_method()
     print(f"\n⚡ Neo update available: {current} → {latest}", file=sys.stderr)
-    print(f"   Run: pip install --upgrade {PYPI_PACKAGE_NAME}", file=sys.stderr)
-    print("   Or:  neo update\n", file=sys.stderr)
+    if method == INSTALL_PIPX:
+        print(f"   Run: pipx upgrade {PYPI_PACKAGE_NAME}", file=sys.stderr)
+        print("   Or:  neo update\n", file=sys.stderr)
+    elif method == INSTALL_PIP_VENV:
+        print(f"   Run: pip install --upgrade {PYPI_PACKAGE_NAME}", file=sys.stderr)
+        print("   Or:  neo update\n", file=sys.stderr)
+    elif method == INSTALL_BREW:
+        print(f"   Run: brew upgrade {PYPI_PACKAGE_NAME}", file=sys.stderr)
+        print("   (Homebrew formula may lag PyPI by 24-48h.)\n", file=sys.stderr)
+    else:  # INSTALL_EXTERNAL
+        print(
+            "   Your install is in a system / externally-managed Python.\n"
+            f"   Switch to pipx for safe auto-updates:\n"
+            f"     pipx install {PYPI_PACKAGE_NAME}\n",
+            file=sys.stderr,
+        )
+
+
+def _notified_marker_path() -> Path:
+    """Where we record the last version we told the user about."""
+    return _get_cache_file().parent / "install_notified.json"
+
+
+def _already_notified(version: str) -> bool:
+    try:
+        data = json.loads(_notified_marker_path().read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return data.get("notified_version") == version
+
+
+def _mark_notified(version: str) -> None:
+    try:
+        _notified_marker_path().write_text(json.dumps({"notified_version": version}))
+    except OSError as e:
+        logger.debug(f"Failed to write notified marker: {e}")
+
+
+def _append_log(message: str) -> None:
+    """Append a line to ~/.neo/auto_update.log."""
+    log_file = _get_cache_file().parent / "auto_update.log"
+    try:
+        with open(log_file, "a") as f:
+            f.write(message)
+    except OSError as e:
+        logger.debug(f"Failed to write auto-update log: {e}")
+
+
+def _run_pipx_upgrade(quiet: bool = True) -> tuple[bool, str]:
+    """Run `pipx upgrade neo-reasoner`. Returns (success, stderr)."""
+    try:
+        result = subprocess.run(
+            ["pipx", "upgrade", PYPI_PACKAGE_NAME],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return result.returncode == 0, result.stderr
+    except FileNotFoundError:
+        return False, "pipx not found on PATH"
+    except subprocess.TimeoutExpired:
+        return False, "pipx upgrade timed out after 120s"
+
+
+def _run_pip_upgrade(quiet: bool = True) -> tuple[bool, str]:
+    """Run `pip install --upgrade neo-reasoner` in the current venv."""
+    try:
+        result = subprocess.run(
+            _pip_install_cmd(PYPI_PACKAGE_NAME, quiet=quiet),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return result.returncode == 0, result.stderr
+    except subprocess.TimeoutExpired:
+        return False, "pip upgrade timed out after 120s"
 
 
 def perform_auto_install(new_version: str) -> bool:
     """
     Perform automatic background update installation.
 
-    This is more aggressive than perform_update() - it installs without prompting.
-    Should only be called when auto_install_updates is enabled in config.
+    Dispatches to the appropriate package manager based on how neo was
+    installed. For brew/external installs, prints guidance instead of
+    pip-overriding (the latter creates duplicate metadata that breaks
+    future detection — see auto_update.log loop bug, fixed here).
 
     Args:
         new_version: The version to install
 
     Returns:
-        True if update was successful, False otherwise
+        True if the upgrade actually happened. False if the upgrade
+        failed, OR if the install method requires manual user action
+        (brew/external) — in those cases we print guidance and return
+        False so the caller knows neo did not self-update.
     """
-    import subprocess
-
     current_version = _get_current_version()
     if current_version == new_version:
-        return True  # Already installed
+        return True
+
+    method = _detect_install_method()
+
+    # Methods that require user action — print guidance, throttled per version.
+    if method in (INSTALL_BREW, INSTALL_EXTERNAL):
+        if not _already_notified(new_version):
+            _print_update_notification(current_version, new_version)
+            _mark_notified(new_version)
+        _append_log(
+            f"\n[{_now_iso()}] Update available {current_version} -> {new_version}"
+            f"; install method '{method}' requires manual upgrade — skipping pip.\n"
+        )
+        return False
+
+    # Auto-installable methods.
+    timestamp = _now_iso()
+    _append_log(
+        f"\n[{timestamp}] Auto-updating from {current_version} to {new_version} via {method}\n"
+    )
+    print(
+        f"\n⚡ Auto-installing neo update: {current_version} → {new_version} (via {method})",
+        file=sys.stderr,
+    )
+    print("   This happens in the background. Please wait...\n", file=sys.stderr)
 
     try:
-        # Write update log
-        log_file = _get_cache_file().parent / "auto_update.log"
-        with open(log_file, 'a') as f:
-            import datetime
-            timestamp = datetime.datetime.now().isoformat()
-            f.write(f"\n[{timestamp}] Auto-updating from {current_version} to {new_version}\n")
-
-        # Notify user that auto-update is happening
-        print(f"\n⚡ Auto-installing neo update: {current_version} → {new_version}", file=sys.stderr)
-        print("   This happens in the background. Please wait...\n", file=sys.stderr)
-
-        # Use pip to upgrade (handles PEP 668 externally-managed environments)
-        result = subprocess.run(
-            _pip_install_cmd(PYPI_PACKAGE_NAME, quiet=True),
-            capture_output=True,
-            text=True,
-            timeout=120  # 2 minute timeout
-        )
-
-        if result.returncode == 0:
-            # Log success
-            with open(log_file, 'a') as f:
-                f.write(f"   ✓ Success! Updated to {new_version}\n")
-
-            print(f"✓ Auto-update completed: {new_version}", file=sys.stderr)
-            print("   Restart neo to use the new version.\n", file=sys.stderr)
-
-            # Clear cache so next check will re-verify
-            cache_file = _get_cache_file()
-            if cache_file.exists():
-                cache_file.unlink()
-
-            return True
-        else:
-            # Log failure
-            with open(log_file, 'a') as f:
-                f.write(f"   ✗ Failed: {result.stderr}\n")
-
-            logger.debug(f"Auto-update failed: {result.stderr}")
-            return False
-
-    except subprocess.TimeoutExpired:
-        logger.debug("Auto-update timed out after 120 seconds")
-        return False
+        if method == INSTALL_PIPX:
+            ok, err = _run_pipx_upgrade(quiet=True)
+        else:  # INSTALL_PIP_VENV
+            ok, err = _run_pip_upgrade(quiet=True)
     except Exception as e:
         logger.debug(f"Auto-update failed: {e}")
+        _append_log(f"   ✗ Failed: {e}\n")
         return False
+
+    if ok:
+        _append_log(f"   ✓ Success! Updated to {new_version}\n")
+        print(f"✓ Auto-update completed: {new_version}", file=sys.stderr)
+        print("   Restart neo to use the new version.\n", file=sys.stderr)
+        # Clear the version-check cache so next run re-verifies.
+        cache_file = _get_cache_file()
+        if cache_file.exists():
+            cache_file.unlink()
+        return True
+
+    _append_log(f"   ✗ Failed: {err}\n")
+    logger.debug(f"Auto-update failed: {err}")
+    return False
+
+
+def _now_iso() -> str:
+    import datetime
+    return datetime.datetime.now().isoformat()
 
 
 def perform_update() -> bool:
     """
-    Perform a self-update using pip.
-
-    Returns:
-        True if update was successful, False otherwise
+    Perform a self-update, dispatching to the correct package manager
+    for the current install method. Used by `neo update`.
     """
-    import subprocess
-
     current_version = _get_current_version()
 
-    # Check if update is available
     print("Checking for updates...")
     new_version = check_for_updates(suppress_output=True)
 
@@ -348,34 +478,31 @@ def perform_update() -> bool:
         print(f"✓ Neo is already up to date (version {current_version})")
         return True
 
-    print(f"Updating {PYPI_PACKAGE_NAME} from {current_version} to {new_version}...")
+    method = _detect_install_method()
+
+    if method in (INSTALL_BREW, INSTALL_EXTERNAL):
+        # Manual action required — print guidance and bail without trying pip.
+        _print_update_notification(current_version, new_version)
+        return False
+
+    print(f"Updating {PYPI_PACKAGE_NAME} from {current_version} to {new_version} (via {method})...")
 
     try:
-        # Use pip to upgrade (handles PEP 668 externally-managed environments)
-        subprocess.run(
-            _pip_install_cmd(PYPI_PACKAGE_NAME),
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=120
-        )
-
-        print(f"✓ Successfully updated to version {new_version}")
-        print("\nPlease restart neo for changes to take effect.")
-
-        # Clear cache so next check will re-verify
-        cache_file = _get_cache_file()
-        if cache_file.exists():
-            cache_file.unlink()
-
-        return True
-
-    except subprocess.TimeoutExpired:
-        print("✗ Update timed out after 120 seconds", file=sys.stderr)
-        return False
-    except subprocess.CalledProcessError as e:
-        print(f"✗ Update failed: {e.stderr}", file=sys.stderr)
-        return False
+        if method == INSTALL_PIPX:
+            ok, err = _run_pipx_upgrade(quiet=False)
+        else:  # INSTALL_PIP_VENV
+            ok, err = _run_pip_upgrade(quiet=False)
     except Exception as e:
         print(f"✗ Unexpected error during update: {e}", file=sys.stderr)
         return False
+
+    if ok:
+        print(f"✓ Successfully updated to version {new_version}")
+        print("\nPlease restart neo for changes to take effect.")
+        cache_file = _get_cache_file()
+        if cache_file.exists():
+            cache_file.unlink()
+        return True
+
+    print(f"✗ Update failed: {err}", file=sys.stderr)
+    return False

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -24,8 +24,13 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from neo import update_checker
 from neo.update_checker import (
+    INSTALL_BREW,
+    INSTALL_EXTERNAL,
+    INSTALL_PIP_VENV,
+    INSTALL_PIPX,
     UPDATE_CHECK_INTERVAL,
     _compare_versions,
+    _detect_install_method,
     _get_cache_file,
     _get_current_version,
     _read_cache,
@@ -179,21 +184,21 @@ class TestAutoInstallIdempotency:
             assert result is True
 
     def test_attempts_install_when_versions_differ(self):
-        """Test that auto_install runs pip when versions differ."""
+        """Test that auto_install runs pip when versions differ (pip-venv path)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_file = Path(tmpdir) / "update_check.json"
 
             with patch.object(
                 update_checker, "_get_current_version", return_value="0.9.0"
-            ):
-                with patch.object(
-                    update_checker, "_get_cache_file", return_value=cache_file
-                ):
-                    with patch("subprocess.run") as mock_run:
-                        mock_run.return_value = MagicMock(returncode=0)
-                        result = perform_auto_install("1.0.0")
-                        assert mock_run.called
-                        assert result is True
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_PIP_VENV
+            ), patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                result = perform_auto_install("1.0.0")
+                assert mock_run.called
+                assert result is True
 
 
 class TestCheckForUpdates:
@@ -433,16 +438,16 @@ class TestTimeoutHandling:
 
             with patch.object(
                 update_checker, "_get_current_version", return_value="0.9.0"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_PIP_VENV
+            ), patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired("pip", 120),
             ):
-                with patch.object(
-                    update_checker, "_get_cache_file", return_value=cache_file
-                ):
-                    with patch(
-                        "subprocess.run",
-                        side_effect=subprocess.TimeoutExpired("pip", 120),
-                    ):
-                        result = perform_auto_install("1.0.0")
-                        assert result is False
+                result = perform_auto_install("1.0.0")
+                assert result is False
 
     def test_pypi_fetch_respects_timeout(self):
         """Test that PyPI fetch handles timeout errors."""
@@ -528,45 +533,38 @@ class TestPerformUpdate:
                 assert result is True
 
     def test_perform_update_success(self):
-        """Test successful update via perform_update."""
+        """Test successful update via perform_update (pip-venv path)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_file = Path(tmpdir) / "update_check.json"
             cache_file.write_text("{}")
 
             with patch.object(
                 update_checker, "_get_cache_file", return_value=cache_file
-            ):
-                with patch.object(
-                    update_checker, "_get_current_version", return_value="0.9.0"
-                ):
-                    with patch.object(
-                        update_checker, "check_for_updates", return_value="1.0.0"
-                    ):
-                        with patch("subprocess.run") as mock_run:
-                            mock_run.return_value = MagicMock(returncode=0)
-                            result = perform_update()
-                            assert result is True
-                            assert mock_run.called
-                            assert not cache_file.exists()
+            ), patch.object(
+                update_checker, "_get_current_version", return_value="0.9.0"
+            ), patch.object(
+                update_checker, "check_for_updates", return_value="1.0.0"
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_PIP_VENV
+            ), patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                result = perform_update()
+                assert result is True
+                assert mock_run.called
+                assert not cache_file.exists()
 
     def test_perform_update_pip_failure(self):
-        """Test perform_update when pip fails."""
-        import subprocess
-
+        """Test perform_update when pip exits non-zero."""
         with patch.object(
             update_checker, "_get_current_version", return_value="0.9.0"
-        ):
-            with patch.object(
-                update_checker, "check_for_updates", return_value="1.0.0"
-            ):
-                with patch(
-                    "subprocess.run",
-                    side_effect=subprocess.CalledProcessError(
-                        1, "pip", stderr="pip error"
-                    ),
-                ):
-                    result = perform_update()
-                    assert result is False
+        ), patch.object(
+            update_checker, "check_for_updates", return_value="1.0.0"
+        ), patch.object(
+            update_checker, "_detect_install_method", return_value=INSTALL_PIP_VENV
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="pip error")
+            result = perform_update()
+            assert result is False
 
     def test_perform_update_timeout(self):
         """Test perform_update handles timeout."""
@@ -574,16 +572,16 @@ class TestPerformUpdate:
 
         with patch.object(
             update_checker, "_get_current_version", return_value="0.9.0"
+        ), patch.object(
+            update_checker, "check_for_updates", return_value="1.0.0"
+        ), patch.object(
+            update_checker, "_detect_install_method", return_value=INSTALL_PIP_VENV
+        ), patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("pip", 120),
         ):
-            with patch.object(
-                update_checker, "check_for_updates", return_value="1.0.0"
-            ):
-                with patch(
-                    "subprocess.run",
-                    side_effect=subprocess.TimeoutExpired("pip", 120),
-                ):
-                    result = perform_update()
-                    assert result is False
+            result = perform_update()
+            assert result is False
 
 
 class TestGetCurrentVersion:
@@ -615,6 +613,159 @@ class TestGetCacheFile:
         cache_file = _get_cache_file()
         assert cache_file.name == "update_check.json"
         assert cache_file.parent.name == ".neo"
+
+
+class TestInstallMethodDetection:
+    """Detect how this neo install was deployed: pipx / pip-venv / brew / external."""
+
+    def _stub_neo_path(self, fake_path: str):
+        """Patch neo.__file__ so detection sees a synthetic install location."""
+        return patch.object(update_checker, "Path", side_effect=lambda p: Path(fake_path) if p == fake_path else Path(p))
+
+    def test_detects_pipx_venv(self, monkeypatch):
+        fake = "/Users/me/.local/pipx/venvs/neo-reasoner/lib/python3.12/site-packages/neo/__init__.py"
+        fake_neo = MagicMock()
+        fake_neo.__file__ = fake
+        monkeypatch.setitem(sys.modules, "neo", fake_neo)
+        # Force fall-through past venv-prefix check to prove the pipx branch fires
+        # *first* when the path is in a pipx venv (even if also in a venv).
+        assert _detect_install_method() == INSTALL_PIPX
+
+    def test_detects_pip_venv(self, monkeypatch):
+        fake = "/tmp/myproject/.venv/lib/python3.12/site-packages/neo/__init__.py"
+        fake_neo = MagicMock()
+        fake_neo.__file__ = fake
+        monkeypatch.setitem(sys.modules, "neo", fake_neo)
+        # Force sys.prefix != sys.base_prefix to look like an isolated venv.
+        monkeypatch.setattr(sys, "prefix", "/tmp/myproject/.venv")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        assert _detect_install_method() == INSTALL_PIP_VENV
+
+    def test_detects_brew_when_brew_owns_formula(self, monkeypatch):
+        fake = "/opt/homebrew/lib/python3.14/site-packages/neo/__init__.py"
+        fake_neo = MagicMock()
+        fake_neo.__file__ = fake
+        monkeypatch.setitem(sys.modules, "neo", fake_neo)
+        monkeypatch.setattr(sys, "prefix", "/usr")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        with patch.object(update_checker, "_brew_owns", return_value=True):
+            assert _detect_install_method() == INSTALL_BREW
+
+    def test_brew_path_without_formula_is_external(self, monkeypatch):
+        """Pip-into-brew-Python looks like a brew path but brew doesn't own it.
+        That's the exact case Matt's install hit — must be classified as external."""
+        fake = "/opt/homebrew/lib/python3.14/site-packages/neo/__init__.py"
+        fake_neo = MagicMock()
+        fake_neo.__file__ = fake
+        monkeypatch.setitem(sys.modules, "neo", fake_neo)
+        monkeypatch.setattr(sys, "prefix", "/opt/homebrew")
+        monkeypatch.setattr(sys, "base_prefix", "/opt/homebrew")
+        with patch.object(update_checker, "_brew_owns", return_value=False):
+            assert _detect_install_method() == INSTALL_EXTERNAL
+
+    def test_detects_external_for_system_python(self, monkeypatch):
+        fake = "/usr/lib/python3.11/site-packages/neo/__init__.py"
+        fake_neo = MagicMock()
+        fake_neo.__file__ = fake
+        monkeypatch.setitem(sys.modules, "neo", fake_neo)
+        monkeypatch.setattr(sys, "prefix", "/usr")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        assert _detect_install_method() == INSTALL_EXTERNAL
+
+
+class TestInstallMethodDispatch:
+    """perform_auto_install must route to the right tool — and refuse pip
+    on brew/external installs to avoid the duplicate-metadata loop."""
+
+    def test_brew_install_skips_pip_and_prints_guidance(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "update_check.json"
+            with patch.object(
+                update_checker, "_get_current_version", return_value="0.15.5"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_BREW
+            ), patch("subprocess.run") as mock_run:
+                result = perform_auto_install("0.16.0")
+
+            assert result is False
+            assert not mock_run.called  # no pip invocation
+            err = capsys.readouterr().err
+            assert "brew upgrade" in err
+
+    def test_external_install_skips_pip_and_prints_guidance(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "update_check.json"
+            with patch.object(
+                update_checker, "_get_current_version", return_value="0.15.5"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_EXTERNAL
+            ), patch("subprocess.run") as mock_run:
+                result = perform_auto_install("0.16.0")
+
+            assert result is False
+            assert not mock_run.called
+            err = capsys.readouterr().err
+            assert "pipx" in err
+
+    def test_pipx_install_runs_pipx_upgrade(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "update_check.json"
+            with patch.object(
+                update_checker, "_get_current_version", return_value="0.15.5"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_PIPX
+            ), patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stderr="")
+                result = perform_auto_install("0.16.0")
+
+            assert result is True
+            assert mock_run.called
+            cmd = mock_run.call_args.args[0]
+            assert cmd[:2] == ["pipx", "upgrade"]
+            assert cmd[2] == "neo-reasoner"
+
+    def test_guidance_throttled_per_version(self, capsys):
+        """The brew/external guidance must not spam on every invocation —
+        once per known new version is enough."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "update_check.json"
+            with patch.object(
+                update_checker, "_get_current_version", return_value="0.15.5"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_EXTERNAL
+            ):
+                perform_auto_install("0.16.0")
+                first = capsys.readouterr().err
+                perform_auto_install("0.16.0")
+                second = capsys.readouterr().err
+
+            assert "0.16.0" in first
+            assert second == ""  # silent on the second call
+
+    def test_guidance_reprints_when_new_version_appears(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "update_check.json"
+            with patch.object(
+                update_checker, "_get_current_version", return_value="0.15.5"
+            ), patch.object(
+                update_checker, "_get_cache_file", return_value=cache_file
+            ), patch.object(
+                update_checker, "_detect_install_method", return_value=INSTALL_EXTERNAL
+            ):
+                perform_auto_install("0.16.0")
+                capsys.readouterr()  # discard
+                perform_auto_install("0.17.0")
+                second = capsys.readouterr().err
+
+            assert "0.17.0" in second
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The auto-updater unconditionally shelled out to `pip install --upgrade` regardless of how neo was installed. On Homebrew Python with the PEP-668 externally-managed marker, this used `--break-system-packages --ignore-installed`, which writes a new copy without removing the old — so `importlib.metadata.version()` kept resolving the stale 0.15.3 copy and produced an infinite "upgrading from 0.15.3 to 0.15.4" loop in `~/.neo/auto_update.log`.

This PR makes the auto-updater detect the install method at runtime and dispatch to the correct package manager — or refuse to run pip and print user guidance when pip would do harm.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

N/A — discovered in the field on a maintainer's Homebrew install.

## Motivation and Context

`auto_update.log` on a Homebrew-Python neo install showed seven consecutive "Auto-updating from 0.15.3 to 0.15.4 ✓ Success" entries across Apr 27–28. Each invocation thought it was upgrading 0.15.3 → 0.15.4 and "succeeded," but the next process start saw 0.15.3 again. Root cause: `--break-system-packages --ignore-installed` writes a new dist-info next to the old one, and `importlib.metadata` resolves whichever wins on `sys.path` (the Homebrew-managed copy). The fix to update-check interval shipped in 0.16.0 doesn't help users on this kind of install — they can't auto-receive 0.16.0 in the first place.

## Solution

Detect the install method at runtime and route the upgrade through whatever actually owns this neo:

| Detected method | Upgrade command |
|---|---|
| `pipx`     | `pipx upgrade neo-reasoner` |
| `pip-venv` | `pip install --upgrade neo-reasoner` (current interpreter) |
| `brew`     | Print guidance: run `brew upgrade <formula>` (formula may lag PyPI 24–48h) |
| `external` | Print guidance: switch to pipx for safe auto-updates |

Detection signals:
- `neo.__file__` location (pipx puts each app in `~/.local/pipx/venvs/<app>/...`)
- `sys.prefix != sys.base_prefix` (real venv)
- `brew list --formula <name>` to distinguish a true Homebrew formula install from "pip into Homebrew Python's externally-managed site-packages" — the latter looks like brew but isn't, and is the bug-inducing case.

For brew/external, the notification is throttled per latest version via `~/.neo/install_notified.json` so users don't see the same notice on every neo invocation; it re-prints only when a *different* new version appears.

Removes the `--break-system-packages --ignore-installed` workaround in `_pip_install_cmd` since pip is no longer attempted on installs that would need those flags.

## How Has This Been Tested?

- [x] Live verification on a real Homebrew-Python neo install: `_detect_install_method()` returns `external` (the bug-inducing case), confirming the fix correctly classifies it.
- [x] `TestInstallMethodDetection` (5 cases): pipx venv, isolated pip venv, brew-owned formula, brew-path-without-formula, system Python.
- [x] `TestInstallMethodDispatch` (5 cases): brew/external skip pip and print guidance; pipx invokes `pipx upgrade neo-reasoner`; throttling silences repeat notices for the same version; a different version re-prints.
- [x] Updated 4 existing tests that exercised the pip subprocess path to pin `_detect_install_method` to `pip-venv` so they stay deterministic across CI environments.
- [x] Full test suite passes locally: **578 passed, 46 skipped** in 67s.
- [x] Pre-commit ruff lint: clean.

**Test Configuration**:
- Python version: 3.14.3
- OS: macOS Darwin 25.4.0 (Apple Silicon)
- Neo version (pre-fix): 0.15.5

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Behavior change for users on `external` installs (e.g. Matt's):** they will now see a one-time notice per new version pointing at pipx, instead of the old silent (and broken) auto-pip path. The old behavior wasn't actually working — it just *looked* like it was working in the log. Users who want to keep auto-update working should switch to pipx as suggested.