### PR TITLE
chore: align car-runtime version refs to 0.18.0 floor and cap major

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@
   - `prune_stale_facts` → `demote_unhelpful_facts` → `purge_dead_facts` run on every
     cold start (`store.py:190-192`). For on-demand compaction of tombstone bloat in a
     specific project's fact file, use `neo memory prune [--all] [--dry-run]`
-    (`subcommands.py:_compact_fact_file`).
+    (`neo/subcommands.py:_compact_fact_file` — at the package root, not
+    under `memory/`).
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the
@@ -92,7 +93,7 @@
   that runs `synthesize_reviews` on a wall-clock cadence, decoupled from the
   request path. *Additive* — the inline triple-trigger gate keeps firing too;
   the observer just makes synthesis more frequent. **Hard dep**: car-runtime
-  ≥ 0.17.0 and a running `car-server` daemon — CAR's supervisor owns the
+  ≥ 0.18.0 and a running `car-server` daemon — CAR's supervisor owns the
   spawn / restart-on-failure / log redirection / clean SIGTERM shutdown.
   Spec persisted to `~/.car/agents.json` (`auto_start: true` so it comes back
   on daemon boot); logs land at `~/.car/logs/neo-observer-<id8>.{stdout,stderr}.log`.

--- a/docs/solutions/async-observer.md
+++ b/docs/solutions/async-observer.md
@@ -7,7 +7,8 @@ after ECC's `continuous-learning-v2` observer
 > **As-built note (post-v0.19):** the first cut of this proposal rolled its own
 > daemon (`subprocess.Popen` + PID file + SIGUSR1 kick + idle-exit). That
 > implementation was replaced before any release with a port to CAR's
-> `agents_*` lifecycle API (car-runtime ≥ 0.16.1). The motivation, ECC
+> `agents_*` lifecycle API (the API landed in car-runtime 0.16.1; the
+> hard dep is ≥ 0.18.0 — see car-releases#54). The motivation, ECC
 > reference points, and design rationale below remain accurate; the
 > "Process model" section's plumbing is **superseded** — CAR's supervisor
 > owns spawn, restart-on-failure, log redirection, and clean shutdown.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,13 @@ ollama = ["requests>=2.31.0"]
 # for `CarAdapter`-only use, but `neo memory observer start` will
 # reject them with an actionable error.
 car = [
-    "car-runtime>=0.18.0",
+    # Upper-capped at the next major so `keep current` (a plain
+    # `pipx upgrade`) tracks latest within a compatible major rather
+    # than silently adopting a breaking rewrite of this sealed binary.
+    # NB: car-runtime is pre-1.0, so 0.x minor bumps can still carry
+    # breaking changes (see history above) — validate the observer
+    # after upgrading across a minor.
+    "car-runtime>=0.18.0,<1.0",
     # JSON-RPC-over-WebSocket client for the A2UI surface
     # (`neo.a2ui`). The Python `car_runtime.a2ui_*` helpers are
     # in-process only; reaching the daemon's a2ui store — which is

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -11,8 +11,10 @@ agent supervisor:
     redirection to ``~/.car/logs/<id>.{stdout,stderr}.log``, and auto-
     start at daemon boot when ``auto_start=True``.
 
-Hard dependency on ``car-runtime>=0.16.1`` (when the ``agents_*``
-lifecycle API landed). The car-server daemon must be running; the
+Hard dependency on ``car-runtime>=0.18.0`` (the ``agents_*`` lifecycle
+API landed in 0.16.1, but earlier bindings grab the supervisor manifest
+lock in-process and collide with a running car-server — see
+Parslee-ai/car-releases#54). The car-server daemon must be running; the
 CAR bindings will auto-spawn it via ``CAR_AUTOSTART`` if reachable
 on the default ``ws://127.0.0.1:9100``.
 
@@ -51,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 
 _CAR_REQUIRED_MSG = (
-    "Observer requires car-runtime >= 0.17.0 (where the agents_* "
+    "Observer requires car-runtime >= 0.18.0 (where the agents_* "
     "calls route to the running car-server daemon instead of "
     "colliding with its supervisor lock — see Parslee-ai/car-releases#54). "
     "Install: `pip install neo[car]`, then ensure car-server is running "


### PR DESCRIPTION
## Description

Aligns drifted `car-runtime` version references to the canonical `0.18.0` floor and adds an upper cap so the `[car]` extra tracks latest within a compatible major. Also fixes a misleading file path in the project CLAUDE.md. Documentation + dependency-constraint only — no logic changed.

The observer's car-runtime gate is capability-based (`hasattr(car_runtime, "agents_upsert")`), so the version numbers in docstrings and the `_CAR_REQUIRED_MSG` were documentation that had drifted to `0.16.1` / `0.17.0`, below the `pyproject` floor of `0.18.0`.

## Type of Change

- [x] Documentation update
- [x] Code cleanup/refactoring

## Related Issue

N/A — surfaced during a local install health check.

## Motivation and Context

- `observer.py` reported `requires car-runtime >= 0.17.0` while `pyproject` pins `>=0.18.0` — a misleading error string.
- The project CLAUDE.md referenced `subcommands.py` ambiguously; the file lives at `src/neo/subcommands.py`, not under `memory/` like the sibling `store.py`/`outcomes.py` references in the same section.
- With the install now declaratively carrying the `[car]` extra, `car-runtime>=0.18.0` is load-bearing for `pipx upgrade`; an upper cap prevents silently adopting a breaking major of the sealed binary.

## Changes

- `observer.py`: docstring + `_CAR_REQUIRED_MSG` now state `>=0.18.0`
- `CLAUDE.md`: observer hard-dep note `0.17.0` → `0.18.0`; disambiguate the `subcommands.py` path
- `docs/solutions/async-observer.md`: clarify the `agents_*` API landed in `0.16.1` but the hard dep is `0.18.0`
- `pyproject.toml`: cap `[car]` `car-runtime` at `<1.0`

## How Has This Been Tested?

- [x] Full pre-commit suite (ruff + pytest): **950 passed, 3 skipped**
- [x] `tomllib` parse of `pyproject.toml` confirms valid

**Test Configuration**:
- Python version: 3.14.4
- OS: macOS (Darwin)
- Neo version: 0.20.3

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Reviewed by the @neo and @linus agents, which caught a fourth stale `0.16.1` reference (in `docs/solutions/async-observer.md`) beyond the initially-identified two files.