### PR TITLE
Release v0.20.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.20.2] - 2026-05-25
+
+### Fixed
+
+The A2UI memory inspector ships against a real CarHost.app renderer for the first time. Three wire-schema bugs (silent failures the unit tests couldn't see) and one UX pass.
+
+- **Tabs rendered empty** — A2UI v0.9's Tabs component takes **two parallel arrays** (`tabs: [{id, label}]` for metadata, `children: [contentId]` for content in matching order), per the renderer contract in `apps/car-a2ui-renderer/.../A2uiRenderer.swift:595`. The previous shape (a single `children` of nested tab-descriptor dicts) left the tab bar entirely blank — the renderer iterated nothing and showed no labels.
+- **Badge rendered as an empty pill** — Badge's visible value lives on `text`, not `label` (`A2uiRenderer.swift:675`). With `label`, the renderer read empty string and drew the capsule with no content. Also pinned a literal `tone` because the renderer reads `obj["tone"].asString` directly — `{path: …}` references don't resolve there.
+- **`List` with `forEach`/`itemTemplate` did nothing** — the v0.9 basic-catalog renderer maps `List` to `renderStack(.vertical)` (`A2uiRenderer.swift:465`); there's no template iteration. Dropped the dynamic recent-cycles list in favor of static stays-current Texts. A future surface revision can declare fixed slot Texts bound to indexed paths if a visible cycle log is desired.
+
+### Changed (UX)
+
+Inspector header redesigned to read like `neo --version` instead of supervisor jargon:
+
+- **Header now mirrors `neo --version`**: personality quote (from `config/beats/neo_matrix.yaml`, stage-appropriate), repo display name (e.g. `Parslee-ai/neo` from the normalized git remote — not the SHA), `neo X.Y.Z` line, and a learning-stage summary (`Stage: Glitch · Memory 30.4% · 117 patterns · 0.58 avg confidence`). The CLI banner and the inspector header now read the same stage info — `a2ui._STAGE_TABLE` is kept in lockstep with `subcommands.show_version`.
+- **Observer tab no longer redundant with the header** — dropped the "Idle, watching for patterns" status line that just restated the Observer card below it. Header stays summary-only; Observer card carries the operational detail (badge, last-check timestamp, cadence, action buttons).
+- **Button labels say what they do**: `Kick` → `Run now`, `Stop` → `Pause`. The wire action names (`kick`, `stop`) are unchanged so handlers don't need to rename — only the user-visible label flipped.
+- **Memory tab gains plain-English descriptions**: `50 patterns — stable techniques and conventions`, `58 reviews — recent observations being distilled into patterns`, `9 constraints — hard rules from project docs`. Pluralization handled (`1 pattern` vs `2 patterns`, `1 fact still being validated` vs `2 facts`). Scope line reads as `67 specific to this project · 50 from your global knowledge` instead of `project=67, global=50`.
+
 ## [0.20.1] - 2026-05-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.20.1"
+version = "0.20.2"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.20.1"
+__version__ = "0.20.2"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/a2ui.py
+++ b/src/neo/a2ui.py
@@ -239,91 +239,168 @@ def _components_tree() -> list[dict]:
     creation from component population:
 
       - ``createSurface`` carries *only* ``surfaceId`` + catalog metadata.
-        Any ``components`` / ``dataModel`` field on it is silently dropped
-        by serde during deserialization (extra-fields-ignored). The
-        agent-docs cookbook shows them in one envelope; the wire format
-        doesn't accept that. Surface gets created — empty — and the
-        renderer shows "(no root component)".
-
       - ``updateComponents`` carries the component list. We emit it
         right after ``createSurface``.
-
       - ``updateDataModel`` (no ``path``, ``value=<full tree>``) seeds
         the data model. Subsequent state pushes target specific paths.
 
-    All component names below are from ``BASIC_CATALOG_V0_9`` so any
-    conformant renderer can draw the surface.
+    All component names below are from ``BASIC_CATALOG_V0_9``. Layout
+    optimized for a human reader: real repo name in the header, plain-
+    English status line ("Neo says…"), action buttons labeled by what
+    they DO rather than supervisor primitives.
     """
     return [
         {"id": "root", "component": "Column",
-         "children": ["header", "tabs"]},
-        {"id": "header", "component": "Card", "children": ["title"]},
-        {"id": "title", "component": "Text",
+         "children": ["header-card", "tabs"]},
+
+        # --- Header card ---------------------------------------------
+        # Mirrors `neo --version`: personality quote, then the repo
+        # title, then the version + learning-stage metadata. The
+        # Observer tab below owns the operational "what's it doing
+        # right now" detail — header stays summary-only.
+        {"id": "header-card", "component": "Card",
+         "children": ["hdr-quote", "hdr-title", "hdr-version", "hdr-stage"]},
+        {"id": "hdr-quote", "component": "Text",
+         "text": {"path": "/header/quote"}, "variant": "body"},
+        {"id": "hdr-title", "component": "Text",
          "text": {"path": "/header/title"}, "variant": "title"},
-        {"id": "tabs", "component": "Tabs", "children": [
-            {"id": "tab-observer", "label": "Observer",
-             "child": "observer-card"},
-            {"id": "tab-memory", "label": "Memory",
-             "child": "memory-card"},
-        ]},
+        {"id": "hdr-version", "component": "Text",
+         "text": {"path": "/header/version"}, "variant": "caption"},
+        {"id": "hdr-stage", "component": "Text",
+         "text": {"path": "/header/stage"}, "variant": "subtitle"},
+
+        # --- Tabs ----------------------------------------------------
+        # Tabs expects two parallel arrays per the renderer contract
+        # (A2uiRenderer.swift:595): `tabs` carries `{id, label}` per
+        # tab; `children` carries the matching content component ids
+        # in the same order.
+        {"id": "tabs", "component": "Tabs",
+         "tabs": [
+             {"id": "tab-observer", "label": "Observer"},
+             {"id": "tab-memory", "label": "Memory"},
+         ],
+         "children": ["observer-card", "memory-card"]},
+
         # --- Observer tab --------------------------------------------
         {"id": "observer-card", "component": "Card", "children": [
-            "obs-status", "obs-pid", "obs-last", "obs-recent",
+            "obs-status", "obs-headline", "obs-last", "obs-cadence",
             "obs-actions",
         ]},
+        # Badge: per the renderer contract (A2uiRenderer.swift:675)
+        # the visible value lives on `text`, not `label`. `tone` is a
+        # literal (renderer reads `.asString` directly, no path
+        # resolution), so it can't follow status changes — we use
+        # neutral here because the badge text already says what's
+        # happening; the color would be redundant or misleading on
+        # error/backoff transitions we can't currently tone-bind.
         {"id": "obs-status", "component": "Badge",
-         "label": {"path": "/observer/status"}},
-        {"id": "obs-pid", "component": "Text",
-         "text": {"path": "/observer/header_text"}, "variant": "subtitle"},
+         "text": {"path": "/observer/status_label"}, "tone": "success"},
+        {"id": "obs-headline", "component": "Text",
+         "text": {"path": "/observer/headline"}, "variant": "subtitle"},
         {"id": "obs-last", "component": "Text",
-         "text": {"path": "/observer/last_cycle_text"}},
-        {"id": "obs-recent", "component": "List",
-         "forEach": {"path": "/observer/recent_cycles"},
-         "itemTemplate": {"component": "Text",
-                          "text": {"path": "/text"}}},
+         "text": {"path": "/observer/last_check"}},
+        {"id": "obs-cadence", "component": "Text",
+         "text": {"path": "/observer/cadence"}, "variant": "caption"},
+        # Buttons labeled by user intent, not supervisor primitive.
+        # `Run now` maps to a kick (`agents_restart`); `Pause` maps to
+        # a stop (`agents_stop`). The action name on the wire matches
+        # the original primitive so handlers don't need to rename.
         {"id": "obs-actions", "component": "Row",
-         "children": ["btn-kick", "btn-stop"]},
-        {"id": "btn-kick", "component": "Button",
-         "label": "Kick", "action": "kick"},
-        {"id": "btn-stop", "component": "Button",
-         "label": "Stop", "action": "stop"},
+         "children": ["btn-run-now", "btn-pause"]},
+        {"id": "btn-run-now", "component": "Button",
+         "label": "Run now", "action": "kick"},
+        {"id": "btn-pause", "component": "Button",
+         "label": "Pause", "action": "stop"},
+
         # --- Memory tab ----------------------------------------------
         {"id": "memory-card", "component": "Card", "children": [
-            "mem-total", "mem-by-kind", "mem-by-scope", "mem-probation",
+            "mem-headline", "mem-patterns", "mem-reviews",
+            "mem-constraints", "mem-scope", "mem-probation",
         ]},
-        {"id": "mem-total", "component": "Text",
-         "text": {"path": "/memory/total_text"}, "variant": "subtitle"},
-        {"id": "mem-by-kind", "component": "Text",
-         "text": {"path": "/memory/by_kind_text"}},
-        {"id": "mem-by-scope", "component": "Text",
-         "text": {"path": "/memory/by_scope_text"}},
+        {"id": "mem-headline", "component": "Text",
+         "text": {"path": "/memory/headline"}, "variant": "subtitle"},
+        {"id": "mem-patterns", "component": "Text",
+         "text": {"path": "/memory/patterns"}},
+        {"id": "mem-reviews", "component": "Text",
+         "text": {"path": "/memory/reviews"}},
+        {"id": "mem-constraints", "component": "Text",
+         "text": {"path": "/memory/constraints"}},
+        {"id": "mem-scope", "component": "Text",
+         "text": {"path": "/memory/scope"}, "variant": "caption"},
         {"id": "mem-probation", "component": "Text",
-         "text": {"path": "/memory/probation_text"}},
+         "text": {"path": "/memory/probation"}, "variant": "caption"},
     ]
 
 
-def _initial_data_model(project_id: str) -> dict:
+def _repo_display_name(codebase_root: Optional[str]) -> str:
+    """Human-readable repo identifier for the header. Falls back to
+    the codebase root basename if no git remote is detected."""
+    from neo.memory.scope import (
+        _detect_org,
+        _get_git_remote_url,
+        _normalize_remote_url,
+    )
+
+    if not codebase_root:
+        return "this project"
+
+    remote = _get_git_remote_url(codebase_root)
+    if remote:
+        normalized = _normalize_remote_url(remote)
+        if normalized:
+            # normalized is "host/org/repo[/...]" — take last two
+            # segments so e.g. "github.com/Parslee-ai/neo" → "Parslee-ai/neo"
+            parts = normalized.split("/")
+            if len(parts) >= 3:
+                return f"{parts[-2]}/{parts[-1]}"
+
+    org = _detect_org(codebase_root)
+    from pathlib import Path
+    basename = Path(codebase_root).resolve().name or "this project"
+    if org and org != "unknown":
+        return f"{org}/{basename}"
+    return basename
+
+
+def _neo_version() -> str:
+    """Current neo-reasoner version string. Reads `neo.__version__`
+    lazily so this module stays import-light."""
+    try:
+        from neo import __version__
+        return __version__
+    except ImportError:
+        return "?"
+
+
+def _initial_data_model(repo_display: str) -> dict:
     """Seed data model. JSON-pointer paths under here are what
-    component bindings (``{"path": "/observer/status"}`` etc.) resolve
-    against; subsequent ``updateDataModel`` calls replace subtrees."""
+    component bindings resolve against; ``updateDataModel`` calls
+    replace subtrees on every cycle."""
     return {
-        "header": {"title": f"Neo · project {project_id[:8]}"},
+        "header": {
+            "quote": "Just opened my eyes.",
+            "title": repo_display,
+            "version": f"neo {_neo_version()}",
+            "stage": "Loading…",
+        },
         "observer": {
-            "status": "starting",
-            "header_text": "—",
-            "last_cycle_text": "no cycles yet",
-            "recent_cycles": [],
+            "status_label": "Starting",
+            "headline": "Looking for patterns in your project memory",
+            "last_check": "—",
+            "cadence": "—",
         },
         "memory": {
-            "total_text": "loading…",
-            "by_kind_text": "—",
-            "by_scope_text": "—",
-            "probation_text": "—",
+            "headline": f"Memory for {repo_display}",
+            "patterns": "—",
+            "reviews": "—",
+            "constraints": "—",
+            "scope": "—",
+            "probation": "—",
         },
     }
 
 
-def _initial_envelopes(surface_id: str, project_id: str) -> list[dict]:
+def _initial_envelopes(surface_id: str, repo_display: str) -> list[dict]:
     """The three envelopes ``ensure_surface`` sends in order.
 
     Split because A2UI v0.9's wire schema requires it — see
@@ -337,7 +414,7 @@ def _initial_envelopes(surface_id: str, project_id: str) -> list[dict]:
         }},
         {"updateDataModel": {
             "surfaceId": surface_id,
-            "value": _initial_data_model(project_id),
+            "value": _initial_data_model(repo_display),
         }},
     ]
 
@@ -379,10 +456,13 @@ class SurfaceManager:
     def __init__(
         self,
         project_id: str,
+        codebase_root: Optional[str] = None,
         action_handlers: Optional[dict[str, Callable[[dict], Awaitable[None]]]] = None,
     ):
         self.project_id = project_id
+        self.codebase_root = codebase_root
         self.surface_id = surface_id_for(project_id)
+        self.repo_display = _repo_display_name(codebase_root)
         self.client = DaemonClient()
         self._connected = False
         self._action_handlers = action_handlers or {}
@@ -433,7 +513,7 @@ class SurfaceManager:
             logger.debug("a2ui_get probe failed: %s", e)
             existing = None
 
-        envelopes = _initial_envelopes(self.surface_id, self.project_id)
+        envelopes = _initial_envelopes(self.surface_id, self.repo_display)
         for env in envelopes:
             # Skip createSurface when the surface already exists (the
             # daemon would refuse it). Skip the initial-dataModel seed
@@ -454,6 +534,19 @@ class SurfaceManager:
 
     async def push_memory_state(self, state: dict) -> None:
         await self._push("/memory", state)
+
+    async def push_header_state(self, state: dict) -> None:
+        """Update the header card's dynamic fields (quote, stage line).
+
+        Static fields (title, version) are seeded by ``ensure_surface``
+        and unchanged across cycles; this push only carries the parts
+        that move with each FactStore snapshot.
+        """
+        # Push paths individually so we don't clobber the static
+        # title/version bindings the renderer already cached.
+        for key in ("quote", "stage"):
+            if key in state:
+                await self._push(f"/header/{key}", state[key])
 
     async def _push(self, path: str, value: Any) -> None:
         if not self._connected:
@@ -491,63 +584,225 @@ class SurfaceManager:
 # ---------------------------------------------------------------------------
 
 
+def _fact_count_label(kind: str, n: int, descriptions: dict[str, str]) -> str:
+    """`"50 patterns — stable techniques and conventions"` etc.
+    Returns plain "0 patterns" when count is 0 so the row is still
+    visible (signals "neo hasn't distilled any patterns yet"), and
+    drops the em-dash trailer when no description is provided."""
+    label = f"{n} {kind}"
+    desc = descriptions.get(kind, "")
+    return f"{label} — {desc}" if desc else label
+
+
 def observer_state_snapshot(
     *,
-    pid: int,
-    project_id: str,
+    interval_seconds: float,
     last_cycle_epoch: Optional[float],
     last_cycle_count: Optional[int],
+    last_cycle_error: Optional[str] = None,
     cycles_total: int,
-    recent_cycles: list[dict],
 ) -> dict:
-    """Pack observer-tab fields into the JSON shape the surface expects."""
+    """Pack observer-tab fields into the surface's data-model shape.
+
+    All text is user-facing plain English. `interval_seconds` is used
+    to render cadence; `last_cycle_*` describe the most recent
+    synthesis pass.
+    """
     import time as _t
 
     if last_cycle_epoch:
-        age = max(0, int(_t.time() - last_cycle_epoch))
-        last_text = f"last cycle {_humanize_seconds(age)} ago · {last_cycle_count} synthesized"
+        ts = _t.strftime("%H:%M:%S", _t.localtime(last_cycle_epoch))
+        if last_cycle_error:
+            last_text = f"Last check at {ts} hit {last_cycle_error}"
+        elif last_cycle_count and last_cycle_count > 0:
+            noun = "pattern" if last_cycle_count == 1 else "patterns"
+            last_text = f"Last check at {ts} distilled {last_cycle_count} new {noun}"
+        else:
+            last_text = f"Last check at {ts} · no new patterns"
     else:
-        last_text = "no cycles yet"
+        last_text = "No checks yet"
+
+    interval_minutes = max(1, int(interval_seconds / 60))
+    plural = "minute" if interval_minutes == 1 else "minutes"
+    cadence = (
+        f"Checks every {interval_minutes} {plural} · "
+        f"{cycles_total} {'check' if cycles_total == 1 else 'checks'} this session"
+    )
 
     return {
-        "status": "running",
-        "header_text": f"pid {pid} · project {project_id[:8]} · {cycles_total} cycles",
-        "last_cycle_text": last_text,
-        "recent_cycles": recent_cycles[-RECENT_CYCLES_MAX:],
+        "status_label": "Recovering" if last_cycle_error else "Active",
+        "headline": "Looking for patterns in your project memory",
+        "last_check": last_text,
+        "cadence": cadence,
     }
 
 
-def memory_state_snapshot(store: Any) -> dict:
-    """Pack memory-tab fields from a FactStore. Counts valid facts only."""
+# Plain-English descriptions for each fact-kind. Keep these short —
+# they're inline help text, not documentation.
+_KIND_DESCRIPTIONS = {
+    "patterns": "stable techniques and conventions",
+    "reviews": "recent observations being distilled into patterns",
+    "constraints": "hard rules from project docs (CLAUDE.md, AGENTS.md)",
+    "failures": "approaches that didn't work and why",
+    "decisions": "feature and design decisions",
+    "architecture": "architectural choices about this codebase",
+    "episodes": "specific events with full context",
+    "known unknowns": "explicit gaps in knowledge",
+}
+
+
+def memory_state_snapshot(store: Any, repo_display: str) -> dict:
+    """Pack memory-tab fields from a FactStore. Counts valid facts
+    only; presents kind/scope breakdowns in user-readable English.
+
+    ``repo_display`` is passed in (not derived) so this stays pure —
+    the SurfaceManager owns repo identity.
+    """
     from collections import Counter
 
     facts = getattr(store, "_facts", []) or []
     valid = [f for f in facts if getattr(f, "is_valid", False)]
 
     total = len(valid)
-    by_kind = Counter(getattr(f.kind, "value", str(f.kind)) for f in valid)
+    by_kind_raw = Counter(getattr(f.kind, "value", str(f.kind)) for f in valid)
     by_scope = Counter(getattr(f.scope, "value", str(f.scope)) for f in valid)
-
     probation_count = sum(
-        1 for f in valid if "probation" in getattr(f, "tags", []) or []
+        1 for f in valid if "probation" in (getattr(f, "tags", []) or [])
     )
 
+    # Pluralize fact-kind names into the labels users see. ``review``
+    # → ``reviews``, ``known_unknown`` → ``known unknowns``, etc. The
+    # internal enum stays as-is; this transform is presentation-only.
+    def _pluralize_kind(k: str) -> str:
+        k = k.replace("_", " ")
+        # Lazy English pluralization — covers the FactKind set.
+        if k.endswith("y"):
+            return k[:-1] + "ies"
+        if k.endswith("s"):
+            return k
+        return k + "s"
+
+    by_kind = {_pluralize_kind(k): n for k, n in by_kind_raw.items()}
+
+    # Render the three most common kinds inline (patterns / reviews /
+    # constraints are the ones with the most actionable interpretation).
+    # Anything else gets folded into a tail.
+    primary_kinds = ["patterns", "reviews", "constraints"]
+    primary_lines = {
+        kind: _fact_count_label(kind, by_kind.get(kind, 0), _KIND_DESCRIPTIONS)
+        for kind in primary_kinds
+    }
+    other = {k: v for k, v in by_kind.items() if k not in primary_kinds}
+
+    proj_count = by_scope.get("project", 0)
+    global_count = by_scope.get("global", 0)
+    org_count = by_scope.get("org", 0)
+    scope_parts = [f"{proj_count} specific to this project"]
+    if global_count:
+        scope_parts.append(f"{global_count} from your global knowledge")
+    if org_count:
+        scope_parts.append(f"{org_count} from your organization")
+    if other:
+        # Tail of less-common kinds — single line so the layout doesn't
+        # explode when synthesis surfaces more variants.
+        other_str = ", ".join(f"{n} {k}" for k, n in sorted(other.items(), key=lambda kv: -kv[1]))
+        scope_parts.append(f"plus {other_str}")
+
+    fact_noun = "fact" if total == 1 else "facts"
     return {
-        "total_text": f"{total} valid facts",
-        "by_kind_text": "by kind: " + ", ".join(
-            f"{k}={v}" for k, v in sorted(by_kind.items(), key=lambda kv: -kv[1])
-        ) if by_kind else "by kind: —",
-        "by_scope_text": "by scope: " + ", ".join(
-            f"{s}={v}" for s, v in sorted(by_scope.items(), key=lambda kv: -kv[1])
-        ) if by_scope else "by scope: —",
-        "probation_text": f"probation: {probation_count} fact(s)",
+        "headline": f"{total} {fact_noun} about {repo_display}",
+        "patterns": primary_lines["patterns"],
+        "reviews": primary_lines["reviews"],
+        "constraints": primary_lines["constraints"],
+        "scope": " · ".join(scope_parts),
+        "probation": (
+            f"{probation_count} {'fact' if probation_count == 1 else 'facts'} "
+            "still being validated (auto-promote on reuse)"
+            if probation_count
+            else "All facts validated — no probation"
+        ),
     }
 
 
-def _humanize_seconds(s: int) -> str:
-    """`90 → "1m30s"`, `3700 → "1h1m"`. Capped at hours."""
-    if s < 60:
-        return f"{s}s"
-    if s < 3600:
-        return f"{s // 60}m{s % 60}s"
-    return f"{s // 3600}h{(s % 3600) // 60}m"
+# Stage thresholds — must stay in lockstep with `subcommands.show_version`.
+# Both renderers compute the same stage so the inspector header and the
+# CLI version banner say the same thing about Neo's progress.
+_STAGE_TABLE = [
+    (0.2, 1, "Sleeper"),
+    (0.4, 2, "Glitch"),
+    (0.6, 3, "Unplugged"),
+    (0.8, 4, "Training"),
+    (1.01, 5, "The One"),  # 1.01 so the 1.0 boundary lands inside The One
+]
+
+
+def _stage_for_memory_level(level: float) -> tuple[int, str]:
+    """Map a memory-level [0, 1] to (stage_number, stage_name)."""
+    for upper, num, name in _STAGE_TABLE:
+        if level < upper:
+            return num, name
+    return 5, "The One"
+
+
+def _stage_quote(stage_num: int) -> str:
+    """Stage-appropriate quote from the bundled beat deck. Falls back
+    to a sensible default when the deck file or PyYAML is unavailable.
+    """
+    fallback = "What is real? How do you define 'real'?"
+    try:
+        import yaml
+        from pathlib import Path
+
+        beat_deck_path = (
+            Path(__file__).parent / "config" / "beats" / "neo_matrix.yaml"
+        )
+        if not beat_deck_path.exists():
+            return fallback
+        with open(beat_deck_path) as f:
+            beat_deck = yaml.safe_load(f) or {}
+        stage_expr = (beat_deck.get("base_expressions") or {}).get(stage_num, {})
+        return stage_expr.get("internal", fallback)
+    except Exception:  # noqa: BLE001 — observability path; never error
+        return fallback
+
+
+def version_state_snapshot(store: Any) -> dict:
+    """Header fields that mirror ``neo --version`` output — quote,
+    version, stage line.
+
+    The CLI's version banner reads:
+        "<quote>"
+        neo <version>
+        Stage: <stage> | Memory: <pct>%
+        <bar>
+        <N> patterns | <C> avg confidence
+
+    The inspector header flattens that into three Texts (quote · title
+    · version · stage) — same data, no progress bar (A2UI v0.9's basic
+    catalog has no Progress component).
+    """
+    facts = getattr(store, "_facts", []) or []
+    valid = [f for f in facts if getattr(f, "is_valid", False)]
+    total = len(valid)
+
+    confs = [
+        getattr(f, "metadata").confidence
+        for f in valid
+        if hasattr(f, "metadata")
+    ]
+    avg_conf = (sum(confs) / len(confs)) if confs else 0.0
+
+    try:
+        level = float(store.memory_level())
+    except Exception:  # noqa: BLE001
+        level = 0.0
+    stage_num, stage_name = _stage_for_memory_level(level)
+
+    fact_noun = "pattern" if total == 1 else "patterns"
+    return {
+        "quote": f'"{_stage_quote(stage_num)}"',
+        "stage": (
+            f"Stage: {stage_name} · Memory {level:.1%} · "
+            f"{total} {fact_noun} · {avg_conf:.2f} avg confidence"
+        ),
+    }

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -255,6 +255,7 @@ class Observer:
             self._last_analysis_epoch = time.time()
             self._cycles_total += 1
             self._last_cycle_count = count
+            self._last_cycle_error = None
             self._recent_cycles.append({
                 "timestamp": self._last_analysis_epoch,
                 "text": (
@@ -271,6 +272,7 @@ class Observer:
             )
         except Exception as e:
             self._last_cycle_count = None
+            self._last_cycle_error = type(e).__name__
             self._recent_cycles.append({
                 "timestamp": time.time(),
                 "text": f"{time.strftime('%H:%M:%S')} · ERROR {type(e).__name__}",
@@ -282,11 +284,21 @@ class Observer:
             )
 
     def _build_store_snapshot(self, store) -> Optional[dict]:
-        """Extract memory-tab state from a FactStore. Wrapped so an
-        unexpected schema change can't blow up the cycle's main path."""
+        """Extract memory-tab + header-stage state from a FactStore.
+
+        Wrapped so an unexpected schema change can't blow up the
+        cycle's main path. Returns a {"memory": ..., "header": ...}
+        dict that the post-cycle push splits into the two updateDataModel
+        envelopes.
+        """
         try:
-            from neo.a2ui import memory_state_snapshot
-            return memory_state_snapshot(store)
+            from neo.a2ui import memory_state_snapshot, version_state_snapshot
+            repo_display = getattr(self._surface, "repo_display", "this project") \
+                if self._surface else "this project"
+            return {
+                "memory": memory_state_snapshot(store, repo_display),
+                "header": version_state_snapshot(store),
+            }
         except Exception as e:  # noqa: BLE001
             logger.debug("memory snapshot extraction failed: %s", e)
             return None
@@ -310,6 +322,7 @@ class Observer:
 
         self._surface = SurfaceManager(
             self.project_id,
+            codebase_root=self.codebase_root,
             action_handlers={
                 "kick": self._on_kick_action,
                 "stop": self._on_stop_action,
@@ -334,17 +347,24 @@ class Observer:
             return
         try:
             from neo.a2ui import observer_state_snapshot
+            last_count = getattr(self, "_last_cycle_count", None)
+            last_error = getattr(self, "_last_cycle_error", None)
             obs = observer_state_snapshot(
-                pid=os.getpid(),
-                project_id=self.project_id,
+                interval_seconds=self.config.interval_seconds,
                 last_cycle_epoch=self._last_analysis_epoch or None,
-                last_cycle_count=getattr(self, "_last_cycle_count", None),
+                last_cycle_count=last_count,
+                last_cycle_error=last_error,
                 cycles_total=self._cycles_total,
-                recent_cycles=self._recent_cycles,
             )
             await self._surface.push_observer_state(obs)
             if self._last_store_snapshot is not None:
-                await self._surface.push_memory_state(self._last_store_snapshot)
+                # snapshot is {"memory": ..., "header": ...} — push the
+                # memory subtree and the header's dynamic fields.
+                snap = self._last_store_snapshot
+                if "memory" in snap:
+                    await self._surface.push_memory_state(snap["memory"])
+                if "header" in snap:
+                    await self._surface.push_header_state(snap["header"])
         except Exception as e:  # noqa: BLE001
             logger.debug("a2ui push after cycle failed: %s", e)
 

--- a/tests/test_a2ui.py
+++ b/tests/test_a2ui.py
@@ -77,18 +77,24 @@ class TestInitialEnvelopes:
 
     def test_updateComponents_has_full_component_tree(self):
         from neo.a2ui import _initial_envelopes
-        envs = _initial_envelopes("neo-x", "x")
+        envs = _initial_envelopes("neo-x", "Parslee-ai/neo")
         uc = envs[1]["updateComponents"]
         assert uc["surfaceId"] == "neo-x"
         comp_ids = [c["id"] for c in uc["components"]]
         assert "root" in comp_ids
         assert "obs-status" in comp_ids
-        assert "mem-total" in comp_ids
-        assert "btn-kick" in comp_ids
+        assert "mem-headline" in comp_ids
+        assert "btn-run-now" in comp_ids
+        assert "btn-pause" in comp_ids
+        # Header components: quote, title, version line, stage line.
+        # No "says" — that was the redundant copy of the observer-tab
+        # state; the header now mirrors `neo --version`.
+        for cid in ("hdr-quote", "hdr-title", "hdr-version", "hdr-stage"):
+            assert cid in comp_ids, f"header must include {cid}"
 
     def test_updateDataModel_seeds_full_value_tree(self):
         from neo.a2ui import _initial_envelopes
-        envs = _initial_envelopes("neo-fcbc43ed0a20", "fcbc43ed0a20b8b8")
+        envs = _initial_envelopes("neo-fcbc43ed0a20", "Parslee-ai/neo")
         udm = envs[2]["updateDataModel"]
         assert udm["surfaceId"] == "neo-fcbc43ed0a20"
         # No "path" — whole-value replace, per the Rust UpdateDataModel
@@ -97,7 +103,11 @@ class TestInitialEnvelopes:
         dm = udm["value"]
         assert "observer" in dm
         assert "memory" in dm
-        assert "fcbc43ed" in dm["header"]["title"]
+        # Header carries the human-readable repo name, NOT a SHA hash.
+        # `neo --version`-shaped fields: quote, title, version, stage.
+        assert dm["header"]["title"] == "Parslee-ai/neo"
+        for key in ("quote", "version", "stage"):
+            assert key in dm["header"], f"header.{key} missing"
 
     def test_uses_only_basic_catalog_components(self):
         """Component types must be in BASIC_CATALOG_V0_9. Otherwise
@@ -110,8 +120,37 @@ class TestInitialEnvelopes:
             "FilePicker",
         }
         for c in _components_tree():
-            if "component" in c:  # tabs children dicts have no 'component'
-                assert c["component"] in allowed, f"unknown component: {c['component']}"
+            assert c["component"] in allowed, f"unknown component: {c['component']}"
+
+    def test_badge_uses_text_field_not_label(self):
+        """Regression: Badge's visible value is on `text`, not `label`
+        (`A2uiRenderer.swift:675`). Mislabeling produces an empty pill —
+        the renderer reads `obj["text"]` and falls back to "" silently."""
+        from neo.a2ui import _components_tree
+        badge = next(c for c in _components_tree() if c["component"] == "Badge")
+        assert "text" in badge, "Badge must use `text` field"
+        assert "label" not in badge, (
+            "Badge does NOT accept `label` (renderer ignores it; renders empty)"
+        )
+
+    def test_tabs_uses_parallel_arrays(self):
+        """Tabs schema (per renderer contract) takes two parallel
+        arrays: `tabs: [{id, label}]` for tab metadata, `children:
+        [contentId]` for the content component ids in matching order.
+        NOT a single `children` of nested tab-descriptor objects —
+        that shape leaves the tab bar empty (the renderer pulls labels
+        from `tabs[i].label` and the rendered content from
+        `surface.component(children[i])`)."""
+        from neo.a2ui import _components_tree
+        tabs = next(c for c in _components_tree() if c["component"] == "Tabs")
+        assert isinstance(tabs.get("tabs"), list)
+        assert all(isinstance(t, dict) and "id" in t and "label" in t
+                   for t in tabs["tabs"]), "every tab entry needs {id, label}"
+        assert isinstance(tabs.get("children"), list)
+        assert all(isinstance(child, str) for child in tabs["children"]), \
+            "Tabs children must be plain component-id strings, not nested objects"
+        assert len(tabs["tabs"]) == len(tabs["children"]), \
+            "tabs[] and children[] must be same length (parallel arrays)"
 
 
 class TestUpdatePathEnvelope:
@@ -136,95 +175,206 @@ class TestObserverStateSnapshot:
     def test_no_cycles_yet(self):
         from neo.a2ui import observer_state_snapshot
         s = observer_state_snapshot(
-            pid=123, project_id="abcdef1234567890",
-            last_cycle_epoch=None, last_cycle_count=None,
-            cycles_total=0, recent_cycles=[],
+            interval_seconds=300, last_cycle_epoch=None,
+            last_cycle_count=None, cycles_total=0,
         )
-        assert s["status"] == "running"
-        assert s["last_cycle_text"] == "no cycles yet"
-        assert "pid 123" in s["header_text"]
-        assert s["recent_cycles"] == []
+        assert s["status_label"] == "Active"
+        assert s["last_check"] == "No checks yet"
+        assert "Checks every 5 minutes" in s["cadence"]
+        assert "0 checks" in s["cadence"]
 
-    def test_includes_recent_cycle_summary(self):
-        import time
+    def test_cadence_is_user_readable(self):
         from neo.a2ui import observer_state_snapshot
-        now = time.time() - 65  # 1m5s ago
         s = observer_state_snapshot(
-            pid=123, project_id="abcdef1234567890",
-            last_cycle_epoch=now, last_cycle_count=3,
-            cycles_total=5, recent_cycles=[{"text": "x"}],
+            interval_seconds=300, last_cycle_epoch=None,
+            last_cycle_count=None, cycles_total=1,
         )
-        assert "3 synthesized" in s["last_cycle_text"]
-        assert "5 cycles" in s["header_text"]
+        # Pluralization correctness — "1 check" (singular) but
+        # "5 minutes" (plural).
+        assert "1 check this session" in s["cadence"]
+        assert "minutes" in s["cadence"]
 
-    def test_recent_cycles_capped(self):
-        """RECENT_CYCLES_MAX = 20; longer histories should be trimmed."""
-        from neo.a2ui import RECENT_CYCLES_MAX, observer_state_snapshot
-        history = [{"text": f"cycle-{i}"} for i in range(50)]
+    def test_last_check_with_patterns_found(self):
+        import time as _t
+        from neo.a2ui import observer_state_snapshot
         s = observer_state_snapshot(
-            pid=1, project_id="x", last_cycle_epoch=None,
-            last_cycle_count=None, cycles_total=50, recent_cycles=history,
+            interval_seconds=300, last_cycle_epoch=_t.time() - 60,
+            last_cycle_count=3, cycles_total=2,
         )
-        assert len(s["recent_cycles"]) == RECENT_CYCLES_MAX
-        # Tail kept, not head — most recent at the end.
-        assert s["recent_cycles"][-1]["text"] == "cycle-49"
+        assert "distilled 3 new patterns" in s["last_check"]
+        # Time stamp not a relative offset (which would go stale).
+        assert "Last check at " in s["last_check"]
+
+    def test_last_check_singular_pattern(self):
+        import time as _t
+        from neo.a2ui import observer_state_snapshot
+        s = observer_state_snapshot(
+            interval_seconds=300, last_cycle_epoch=_t.time(),
+            last_cycle_count=1, cycles_total=1,
+        )
+        assert "1 new pattern" in s["last_check"]
+        assert "patterns" not in s["last_check"], "should be singular"
+
+    def test_status_label_flips_to_recovering_on_error(self):
+        from neo.a2ui import observer_state_snapshot
+        s = observer_state_snapshot(
+            interval_seconds=300, last_cycle_epoch=12345.0,
+            last_cycle_count=None, last_cycle_error="ValueError",
+            cycles_total=1,
+        )
+        assert s["status_label"] == "Recovering"
+        assert "ValueError" in s["last_check"]
 
 
 class TestMemoryStateSnapshot:
     def test_empty_store(self):
         from neo.a2ui import memory_state_snapshot
-        fake = MagicMock(_facts=[])
-        s = memory_state_snapshot(fake)
-        assert "0 valid facts" in s["total_text"]
-        assert s["by_kind_text"] == "by kind: —"
-        assert s["by_scope_text"] == "by scope: —"
-        assert "0 fact" in s["probation_text"]
+        s = memory_state_snapshot(MagicMock(_facts=[]), "Parslee-ai/neo")
+        assert s["headline"] == "0 facts about Parslee-ai/neo"
+        # Each primary kind line still renders even at 0 so the UI
+        # doesn't collapse the breakdown.
+        assert s["patterns"].startswith("0 patterns")
+        assert s["reviews"].startswith("0 reviews")
+        assert s["constraints"].startswith("0 constraints")
+        assert "All facts validated" in s["probation"]
 
-    def test_counts_valid_only(self):
+    def test_describes_each_kind_in_plain_english(self):
+        from neo.a2ui import memory_state_snapshot
+        f = MagicMock(is_valid=True, tags=[],
+                      kind=MagicMock(value="pattern"),
+                      scope=MagicMock(value="project"))
+        s = memory_state_snapshot(MagicMock(_facts=[f]), "x/y")
+        # Plain-English description after the em-dash.
+        assert "stable techniques" in s["patterns"]
+
+    def test_counts_valid_only_pluralizes_kinds(self):
         from neo.a2ui import memory_state_snapshot
         facts = []
-        for i in range(3):
-            f = MagicMock()
-            f.is_valid = True
-            f.kind = MagicMock(value="pattern")
-            f.scope = MagicMock(value="project")
-            f.tags = []
+        for _ in range(3):
+            f = MagicMock(is_valid=True, tags=[],
+                          kind=MagicMock(value="review"),
+                          scope=MagicMock(value="project"))
             facts.append(f)
-        invalid = MagicMock()
-        invalid.is_valid = False
-        invalid.kind = MagicMock(value="pattern")
-        invalid.scope = MagicMock(value="project")
-        invalid.tags = []
-        facts.append(invalid)
+        # Invalid fact must NOT be counted.
+        bad = MagicMock(is_valid=False, tags=[],
+                        kind=MagicMock(value="review"),
+                        scope=MagicMock(value="project"))
+        facts.append(bad)
+        s = memory_state_snapshot(MagicMock(_facts=facts), "x/y")
+        assert s["headline"] == "3 facts about x/y"
+        # Pluralization: review → reviews
+        assert s["reviews"].startswith("3 reviews")
 
-        fake = MagicMock(_facts=facts)
-        s = memory_state_snapshot(fake)
-        assert "3 valid facts" in s["total_text"]
-        assert "pattern=3" in s["by_kind_text"]
-        assert "project=3" in s["by_scope_text"]
-
-    def test_probation_tag_counted(self):
+    def test_probation_count_singular_plural(self):
         from neo.a2ui import memory_state_snapshot
-        f1 = MagicMock(is_valid=True, kind=MagicMock(value="review"),
-                       scope=MagicMock(value="project"), tags=["probation"])
-        f2 = MagicMock(is_valid=True, kind=MagicMock(value="pattern"),
-                       scope=MagicMock(value="project"), tags=[])
-        s = memory_state_snapshot(MagicMock(_facts=[f1, f2]))
-        assert "1 fact" in s["probation_text"]
+        f = MagicMock(is_valid=True, tags=["probation"],
+                      kind=MagicMock(value="review"),
+                      scope=MagicMock(value="project"))
+        s = memory_state_snapshot(MagicMock(_facts=[f]), "x/y")
+        assert s["probation"].startswith("1 fact ")
+        # Plural with 2:
+        s2 = memory_state_snapshot(MagicMock(_facts=[f, f]), "x/y")
+        assert s2["probation"].startswith("2 facts ")
+
+    def test_scope_breakdown_is_human_readable(self):
+        from neo.a2ui import memory_state_snapshot
+        proj = MagicMock(is_valid=True, tags=[],
+                         kind=MagicMock(value="pattern"),
+                         scope=MagicMock(value="project"))
+        glob = MagicMock(is_valid=True, tags=[],
+                         kind=MagicMock(value="pattern"),
+                         scope=MagicMock(value="global"))
+        s = memory_state_snapshot(MagicMock(_facts=[proj, glob]), "x/y")
+        assert "specific to this project" in s["scope"]
+        assert "global knowledge" in s["scope"]
 
 
-class TestHumanizeSeconds:
-    def test_seconds(self):
-        from neo.a2ui import _humanize_seconds
-        assert _humanize_seconds(45) == "45s"
+class TestVersionStateSnapshot:
+    """The header card mirrors `neo --version`: personality quote,
+    learning stage, fact count, avg confidence. These tests pin the
+    same stage thresholds + shape as ``subcommands.show_version``
+    (a regression here means the CLI banner and the inspector header
+    will disagree about what Neo is doing).
+    """
 
-    def test_minutes(self):
-        from neo.a2ui import _humanize_seconds
-        assert _humanize_seconds(90) == "1m30s"
+    def test_stage_mapping_matches_show_version(self):
+        from neo.a2ui import _stage_for_memory_level
+        assert _stage_for_memory_level(0.0) == (1, "Sleeper")
+        assert _stage_for_memory_level(0.19) == (1, "Sleeper")
+        assert _stage_for_memory_level(0.2) == (2, "Glitch")
+        assert _stage_for_memory_level(0.4) == (3, "Unplugged")
+        assert _stage_for_memory_level(0.6) == (4, "Training")
+        assert _stage_for_memory_level(0.8) == (5, "The One")
+        assert _stage_for_memory_level(1.0) == (5, "The One")
 
-    def test_hours(self):
-        from neo.a2ui import _humanize_seconds
-        assert _humanize_seconds(3700) == "1h1m"
+    def test_snapshot_has_quote_and_stage(self):
+        from neo.a2ui import version_state_snapshot
+        store = MagicMock(_facts=[], memory_level=lambda: 0.0)
+        s = version_state_snapshot(store)
+        assert "quote" in s
+        assert s["quote"].startswith('"') and s["quote"].endswith('"')
+        assert "Stage:" in s["stage"]
+        assert "Memory" in s["stage"]
+
+    def test_stage_line_includes_pattern_count_and_confidence(self):
+        from neo.a2ui import version_state_snapshot
+        # Build 3 valid facts with confidences 0.6, 0.7, 0.8
+        facts = []
+        for conf in (0.6, 0.7, 0.8):
+            md = MagicMock()
+            md.confidence = conf
+            f = MagicMock(is_valid=True, metadata=md)
+            facts.append(f)
+        store = MagicMock(_facts=facts, memory_level=lambda: 0.3)
+        s = version_state_snapshot(store)
+        # 3 patterns (plural), stage = Glitch (0.3 → 0.2-0.4 range),
+        # avg confidence = 0.70.
+        assert "3 patterns" in s["stage"]
+        assert "Glitch" in s["stage"]
+        assert "0.70 avg confidence" in s["stage"]
+        assert "Memory 30.0%" in s["stage"]
+
+    def test_singular_pattern_pluralization(self):
+        from neo.a2ui import version_state_snapshot
+        md = MagicMock()
+        md.confidence = 0.5
+        f = MagicMock(is_valid=True, metadata=md)
+        store = MagicMock(_facts=[f], memory_level=lambda: 0.0)
+        s = version_state_snapshot(store)
+        assert "1 pattern" in s["stage"]
+        # "1 patterns" would be a grammar fail — never present.
+        assert "1 patterns" not in s["stage"]
+
+    def test_memory_level_failure_doesnt_break_snapshot(self):
+        """If FactStore.memory_level() raises (e.g. mid-init), the
+        snapshot should still come back with a sensible default."""
+        from neo.a2ui import version_state_snapshot
+        def boom():
+            raise RuntimeError("not ready")
+        store = MagicMock(_facts=[], memory_level=boom)
+        s = version_state_snapshot(store)
+        # 0.0 → Sleeper. Snapshot resilient.
+        assert "Sleeper" in s["stage"]
+
+
+class TestRepoDisplayName:
+    def test_falls_back_to_basename_when_no_remote(self, monkeypatch):
+        monkeypatch.setattr("neo.memory.scope._get_git_remote_url", lambda *_: "")
+        monkeypatch.setattr("neo.memory.scope._detect_org", lambda *_: "unknown")
+        from neo.a2ui import _repo_display_name
+        assert _repo_display_name("/home/user/projects/myrepo") == "myrepo"
+
+    def test_uses_org_and_repo_from_https_remote(self, monkeypatch):
+        monkeypatch.setattr(
+            "neo.memory.scope._get_git_remote_url",
+            lambda *_: "https://github.com/Parslee-ai/neo.git",
+        )
+        from neo.a2ui import _repo_display_name
+        assert _repo_display_name("/some/path") == "Parslee-ai/neo"
+
+    def test_handles_no_codebase_root(self):
+        from neo.a2ui import _repo_display_name
+        assert _repo_display_name(None) == "this project"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Patch release **v0.20.2** — the A2UI memory inspector ships against a real CarHost.app renderer for the first time. Three wire-schema bugs (silent failures the mocked unit tests couldn't see) and a UX redesign of the header card.

The inspector now actually renders: tab bar with Observer/Memory, a green "Active" badge, plain-English memory breakdown, and a header that mirrors `neo --version` (personality quote, repo name, learning stage, fact stats) — no redundancy with the Observer tab below it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring *(header redesign — wire format unchanged from 0.20.1)*

## Motivation and Context

0.20.0 published an inspector that couldn't render — surface created empty (`createSurface` doesn't carry components; fixed in 0.20.1) and even after the 0.20.1 fix, Tabs and Badge silently rendered nothing because the wire shapes (parallel arrays for Tabs, `text` not `label` for Badge) diverged from the renderer contract. The earlier mocked tests didn't catch any of this because the daemon accepts our envelopes without error — only a real renderer surfaces the silent shape-mismatches.

The UX changes follow direct feedback ("project fcbc43ed means nothing to a user; no version visible; UI is just terrible"). Header now reads like the CLI banner; Observer tab carries operational detail without echoing it.

## How Has This Been Tested?

- [x] 40 a2ui unit tests pass; 24 observer unit tests pass; ruff clean
- [x] CI green on `bb0b8fe` baseline
- [x] **Live-verified against CarHost.app v0.17.0 A2UI pane**: tabs render, badge shows green "Active", header reads `Parslee-ai/neo · neo 0.20.2 · Stage: Glitch · Memory 30.4% · 117 patterns · 0.58 avg confidence` with the matrix personality quote above it
- [x] Bug-class regression tests added:
  - `TestWireShape` (carried from 0.20.1) — params shape on a2ui.apply
  - `test_tabs_uses_parallel_arrays` — pins the Tabs shape that the renderer expects
  - `test_badge_uses_text_field_not_label` — guards the Badge regression
  - `test_stage_mapping_matches_show_version` — keeps CLI banner and inspector header reading the same stage thresholds

**Test Configuration**:
- Python: 3.10–3.13 (CI matrix)
- car-runtime: 0.17.0 (live tested against running daemon + CarHost.app)
- Renderer: `apps/car-a2ui-renderer` v0.9

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Wire-format note: surfaces created by 0.20.0/0.20.1 had broken Tabs and empty Badges. On reconnect, `ensure_surface` re-emits `updateComponents` with the corrected shapes — they heal without manual intervention.