### PR TITLE
chore: bump version to 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.1] - 2026-05-04
+
+### Fixed
+- Auto-updater now routes through the install method that owns neo (#89). Previously it unconditionally shelled out to `pip install --upgrade --break-system-packages --ignore-installed`, which on Homebrew Python wrote a duplicate copy without removing the old one — `importlib.metadata` resolved the stale copy on next start, producing an infinite "upgrading from X to Y ✓ Success" loop in `~/.neo/auto_update.log`. Detection now distinguishes pipx / pip-venv / brew-formula / external (PEP-668) installs and uses the correct upgrade command (or prints user guidance, throttled per version, when pip would do harm).
+- Drop update-check interval from 24h to 1h with stale-while-revalidate so users on auto-update receive new releases within ~1 hour of publication instead of up to 24h (#87).
+- Disable exploration in ranking tests to eliminate the last 3% test flake (#88).
+- Stabilize ReasoningBank tests across Python versions (#86).
+
 ## [0.16.0] - 2026-05-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.16.0"
+version = "0.16.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Patch release 0.16.0 → 0.16.1. Bundles four fixes that have landed since the 0.16.0 tag.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Bundles #86, #87, #88, #89.

## Motivation and Context

Most importantly, #89 fixes the auto-update loop on Homebrew Python — the existing 0.16.0 install path can't reliably auto-update itself, so this release exists in part to *get past* that bug. Users on `pipx` and isolated venvs continue to receive auto-updates as normal; users on `external` (PEP-668) installs will now see a one-time pipx-switch notice instead of looping silently.

## How Has This Been Tested?

- [x] Full local suite: **578 passed, 46 skipped** in 54s.
- [x] Pre-commit ruff lint: clean.
- [x] All four bundled PRs already passed CI on every supported Python version (3.10–3.13) at merge time.

**Test Configuration**:
- Python version: 3.14.3
- OS: macOS Darwin 25.4.0
- Neo version (pre-bump): 0.16.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

After merge, tag `v0.16.1` and create a GitHub release — `publish.yml` will pick up the release event and publish to PyPI via Trusted Publishers.