### PR TITLE
Release v0.20.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.1] - 2026-05-25
+
+### Fixed
+
+- **A2UI memory inspector surface rendered as "(no root component)"** in CarHost.app despite the daemon-side dataModel populating correctly. Root cause: A2UI v0.9's `CreateSurface` wire schema (`car-a2ui/src/lib.rs:120`) only carries `surfaceId` + catalog metadata — `components` and `dataModel` are silently dropped by serde (extra-fields-ignored). The agent-docs cookbook example shows them inside `createSurface`; the wire format doesn't actually accept that. `SurfaceManager.ensure_surface` now emits three envelopes in order: `createSurface` (surfaceId only) → `updateComponents` (the tree) → `updateDataModel` (initial state). For existing surfaces left empty by 0.20.0, re-emits ONLY `updateComponents` on reconnect — heals the tree without wiping live observer/memory state. Live-confirmed against CarHost.app: 17 components, correct root, observer + memory dataModel intact.
+
 ## [0.20.0] - 2026-05-24
 
 Neo gains a long-lived presence: an out-of-band synthesis observer supervised by CAR's agent runtime, a live A2UI memory inspector that exposes both observer cycles and FactStore state to any conformant renderer, plus quieter foundational work on project-ID stability, metrics ergonomics, and a new fact-domain taxonomy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.20.0"
+version = "0.20.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Patch release **v0.20.1** — fixes the empty A2UI surface in CarHost.app reported against 0.20.0.

Single fix: `SurfaceManager.ensure_surface` now emits three envelopes (`createSurface` → `updateComponents` → `updateDataModel`) instead of one combined `createSurface`. Root cause: A2UI v0.9's Rust wire schema rejects `components`/`dataModel` as fields on `createSurface` — serde silently drops them, the surface is created empty, the renderer shows "(no root component)". The agent-docs cookbook example shows the combined shape, but the wire format doesn't accept it.

For surfaces already in the broken state (created by 0.20.0), the reconnect path re-emits ONLY `updateComponents` — heals the tree without wiping live observer/memory dataModel state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Caught only by attaching CarHost.app's A2UI inspector. 0.20.0's unit tests passed against the envelope shape I had; they didn't catch that the daemon parsed only `surfaceId` from the envelope. New `TestInitialEnvelopes` group now asserts the wire-correct 3-envelope shape — regression test for the bug class.

## How Has This Been Tested?

- [x] 29 a2ui unit tests pass locally + ruff clean
- [x] CI green on main commit `bb0b8fe` (Python 3.10/3.11/3.12/3.13)
- [x] **Live-verified against CarHost.app**: 17 components persist on the daemon-side surface, root tree correctly defined as `Column[header, tabs]`, observer + memory dataModel intact and updating each cycle

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (none needed — fix is internal)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (TestInitialEnvelopes + repair-path tests)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Patch is wire-compat: 0.20.0 users running broken surfaces will heal on next reconnect.