### PR TITLE
feat: learn from Claude Code transcripts (observer transcript ingestion)

### DIFF
--- a/docs/solutions/transcript-ingestion.md
+++ b/docs/solutions/transcript-ingestion.md
@@ -215,14 +215,15 @@ separate cycle ONLY if the tick is measured to stall WS responsiveness.
 **Critical bound (added in review):** an episode *count* budget does not bound
 *time* — with up to ~32 serial LM calls and a 600s adapter timeout, a hung
 provider could park the executor thread and stonewall SIGTERM (the supervisor only
-re-checks `_stop` between executor calls). So ingest is bounded by BOTH
-`NEO_OBSERVER_INGEST_BUDGET` (episodes, default 8) AND
-`NEO_OBSERVER_INGEST_DEADLINE` (wall-clock, default 120s), plus a `should_stop`
-check that honors SIGTERM. These stop *dispatching new* episodes; an in-flight
-call still runs to its own timeout, so worst case collapses from N×timeout to ~1.
-The backlog drains on the next cycle via the watermark. Ingest is isolated in its
-own try/except (runs after synthesis is durable) and surfaces failures in the cycle
-record, not just stderr.
+re-checks `_stop` between executor calls). So ingest is bounded by BOTH a
+per-cycle episode budget (8) AND a wall-clock deadline (120s), plus a
+`should_stop` check that honors SIGTERM. These are **committed constants, not
+env toggles** — the feature is always on, no runtime flag to enable/disable it.
+The bounds stop *dispatching new* episodes; an in-flight call still runs to its
+own timeout, so worst case collapses from N×timeout to ~1. The backlog drains on
+the next cycle via the watermark. Ingest is isolated in its own try/except (runs
+after synthesis is durable) and surfaces failures in the cycle record, not just
+stderr.
 
 ### Watermark — atomic-after-write, per-episode (corrected from v1)
 

--- a/docs/solutions/transcript-ingestion.md
+++ b/docs/solutions/transcript-ingestion.md
@@ -208,10 +208,21 @@ Concern: `_cycle`'s synthesis already runs in a blocking `run_in_executor` to ke
 the WS loop draining; adding LM extract+verify could lengthen the tick and move LM
 calls (timeouts/rate limits) into the supervised path that does zero today. But
 *pre-building* a second supervised lifecycle for an unmeasured cost is
-over-engineering. Revised plan: run ingest **inside the existing `_cycle`, behind
-the existing executor, with a hard per-cycle episode budget** (e.g. N episodes per
-pass), and emit the tick duration. Split into a separate cycle ONLY if the tick is
-measured to stall WS responsiveness. Start simple; measure; split if proven.
+over-engineering. As built: ingest runs **inside the existing `_cycle`, after
+synthesis, behind the existing executor**, with tick-duration logging. Split into a
+separate cycle ONLY if the tick is measured to stall WS responsiveness.
+
+**Critical bound (added in review):** an episode *count* budget does not bound
+*time* — with up to ~32 serial LM calls and a 600s adapter timeout, a hung
+provider could park the executor thread and stonewall SIGTERM (the supervisor only
+re-checks `_stop` between executor calls). So ingest is bounded by BOTH
+`NEO_OBSERVER_INGEST_BUDGET` (episodes, default 8) AND
+`NEO_OBSERVER_INGEST_DEADLINE` (wall-clock, default 120s), plus a `should_stop`
+check that honors SIGTERM. These stop *dispatching new* episodes; an in-flight
+call still runs to its own timeout, so worst case collapses from N×timeout to ~1.
+The backlog drains on the next cycle via the watermark. Ingest is isolated in its
+own try/except (runs after synthesis is durable) and surfaces failures in the cycle
+record, not just stderr.
 
 ### Watermark — atomic-after-write, per-episode (corrected from v1)
 
@@ -260,6 +271,24 @@ Emit `transcript_ingest` events (`spans_found`, `facts_extracted`,
 high-quality, deduped, retrievable PATTERN/FAILURE lessons that get surfaced and
 earn ACCEPTED outcomes — not raw fact count. (Synthesis-clustering is explicitly
 no longer the success metric; Phase 0 retired it.)
+
+## Phase 1 validation results (2026-06-13)
+
+End-to-end on 25 real substantive episodes via gpt-5.5, isolated store:
+
+- **Enrichment:** 41 lessons admitted → 40 valid (1 collapsed by the existing
+  0.85 supersession). Kinds: 27 pattern / 13 failure. Domains populated and
+  queryable (debugging, workflow, testing, architecture, file-patterns, …).
+- **Idempotency:** re-run reported 0 new / 0 processed / 0 LM calls — the
+  per-episode watermark works.
+- **No flood:** 40 ≪ the 500 project cap.
+- **Quality (sampled):** genuinely transferable lessons ("verify behavior, not
+  installs", "pipx injected deps don't auto-upgrade", "pause a background writer
+  before editing its store", "read before editing"). High signal.
+- **Confidence:** max 0.65 — one fact lifted above the 0.6 birth-cap by
+  supersession carry-forward (corroboration); benign and expected.
+
+Gate passed → cleared to wire into the live observer.
 
 ## Risks
 

--- a/docs/solutions/transcript-ingestion.md
+++ b/docs/solutions/transcript-ingestion.md
@@ -1,0 +1,299 @@
+# Transcript & journal ingestion — feeding synthesis from AI-tool artifacts
+
+**Status:** proposal v3 (2026-06-13). Phase 0 spike complete (results below).
+v1 → v2 corrected integration claims after @neo + @linus review; Phase 0 then
+**retired the clustering approach** and v3 pivots the Design to direct ingestion
+of verified lessons as PATTERN/FAILURE facts + cosine semantic dedup. This is the
+architecture being implemented.
+
+## Problem
+
+neo's synthesis engine is starved, not broken. On a real project with 92 valid
+REVIEW facts, `synthesize_reviews` produces **0 patterns** every cycle: the
+reviews are too diverse to form the ≥3-member clusters at cosine ≥
+`SYNTHESIS_SIMILARITY` (0.85) that synthesis requires (max pairwise similarity
+0.90; only 5 pairs ≥ 0.85). Tuning cadence or lowering the threshold
+manufactures junk. The engine has nothing dense to chew on.
+
+Root cause is the **ingestion model**, which assumes git is the record of work.
+It no longer is. neo's five sources are seeds, community feed, CLAUDE.md
+constraints, curated Claude memory `*.md`, and git history (last 50 commits — the
+crystallized result, reasoning stripped), plus REVIEWs from neo's own
+suggestion→git-diff outcomes (only when neo itself is invoked).
+
+Meanwhile ~847 MB of Claude Code transcripts across 191 projects (111 MB for one
+repo) and 492 CAR journals sit ignored — every failed attempt, every user
+correction, every recurring friction pattern, the reasoning behind each commit.
+That signal recurs across sessions where polished git commits don't, so it is the
+material synthesis exists to cluster. This is consistent with the project's own
+*Beyond Conversation* and *Memgine* work: the behavioral stream, not the final
+artifact, is the substrate for learning.
+
+## Goal & constraint
+
+Turn the AI-tool artifact firehose into high-quality, clusterable REVIEW/FAILURE
+facts so synthesis fires on real, recurring signal.
+
+**Quality is the constraint, not cost.** The design centers LM extraction and an
+LM verification gate and does not minimize inference. But "quality" must be a
+*measured number we regress against*, not a gate we trust — see Phase 0.
+
+---
+
+## Phase 0 — validate the clustering premise FIRST (gating, ~half a day)
+
+This is existential and must run before any `TranscriptIngester` is written.
+The whole proposal rests on one unproven claim: *transcript-extracted lessons
+recur, therefore they cluster (≥3 members, complete-linkage, cosine ≥ 0.85).*
+There is a paradox to resolve, raised in review:
+
+> If lessons are similar enough to cluster at 0.85, they are near-duplicates that
+> dedup should collapse (→ clusters of ~1 → synthesis still fires 0). If they are
+> diverse enough to survive dedup, they don't cluster (→ synthesis still fires 0).
+
+Phase 0 resolves this empirically against the 4 real transcript files already on
+this machine (`~/.claude/projects/-Users-mliotta-git-neo/*.jsonl`, ~112 MB):
+
+1. Hand-label correction / error-recovery / lesson spans in those 4 files →
+   ground-truth set.
+2. Run a throwaway Stage A + Stage B over them.
+3. Run the **actual** pre-write dedup (`_exact_canonical_match`, which is exact
+   canonical-signature, NOT cosine — see Correction D below) over the output.
+4. Add a `transcript` synthesis group key and run `synthesize_reviews`'
+   complete-linkage clustering (all-pairs ≥ 0.85, strict) over the deduped facts.
+5. Plot the pairwise-similarity histogram and count ≥3-member complete-linkage
+   clusters **after dedup**.
+
+**Kill criterion:** if no ≥3-member clusters form after dedup, the one success
+criterion ("synthesis produces PATTERNs, currently 0") is unmet and the design is
+theater — stop here. **Quality contract:** Stage A must hit a high recall target
+and Stage B + verify a high precision target against the labeled set, in the
+spirit of the project's existing 95.8% decision-accuracy contract. No
+`TranscriptIngester` ships until Phase 0 passes.
+
+### Phase 0 RESULTS (2026-06-13) — ran against the 4 real transcript files
+
+Faithful spike: schema-correct Stage A → gpt-5.5 extraction → neo's exact
+`_canonical_signature` dedup → Jina Code v2 embeddings → complete-linkage @ 0.85.
+
+- **Stage A:** 119 episodes (108 substantive), anchored on the 119 real human
+  messages (of 1,953 `user` records — confirming the 94%-tool-output schema).
+- **Stage B:** **269 high-quality, generalizable lessons** from 108 episodes,
+  0 extraction errors. Eyeballed sample is genuinely good ("verify behavior, not
+  installation", "don't overclaim test coverage", "gate merges on CI") — many are
+  real lessons from actual sessions. **Extraction is the strong part.**
+- **Dedup:** the spike's first measurement ran only `_exact_canonical_match`
+  (exact-signature) → 269 → **269** (no-op on paraphrases). But `add_fact` runs a
+  *second* dedup the spike skipped: `_find_supersession_candidate` (cosine > 0.85,
+  same kind+scope). Re-measured through the **real full `add_fact` path** admitting
+  all 269 as PATTERN/project: **269 → 256 valid** (13 superseded); the
+  "filter routine events" cluster collapsed 6 → 4. So cosine dedup **already
+  exists** via supersession — it does meaningful (not total) collapse, and the
+  residual paraphrase redundancy is left to probation decay. **A parallel
+  `DEDUP_SIMILARITY` path is rejected** (it would conflict with the 0.85
+  supersession already in the path).
+- **Clustering:** only 24 of 36,046 pairs ≥ 0.85 (0.067%). **2 clusters ≥3
+  members** — but BOTH are the same paraphrase-duplicate lesson (the 6 "filter
+  routine events" copies). Genuinely diverse lessons do **not** cluster.
+
+**Verdict: the kill criterion mechanically passes (2 clusters) but qualitatively
+FAILS.** The only clusters are dedup-failure artifacts of one repeated lesson,
+not synthesis of diverse evidence. This empirically confirms the paradox: diverse
+lessons don't cluster; the things that cluster are near-duplicates dedup should
+have collapsed. **The "extract → cluster at 0.85 → PATTERN" mechanism is the wrong
+tool.**
+
+**Redirect (what the spike actually proved):**
+1. **Drop clustering-into-PATTERNs as the goal.** It provably doesn't fire on
+   diverse lessons and only produces redundant artifacts.
+2. **The real win is direct ingestion of extracted lessons as retrievable facts.**
+   269 high-quality lessons from 4 files is a massive enrichment of a store that
+   currently has ~130 facts. neo's retrieval (hybrid dense+BM25, rank_score)
+   surfaces them when relevant — no synthesis needed.
+3. **Now-critical problems** (re-scoped from the original plan): (a) **semantic
+   dedup** — exact-canonical is useless here; need cosine-based collapse so the
+   "6 copies" become 1; (b) **verify-at-admission + caps** to keep the firehose
+   from flooding; (c) if PATTERN-level compression is still wanted, use **LM
+   thematic grouping/summarization**, not embedding-clustering at 0.85.
+
+---
+
+## Design (build only if Phase 0 passes)
+
+### New source #6 — `TranscriptIngester`
+
+**Schema-correct Stage A (structural, no LM, recall-oriented).** v1 modeled
+transcripts as "user messages"; empirically ~92% of `user`-role records are
+`tool_result` envelopes, not human prompts (11 real prompts of 146 user-role
+records in one file). There are ~10 `type` values (`user`, `assistant`,
+`attachment`, `system`, `permission-mode`, `file-history-snapshot`, `ai-title`,
+`last-prompt`, `queue-operation`, `pr-link`, plus typeless `summary`/`leafUuid`
+records), multiple interleaved `sessionId`s, and `isSidechain` threads. Stage A
+must therefore:
+
+- filter to `type ∈ {user, assistant}`;
+- partition by `sessionId`; order by file position (verified: human anchors are
+  monotonic in file order, only intra-episode tool/assistant records jitter
+  sub-second, so `parentUuid` threading and timestamp sorting buy nothing here —
+  documented invariant in the module);
+- skip `isSidechain` records (the real meta field; `isMeta` does not occur);
+- distinguish *human* text from tool output by content-block structure
+  (`content[].type == 'text'`, not `tool_result`) AND reject synthetic CLI/control
+  strings (leading `<…>` envelopes, interrupt marker) — the latter contaminated
+  ~31% of opened episodes until filtered;
+- open an episode on each genuine human message and fold the following assistant
+  text, tool uses, and tool errors into it.
+
+**Stage B (LM extraction, quality-first).** Per episode/span, the configured
+model (provider stays `openai`/gpt-5.5 — honoring the no-Anthropic-for-our-install
+directive) extracts already-generalized lessons
+`{kind: PATTERN|FAILURE, subject, body, domain, confidence, evidence_span}`. The
+prompt demands transfer-to-future-task lessons, an evidence citation, and a
+self-rated confidence. Phase 0 confirmed this yields high-quality output (269
+lessons / 4 files, 0 errors).
+
+**Stage C — verify at admission, never at promotion (corrected from v1).** v1
+stored raw extractions immediately and gated only later promotion — which floods
+the project scope and evicts *real* facts to hold unverified noise. Fix: a single
+adversarial LM verify pass runs **before `add_fact`**; rejected extractions are
+dropped and never written. Two hard admission filters: (1) the `evidence_span`
+must be present AND found **verbatim** in the source transcript (provable
+evidence, not claimed); (2) the verifier must rate the lesson generalizable.
+Mirrors the existing rule "facts without evidence are dropped, not stored at low
+confidence." (A multi-judge panel is a future quality upgrade; v1 ships one strong
+skeptical judge and measures precision by sampled inspection.)
+
+### Admission as PATTERN/FAILURE — NO clustering (the Phase 0 pivot)
+
+The original "extract → cluster REVIEWs at 0.85 → PATTERN" path is **dropped** —
+Phase 0 proved diverse lessons don't cluster and the only clusters are
+paraphrase-dup artifacts. Instead:
+
+- Admit each verified lesson **directly as a `PATTERN`** (or `FAILURE` for
+  anti-patterns), already generalized by the LM. These are terminal, retrievable
+  facts — neo's hybrid retrieval (dense+BM25, `rank_score`) surfaces them on
+  relevance. No synthesis step is involved.
+- **Deliberately NOT kind `REVIEW`.** REVIEWs feed `synthesize_reviews`; admitting
+  269 transcript REVIEWs would inflate the REVIEW pool and regenerate exactly the
+  dup-cluster artifacts Phase 0 found. Keeping transcript lessons as PATTERN/
+  FAILURE keeps them out of that path entirely.
+- Tag `transcript-derived`, scope `project`, enter **probationary** so unhelpful
+  lessons decay out via the existing lifecycle. PATTERN/FAILURE do not bypass
+  decay (only CONSTRAINT/ARCHITECTURE/DECISION + seed/community/synthesized tags
+  do), so probation/demotion/purge apply normally.
+
+This removes all the net-new synthesis-path work v1 required (group keys, PATTERN
+promotion rule, net-new FAILURE *synthesis*) — there is no clustering to wire.
+`FAILURE` is just a `FactKind` we now *emit at admission*, not synthesize.
+
+### Identity & where it runs (corrected from v1)
+
+v1 called `_resolve_memory_dir().parent` "shared project resolution." It is not:
+that resolver keys on a **path** hash (`codebase_root.replace('/','-')`), while
+neo's fact `project_id` is `SHA256` of the normalized git remote (so clones/
+worktrees share an ID). These are different identity schemes — fine for this
+repo, but on a worktree/clone the path differs and source #6 would read the wrong
+(or no) transcript dir while writing facts under the remote-keyed project.
+Decision required and stated explicitly: resolve the transcript dir from the same
+`codebase_root` the observer already holds, accept that transcripts are located
+by path while facts are scoped by remote, and document the worktree behavior.
+
+Also decide explicitly: source #6 is **observer-only**, not run inside
+`FactStore.initialize()` (where sources #1–#5 live) — otherwise every neo
+invocation pays the transcript-scan cost. The observer owns this.
+
+### Observer loop — measure before splitting (revised per review)
+
+Concern: `_cycle`'s synthesis already runs in a blocking `run_in_executor` to keep
+the WS loop draining; adding LM extract+verify could lengthen the tick and move LM
+calls (timeouts/rate limits) into the supervised path that does zero today. But
+*pre-building* a second supervised lifecycle for an unmeasured cost is
+over-engineering. Revised plan: run ingest **inside the existing `_cycle`, behind
+the existing executor, with a hard per-cycle episode budget** (e.g. N episodes per
+pass), and emit the tick duration. Split into a separate cycle ONLY if the tick is
+measured to stall WS responsiveness. Start simple; measure; split if proven.
+
+### Watermark — atomic-after-write, per-episode (corrected from v1)
+
+The real risk is not file rewrite (transcripts are append-only) but the watermark
+advancing before facts are durably written across `_cycle`'s swallowed
+exceptions — and transcripts watermarked by uuid are **not** replayable like git.
+Fix: advance the watermark only after an episode's facts are durably written, and
+key it on `(sessionId, last_uuid)`. The data supports this cleanly: **100% of
+`user`/`assistant` records carry `uuid` + `sessionId` + `timestamp`** (measured
+over 5,235 records), and episodes are built *only* from those records — so every
+episode has a well-defined anchor. The typeless records that lack a uuid
+(`ai-title`, `last-prompt`, …) are exactly the types Stage A filters out, so they
+never anchor an episode and cause no data loss. This is a **net-new** watermark
+store (per-session, by last-consumed message uuid), not a reuse of the git or
+synthesis watermark.
+
+## Quality controls
+
+- **Measured contract (Phase 0)** — recall on Stage A, precision on Stage B +
+  verify, regressed against the labeled set. The non-negotiable line of defense.
+- **Adversarial verify at admission** — drop on reject, never store unverified.
+- **Evidence requirement** — every fact cites its source span or is dropped.
+- **Dedup: reuse the existing supersession, do NOT fork it.** `add_fact` already
+  runs `_find_supersession_candidate` (cosine > 0.85, same kind+scope) and was
+  measured to collapse the 269 real lessons → 256 valid. No parallel
+  `DEDUP_SIMILARITY` path. If we later want *bump-instead-of-supersede* semantics
+  (keep one, bump access, avoid tombstones), extend the **one** existing
+  `_supersede`/`add_fact` path — not a second cosine function with a second
+  threshold.
+- **Verbatim evidence check** (added per review) — at admission, reject any lesson
+  whose `evidence_span` is not found **verbatim** in the source transcript. This
+  converts "the LM says it has evidence" into "evidence provably exists" — the
+  cheapest large precision gain against hallucination.
+- **Probation + lifecycle + caps** — admitted facts ride the existing
+  probation → demotion → purge path. Project cap is **`SCOPE_LIMITS[project]=500`**
+  (200 is the *global* cap). Risk: fresh transcript PATTERNs have `success_count=0`
+  / mid confidence, so they sit at the bottom of `_enforce_scope_limit`'s eviction
+  order and could evict other unproven facts. The end-to-end task MUST project
+  facts-per-project and confirm transcript lessons don't evict real REVIEWs; if a
+  busy project approaches 500, add a transcript-derived sub-cap.
+
+## Observability
+
+Emit `transcript_ingest` events (`spans_found`, `facts_extracted`,
+`facts_after_verify`, `facts_after_dedup`). Success = the store is enriched with
+high-quality, deduped, retrievable PATTERN/FAILURE lessons that get surfaced and
+earn ACCEPTED outcomes — not raw fact count. (Synthesis-clustering is explicitly
+no longer the success metric; Phase 0 retired it.)
+
+## Risks
+
+- **Confident-hallucinated lessons** — dominant risk; mitigated by verify-at-
+  admission + evidence requirement + probation decay. Precision measured against a
+  sampled inspection in the end-to-end task.
+- **Semantic-dedup mis-tuning** — too-low threshold merges distinct lessons;
+  too-high lets paraphrase-dups through. Tunable, validated on real extractions.
+- **Stage A schema drift** — Claude Code transcript format evolves; pin to a
+  parser tested against real files and fail closed on unknown shapes.
+- **Identity/scope leakage** — current-project-only; worktree behavior documented.
+
+## Phased rollout
+
+- **Phase 0:** clustering-premise spike (gating). ✅ DONE — retired the clustering
+  approach, validated extraction, redirected to direct-ingest (see results above).
+- **Phase 1 (this build):** this-repo transcripts; schema-correct Stage A; LM
+  extract; verify-at-admission; **direct admission as PATTERN/FAILURE** (no
+  clustering); cosine semantic dedup; per-message watermark; separate observer
+  ingest cycle; metrics; end-to-end validation.
+- **Phase 2:** CAR journal ingestion.
+- **Phase 3:** org-scoped cross-project, explicit opt-in.
+
+## Honest reuse vs net-new map
+
+Genuinely reused: fact model/kinds (`memory.models`), probation/lifecycle/caps
+(`memory.store`), embeddings + `batched_cosine`, retrieval (`rank_score`,
+hybrid dense+BM25), observer cadence/supervision (CAR), LM adapter, redaction
+(`lm_logger`).
+
+**Net-new (do not call these reuse):** schema-correct transcript parser + episode
+builder; LM extraction + adversarial verify-at-admission stage; cosine
+semantic-dedup-on-admission (existing dedup is exact-canonical, a no-op here);
+per-message watermark store (atomic-after-write); separate observer ingest cycle;
+transcript-dir resolution from `codebase_root` (path-hash) decoupled from the
+remote-hash fact `project_id`. NB: the synthesis-clustering path is **not** touched
+— the pivot removed all net-new synthesis work.

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -136,6 +136,14 @@ class ObserverConfig:
 
     interval_seconds: float = 300.0
     cooldown_seconds: float = 60.0
+    # Max transcript episodes mined per cycle. Bounds LM calls; the backlog
+    # drains across cycles. 0 disables transcript ingestion.
+    ingest_budget: int = 8
+    # Wall-clock cap on the mining pass. Stops dispatching new episodes past
+    # this (an in-flight LM call still runs to its own timeout) so a hung
+    # provider can't park the cycle and stonewall SIGTERM. Kept well under the
+    # interval so a slow pass doesn't swallow the wake cadence.
+    ingest_deadline_seconds: float = 120.0
 
     @classmethod
     def from_env(cls) -> "ObserverConfig":
@@ -149,9 +157,21 @@ class ObserverConfig:
             except ValueError:
                 return default
 
+        def _read_int(name: str, default: int) -> int:
+            raw = os.getenv(name, "").strip()
+            if not raw:
+                return default
+            try:
+                v = int(raw)
+                return v if v >= 0 else default
+            except ValueError:
+                return default
+
         return cls(
             interval_seconds=_read("NEO_OBSERVER_INTERVAL_SECONDS", 300.0),
             cooldown_seconds=_read("NEO_OBSERVER_COOLDOWN", 60.0),
+            ingest_budget=_read_int("NEO_OBSERVER_INGEST_BUDGET", 8),
+            ingest_deadline_seconds=_read("NEO_OBSERVER_INGEST_DEADLINE", 120.0),
         )
 
 
@@ -183,6 +203,9 @@ class Observer:
         # Latest FactStore snapshot — used to update the A2UI Memory tab
         # without paying a second load.
         self._last_store_snapshot: Optional[dict] = None
+        # Name of the last transcript-ingest exception (or None), surfaced in
+        # the cycle record so a failing LM key isn't invisible.
+        self._last_ingest_error: Optional[str] = None
         # Surface manager (async). Created in run() since it needs an
         # event loop.
         self._surface = None
@@ -257,9 +280,20 @@ class Observer:
             # import cost.
             from neo.memory.store import FactStore
 
+            t0 = time.time()
             store = FactStore(codebase_root=self.codebase_root, eager_init=False)
             store.initialize()
             count = store.synthesize_reviews()
+            # Transcript mining MUST run AFTER synthesis: synthesis is then
+            # already durable, so an ingest/LM failure (isolated in its own
+            # guard) can never abort it. Both passes share this executor-run
+            # call (run_in_executor keeps the WS loop draining); tick is logged
+            # so we can tell if it stalls and needs splitting into a separate
+            # cycle. Do not reorder.
+            ingested = self._ingest_transcripts(store)
+            tick = time.time() - t0
+            mined = (f"{ingested} mined" if not self._last_ingest_error
+                     else f"ingest ERROR {self._last_ingest_error}")
             self._last_analysis_epoch = time.time()
             self._cycles_total += 1
             self._last_cycle_count = count
@@ -268,14 +302,14 @@ class Observer:
                 "timestamp": self._last_analysis_epoch,
                 "text": (
                     f"{time.strftime('%H:%M:%S', time.localtime(self._last_analysis_epoch))} · "
-                    f"{count} synthesized"
+                    f"{count} synthesized, {mined}"
                 ),
             })
             # Stash for the post-cycle Memory tab update. Keep the ref
             # around for ~1 cycle; FactStore is GC'd otherwise.
             self._last_store_snapshot = self._build_store_snapshot(store)
             print(
-                f"neo observer cycle ok: {count} synthesized facts",
+                f"neo observer cycle ok: {count} synthesized, {mined} ({tick:.1f}s)",
                 flush=True,
             )
         except Exception as e:
@@ -290,6 +324,44 @@ class Observer:
                 file=sys.stderr,
                 flush=True,
             )
+
+    def _ingest_transcripts(self, store) -> int:
+        """Mine Claude Code transcripts for lessons, bounded by the per-cycle
+        episode budget AND a wall-clock deadline. Isolated in its own
+        try/except so an LM or transcript failure never aborts the synthesis
+        cycle (which has already completed). Returns facts admitted; records a
+        failure marker in ``self._last_ingest_error`` so a silently-failing LM
+        key is visible in the cycle record, not just stderr.
+        """
+        self._last_ingest_error = None
+        if self.config.ingest_budget <= 0:
+            return 0
+        try:
+            from neo.adapters import create_adapter
+            from neo.config import NeoConfig
+            from neo.memory.transcript import TranscriptIngester
+
+            cfg = NeoConfig.load()
+            adapter = create_adapter(
+                cfg.provider, cfg.model, api_key=cfg.api_key, base_url=cfg.base_url
+            )
+            ingester = TranscriptIngester(
+                store=store, lm_adapter=adapter, codebase_root=self.codebase_root
+            )
+            stats = ingester.ingest(
+                max_episodes=self.config.ingest_budget,
+                max_seconds=self.config.ingest_deadline_seconds,
+                should_stop=lambda: self._stop,  # honor SIGTERM between episodes
+            )
+            return int(stats.get("facts_admitted", 0))
+        except Exception as e:
+            self._last_ingest_error = type(e).__name__
+            print(
+                f"neo observer transcript ingest error: {type(e).__name__}: {e}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 0
 
     def _build_store_snapshot(self, store) -> Optional[dict]:
         """Extract memory-tab + header-stage state from a FactStore.

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -136,13 +136,12 @@ class ObserverConfig:
 
     interval_seconds: float = 300.0
     cooldown_seconds: float = 60.0
-    # Max transcript episodes mined per cycle. Bounds LM calls; the backlog
-    # drains across cycles. 0 disables transcript ingestion.
+    # Committed safety bounds for the per-cycle transcript-mining pass — not
+    # runtime toggles. ``ingest_budget`` caps episodes per cycle (the backlog
+    # drains across cycles); ``ingest_deadline_seconds`` caps wall time so a
+    # hung provider can't park the cycle and stonewall SIGTERM. Kept well under
+    # the interval so a slow pass doesn't swallow the wake cadence.
     ingest_budget: int = 8
-    # Wall-clock cap on the mining pass. Stops dispatching new episodes past
-    # this (an in-flight LM call still runs to its own timeout) so a hung
-    # provider can't park the cycle and stonewall SIGTERM. Kept well under the
-    # interval so a slow pass doesn't swallow the wake cadence.
     ingest_deadline_seconds: float = 120.0
 
     @classmethod
@@ -157,21 +156,9 @@ class ObserverConfig:
             except ValueError:
                 return default
 
-        def _read_int(name: str, default: int) -> int:
-            raw = os.getenv(name, "").strip()
-            if not raw:
-                return default
-            try:
-                v = int(raw)
-                return v if v >= 0 else default
-            except ValueError:
-                return default
-
         return cls(
             interval_seconds=_read("NEO_OBSERVER_INTERVAL_SECONDS", 300.0),
             cooldown_seconds=_read("NEO_OBSERVER_COOLDOWN", 60.0),
-            ingest_budget=_read_int("NEO_OBSERVER_INGEST_BUDGET", 8),
-            ingest_deadline_seconds=_read("NEO_OBSERVER_INGEST_DEADLINE", 120.0),
         )
 
 

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -273,6 +273,7 @@ class FactStore:
         provenance: "str | Provenance" = Provenance.INFERRED,
         retrieval_text: Optional[str] = None,
         context_text: Optional[str] = None,
+        domain: str = "",
     ) -> Fact:
         """Add a new fact to the store.
 
@@ -326,6 +327,7 @@ class FactStore:
             depends_on=depends_on or [],
             retrieval_text=retrieval_text,
             context_text=context_text,
+            domain=domain or None,
         )
 
         # Pre-write dedup: filter -> canonicalize -> exact-match check.

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -1,0 +1,234 @@
+"""
+Claude Code transcript parsing for behavioral-signal ingestion.
+
+Reads Claude Code session transcripts
+(``~/.claude/projects/{codebase_root with / -> -}/*.jsonl``) and segments
+them into *episodes* — a human request plus the assistant work that
+followed — for downstream LM lesson extraction.
+
+This is the schema-correct Stage A: Claude Code transcripts interleave
+~10 record ``type`` values across multiple ``sessionId``s, and ~94% of
+``user``-role records are ``tool_result`` envelopes rather than human
+messages. We therefore parse defensively — filtering to ``user``/
+``assistant`` records, skipping sidechains and meta records, and
+distinguishing genuine human text from tool output by content-block
+structure. Only ``user``/``assistant`` records (which always carry
+``uuid``/``sessionId``/``timestamp``) anchor episodes, so every episode
+has a stable watermark key.
+
+Parsing only — no LM calls, no fact creation. Extraction and admission
+live in the ingester that consumes these episodes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+# Record types that carry a conversational message we care about. Everything
+# else (``ai-title``, ``last-prompt``, ``file-history-snapshot``,
+# ``permission-mode``, ``queue-operation``, ``summary``, ...) is skipped — those
+# are typeless/uuid-less metadata and never anchor an episode.
+_MESSAGE_TYPES = frozenset({"user", "assistant"})
+
+# Cap on the captured human ask, to bound stored size. Assistant/error text is
+# bounded by the downstream extractor, not here.
+_MAX_ASK_CHARS = 1500
+
+
+@dataclass
+class Episode:
+    """A human request plus the assistant activity that followed it.
+
+    ``session_id`` + ``last_uuid`` form the watermark key: an episode is
+    only marked consumed after its derived facts are durably written.
+    """
+
+    session_id: str
+    anchor_uuid: str          # uuid of the human message that opened the episode
+    last_uuid: str            # uuid of the last record folded into the episode
+    timestamp: str            # timestamp of the anchor message
+    ask: str                  # the human request text
+    assistant_text: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def is_substantive(self) -> bool:
+        """True if there is enough here to be worth an extraction call."""
+        return bool(self.ask) and bool(self.assistant_text or self.tools or self.errors)
+
+
+def resolve_transcript_dir(codebase_root: Optional[str]) -> Optional[Path]:
+    """Map a codebase root to its Claude Code transcript directory.
+
+    Claude Code derives the project directory by replacing ``/`` with ``-``
+    in the absolute path. NOTE: this is a *path* identity, distinct from
+    neo's git-remote-hash ``project_id``; transcripts are located by path
+    while the facts they produce are scoped by remote. On a worktree/clone
+    with a different absolute path, this resolves to that path's transcripts.
+    """
+    if not codebase_root:
+        return None
+    encoded = str(codebase_root).replace("/", "-")
+    return CLAUDE_PROJECTS_DIR / encoded
+
+
+def _is_synthetic(text: str) -> bool:
+    """True if a user-role string is tool/CLI plumbing, not human input.
+
+    Claude Code injects string-content ``user`` records that are not human
+    prose: XML-wrapped control/notification envelopes (``<command-name>``,
+    ``<local-command-stdout>``, ``<task-notification>``, ``<bash-input>``, …)
+    and the tool-use interrupt marker. Verified against real transcripts:
+    every such record begins with ``<`` or the interrupt marker, and zero
+    genuine human asks do — so an allowlist on the leading character is robust
+    and won't drift the way a denylist of envelope names would.
+    """
+    s = text.lstrip()
+    return s.startswith("<") or s.startswith("[Request interrupted")
+
+
+def _human_text(content: object) -> str:
+    """Extract genuine human-authored text from a user record's content.
+
+    A ``user`` record is human only when its content is a plain string or
+    contains ``text`` blocks. ``tool_result`` blocks are tool output wearing
+    the user role; synthetic CLI/control strings (see ``_is_synthetic``) also
+    wear the user role. Neither counts as human input.
+    """
+    if isinstance(content, str):
+        text = content.strip()
+    elif isinstance(content, list):
+        parts = [
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        text = "\n".join(p for p in parts if p).strip()
+    else:
+        return ""
+    return "" if _is_synthetic(text) else text
+
+
+def _assistant_parts(content: object) -> tuple[str, list[str]]:
+    """Return (assistant_text, tool_names) from an assistant record's content."""
+    if isinstance(content, str):
+        return content.strip(), []
+    text_parts, tools = [], []
+    if isinstance(content, list):
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "text":
+                text_parts.append(b.get("text", ""))
+            elif b.get("type") == "tool_use":
+                tools.append(b.get("name", "?"))
+    return "\n".join(p for p in text_parts if p).strip(), tools
+
+
+def _tool_errors(content: object) -> list[str]:
+    """Return error strings from tool_result blocks marked is_error."""
+    errs: list[str] = []
+    if isinstance(content, list):
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("is_error"):
+                c = b.get("content")
+                txt = c if isinstance(c, str) else json.dumps(c)
+                errs.append(txt[:300])
+    return errs
+
+
+def iter_records(path: Path) -> Iterator[dict]:
+    """Yield parsed JSON records from a transcript file, skipping bad lines."""
+    try:
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # fail closed on malformed lines
+    except OSError as e:
+        logger.warning("transcript: cannot read %s: %s", path, e)
+
+
+def build_episodes(path: Path) -> list[Episode]:
+    """Parse one transcript file into episodes (schema-correct Stage A).
+
+    Records are filtered to ``user``/``assistant``, sidechains and meta
+    records dropped, and partitioned by ``sessionId``. Within a session a
+    new episode opens on each genuine human message and absorbs the
+    following assistant text, tool uses, and tool errors until the next
+    human message.
+    """
+    # Group records by session, preserving file order. Invariant relied upon:
+    # human-message anchors are monotonic in file order; only intra-episode
+    # tool_result/assistant records jitter (sub-second), and those fold into the
+    # current episode regardless of relative order — so file order never
+    # reorders an anchor relative to its episode. (Confirmed across real files;
+    # timestamp sorting would buy nothing and risks breaking causal order.)
+    by_session: dict[str, list[dict]] = {}
+    for r in iter_records(path):
+        if r.get("type") not in _MESSAGE_TYPES:
+            continue
+        if r.get("isSidechain"):
+            continue
+        sid = r.get("sessionId")
+        uuid = r.get("uuid")
+        if not sid or not uuid:
+            continue  # cannot watermark a record without identity
+        by_session.setdefault(sid, []).append(r)
+
+    episodes: list[Episode] = []
+    for sid, recs in by_session.items():
+        cur: Optional[Episode] = None
+        for r in recs:
+            msg = r.get("message", {}) or {}
+            content = msg.get("content")
+            uuid = r["uuid"]
+            if r["type"] == "user":
+                human = _human_text(content)
+                if human:
+                    if cur:
+                        episodes.append(cur)
+                    cur = Episode(
+                        session_id=sid,
+                        anchor_uuid=uuid,
+                        last_uuid=uuid,
+                        timestamp=r.get("timestamp", ""),
+                        ask=human[:_MAX_ASK_CHARS],
+                    )
+                elif cur:
+                    # tool_result-only user record: fold any errors into the episode
+                    cur.errors += _tool_errors(content)
+                    cur.last_uuid = uuid
+            elif r["type"] == "assistant" and cur is not None:
+                text, tools = _assistant_parts(content)
+                if text:
+                    cur.assistant_text.append(text)
+                cur.tools += tools
+                cur.last_uuid = uuid
+        if cur:
+            episodes.append(cur)
+    return episodes
+
+
+def collect_episodes(codebase_root: Optional[str]) -> list[Episode]:
+    """Build episodes across all transcript files for a codebase root."""
+    tdir = resolve_transcript_dir(codebase_root)
+    if tdir is None or not tdir.is_dir():
+        return []
+    episodes: list[Episode] = []
+    for fp in sorted(tdir.glob("*.jsonl")):
+        episodes.extend(build_episodes(fp))
+    return episodes

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -28,7 +28,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterator, Optional
 
+from neo.memory.io_utils import atomic_write_json
 from neo.memory.models import FactKind, FactScope, Provenance
+from neo.memory.outcomes import SESSIONS_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -374,7 +376,11 @@ class TranscriptIngester:
         )
 
     def ingest_episode(self, ep: Episode) -> int:
-        """Full per-episode pipeline; returns number of facts admitted."""
+        """Full per-episode pipeline; returns number of facts admitted.
+
+        ``store.add_fact`` saves to disk on each call, so an episode's facts
+        are durably written before ``ingest`` advances the watermark.
+        """
         if not ep.is_substantive:
             return 0
         admitted = 0
@@ -383,6 +389,57 @@ class TranscriptIngester:
                 self.admit(lesson, ep)
                 admitted += 1
         return admitted
+
+    # -- incremental ingest with watermark -------------------------------
+    def ingest(self, episodes: Optional[list[Episode]] = None,
+               max_episodes: Optional[int] = None) -> dict:
+        """Ingest not-yet-consumed episodes, advancing the watermark per episode.
+
+        Idempotent: an episode's ``anchor_uuid`` is recorded as consumed only
+        *after* its facts are durably written, so a re-run skips it and a crash
+        mid-episode simply reprocesses it (dedup absorbs any partial). The
+        watermark is keyed by project, not by transcript path, so it survives
+        worktrees/clones that share the same git remote.
+        """
+        if episodes is None:
+            episodes = collect_episodes(self.codebase_root)
+        consumed = self._load_consumed()
+        new = [e for e in episodes if e.anchor_uuid not in consumed]
+        stats = {"episodes_total": len(episodes), "episodes_new": len(new),
+                 "episodes_processed": 0, "facts_admitted": 0}
+        for ep in new:
+            if max_episodes is not None and stats["episodes_processed"] >= max_episodes:
+                break
+            stats["facts_admitted"] += self.ingest_episode(ep)
+            consumed.add(ep.anchor_uuid)
+            self._persist_consumed(consumed)   # advance only after facts are durable
+            stats["episodes_processed"] += 1
+        return stats
+
+    def _watermark_path(self) -> Optional[Path]:
+        pid = getattr(self._store, "project_id", None)
+        if not pid:
+            return None
+        return SESSIONS_DIR / f"transcript_watermark_{pid}.json"
+
+    def _load_consumed(self) -> set:
+        path = self._watermark_path()
+        if not path or not path.exists():
+            return set()
+        try:
+            return set(json.loads(path.read_text(encoding="utf-8")).get("consumed", []))
+        except (OSError, json.JSONDecodeError):
+            return set()
+
+    def _persist_consumed(self, consumed: set) -> None:
+        path = self._watermark_path()
+        if not path:
+            return
+        try:
+            SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(path, {"consumed": sorted(consumed)})
+        except OSError as e:
+            logger.warning("transcript: failed to persist watermark: %s", e)
 
     def _lm_json(self, prompt: str) -> Optional[dict]:
         try:

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterator, Optional
 
+from neo.memory.models import FactKind, FactScope, Provenance
+
 logger = logging.getLogger(__name__)
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
@@ -232,3 +234,164 @@ def collect_episodes(codebase_root: Optional[str]) -> list[Episode]:
     for fp in sorted(tdir.glob("*.jsonl")):
         episodes.extend(build_episodes(fp))
     return episodes
+
+
+# ---------------------------------------------------------------------------
+# Stage B/C: LM lesson extraction + verify-at-admission
+# ---------------------------------------------------------------------------
+
+# Bound downstream token usage per episode (parser leaves these unbounded).
+_MAX_ASST_CHARS = 2500
+_MAX_ERR_CHARS = 800
+# Lessons are "1-2 sentences"; bound the body so a runaway extraction can't bloat
+# the store or the embedding.
+_MAX_BODY_CHARS = 600
+
+# Transcript lessons are a single LM assertion grounded in observed behavior;
+# cap their initial confidence so they never out-rank corroborated facts.
+_MAX_LESSON_CONFIDENCE = 0.6
+_TRANSCRIPT_TAG = "transcript-derived"
+
+_EXTRACT_PROMPT = """You are mining a coding-assistant transcript for GENERALIZABLE engineering lessons that would help on FUTURE tasks in this or other codebases.
+
+Given one episode (a user request + what the assistant did, including any tool errors), extract 0 to 3 transferable lessons. A good lesson is a reusable rule, pattern, gotcha, or correction — NOT a restatement of what happened, NOT project-trivia (file paths, line numbers, one-off values).
+
+Return STRICT JSON: {"lessons":[{"kind":"pattern|failure","subject":"<=8 words","body":"1-2 sentences, generalizable","domain":"testing|debugging|git|architecture|performance|workflow|code-style|security|file-patterns|other","confidence":0.0-1.0,"evidence_span":"a SHORT verbatim quote (<=120 chars) copied EXACTLY from the episode text below that justifies the lesson"}]}
+If there is no transferable lesson, return {"lessons":[]}.
+
+EPISODE:
+USER ASK: <<ASK>>
+ASSISTANT DID: <<ASST>>
+TOOLS USED: <<TOOLS>>
+ERRORS: <<ERRS>>
+"""
+
+_VERIFY_PROMPT = """You are a skeptical reviewer guarding a long-term memory store. Default to REJECT unless the lesson is clearly worth keeping.
+
+Reject if the lesson is: a restatement of one episode rather than a transferable rule; project-trivia; vague; obvious boilerplate; or not actually supported by the evidence quote.
+
+LESSON: <<SUBJECT>> — <<BODY>>
+EVIDENCE QUOTE: <<EVIDENCE>>
+
+Return STRICT JSON: {"keep": true|false, "reason": "<=15 words"}
+"""
+
+
+def _parse_json(text: str) -> Optional[dict]:
+    """Parse the first JSON object from an LM response, tolerantly.
+
+    Uses ``raw_decode`` from the first ``{``, which parses one complete object
+    and ignores any surrounding prose — including trailing text that itself
+    contains braces (where a first-brace/last-brace slice would fail). Fails
+    closed (returns ``None``) rather than risk bad data.
+    """
+    if not text:
+        return None
+    start = text.find("{")
+    if start == -1:
+        return None
+    try:
+        obj, _ = json.JSONDecoder().raw_decode(text, start)
+    except json.JSONDecodeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _normalize_ws(s: str) -> str:
+    return " ".join(s.split())
+
+
+class TranscriptIngester:
+    """Extract verified, generalizable lessons from transcript episodes and
+    admit them directly as PATTERN/FAILURE facts.
+
+    Stage B (extract) and Stage C (verify) both call the configured LM
+    adapter. Admission is gated by two hard filters: the verifier must keep
+    the lesson, and its ``evidence_span`` must appear verbatim in the source
+    episode (provable evidence, not claimed).
+    """
+
+    def __init__(self, store, lm_adapter, codebase_root: Optional[str] = None):
+        self._store = store
+        self._lm = lm_adapter
+        self.codebase_root = codebase_root or getattr(store, "codebase_root", None)
+
+    # -- Stage B ---------------------------------------------------------
+    def extract_lessons(self, ep: Episode) -> list[dict]:
+        prompt = (
+            _EXTRACT_PROMPT
+            .replace("<<ASK>>", ep.ask)
+            .replace("<<ASST>>", (" ".join(ep.assistant_text)[:_MAX_ASST_CHARS]) or "(no text)")
+            .replace("<<TOOLS>>", ", ".join(dict.fromkeys(ep.tools)) or "(none)")
+            .replace("<<ERRS>>", (" | ".join(ep.errors)[:_MAX_ERR_CHARS]) or "(none)")
+        )
+        data = self._lm_json(prompt)
+        if not data:
+            return []
+        return [L for L in data.get("lessons", []) if isinstance(L, dict) and L.get("body")]
+
+    # -- Stage C ---------------------------------------------------------
+    def verify(self, lesson: dict, ep: Episode) -> bool:
+        """Two hard gates: verbatim evidence present, then adversarial judge."""
+        span = _normalize_ws(str(lesson.get("evidence_span", "")))
+        if not span:
+            return False
+        # Include tool names: the extract prompt shows them, so a lesson may
+        # legitimately cite one as evidence.
+        haystack = _normalize_ws(" ".join([ep.ask, *ep.assistant_text, *ep.errors, *ep.tools]))
+        if span not in haystack:
+            return False  # hallucinated / non-verbatim evidence
+        prompt = (
+            _VERIFY_PROMPT
+            .replace("<<SUBJECT>>", str(lesson.get("subject", "")))
+            .replace("<<BODY>>", str(lesson.get("body", "")))
+            .replace("<<EVIDENCE>>", span)
+        )
+        data = self._lm_json(prompt)
+        return bool(data and data.get("keep") is True)
+
+    # -- admission -------------------------------------------------------
+    def admit(self, lesson: dict, ep: Episode):
+        kind = FactKind.FAILURE if lesson.get("kind") == "failure" else FactKind.PATTERN
+        try:
+            raw_conf = float(lesson.get("confidence", 0.5) or 0.5)
+        except (TypeError, ValueError):
+            raw_conf = 0.5  # non-numeric LM confidence ("high") -> conservative default
+        confidence = min(raw_conf, _MAX_LESSON_CONFIDENCE)
+        domain = lesson.get("domain") or ""
+        if domain == "other":
+            domain = ""
+        return self._store.add_fact(
+            subject=str(lesson.get("subject", ""))[:120],
+            body=str(lesson.get("body", ""))[:_MAX_BODY_CHARS],
+            kind=kind,
+            scope=FactScope.PROJECT,
+            confidence=confidence,
+            source_prompt=ep.ask[:200],
+            tags=[_TRANSCRIPT_TAG],
+            provenance=Provenance.INFERRED,  # LM generalization, no bonus over corroborated facts
+            domain=domain,  # first-class field so retrieve_relevant(domain=...) matches
+        )
+
+    def ingest_episode(self, ep: Episode) -> int:
+        """Full per-episode pipeline; returns number of facts admitted."""
+        if not ep.is_substantive:
+            return 0
+        admitted = 0
+        for lesson in self.extract_lessons(ep):
+            if self.verify(lesson, ep):
+                self.admit(lesson, ep)
+                admitted += 1
+        return admitted
+
+    def _lm_json(self, prompt: str) -> Optional[dict]:
+        try:
+            out = self._lm.generate(
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=1024,
+                temperature=0.2,
+            )
+        except Exception as e:
+            logger.warning("transcript: LM call failed: %s", e)
+            return None
+        return _parse_json(out)

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -24,11 +24,13 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 from neo.memory.io_utils import atomic_write_json
+from neo.memory.metrics import record as metrics_record
 from neo.memory.models import FactKind, FactScope, Provenance
 from neo.memory.outcomes import SESSIONS_DIR
 
@@ -392,7 +394,9 @@ class TranscriptIngester:
 
     # -- incremental ingest with watermark -------------------------------
     def ingest(self, episodes: Optional[list[Episode]] = None,
-               max_episodes: Optional[int] = None) -> dict:
+               max_episodes: Optional[int] = None,
+               max_seconds: Optional[float] = None,
+               should_stop: Optional[Callable[[], bool]] = None) -> dict:
         """Ingest not-yet-consumed episodes, advancing the watermark per episode.
 
         Idempotent: an episode's ``anchor_uuid`` is recorded as consumed only
@@ -400,6 +404,13 @@ class TranscriptIngester:
         mid-episode simply reprocesses it (dedup absorbs any partial). The
         watermark is keyed by project, not by transcript path, so it survives
         worktrees/clones that share the same git remote.
+
+        ``max_episodes`` caps episode count; ``max_seconds`` caps wall time and
+        ``should_stop`` caps on an external signal (SIGTERM). Both bounds stop
+        *dispatching new* episodes — an LM call already in flight runs to its own
+        timeout — which collapses a hung pass from N×(call timeout) to ~1, and
+        keeps the supervised observer responsive to shutdown. The watermark
+        drains the remaining backlog on the next cycle.
         """
         if episodes is None:
             episodes = collect_episodes(self.codebase_root)
@@ -407,13 +418,20 @@ class TranscriptIngester:
         new = [e for e in episodes if e.anchor_uuid not in consumed]
         stats = {"episodes_total": len(episodes), "episodes_new": len(new),
                  "episodes_processed": 0, "facts_admitted": 0}
+        start = time.monotonic()
         for ep in new:
             if max_episodes is not None and stats["episodes_processed"] >= max_episodes:
+                break
+            if max_seconds is not None and (time.monotonic() - start) >= max_seconds:
+                break
+            if should_stop is not None and should_stop():
                 break
             stats["facts_admitted"] += self.ingest_episode(ep)
             consumed.add(ep.anchor_uuid)
             self._persist_consumed(consumed)   # advance only after facts are durable
             stats["episodes_processed"] += 1
+        if stats["episodes_processed"]:
+            metrics_record("transcript_ingest", **stats)
         return stats
 
     def _watermark_path(self) -> Optional[Path]:

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -94,28 +94,48 @@ class TestSpecBuilding:
 
 class TestObserverConfig:
     def test_defaults(self, monkeypatch):
-        for k in ("NEO_OBSERVER_INTERVAL_SECONDS", "NEO_OBSERVER_COOLDOWN"):
+        for k in ("NEO_OBSERVER_INTERVAL_SECONDS", "NEO_OBSERVER_COOLDOWN",
+                  "NEO_OBSERVER_INGEST_BUDGET"):
             monkeypatch.delenv(k, raising=False)
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 300.0
         assert cfg.cooldown_seconds == 60.0
+        assert cfg.ingest_budget == 8
 
     def test_env_overrides(self, monkeypatch):
         monkeypatch.setenv("NEO_OBSERVER_INTERVAL_SECONDS", "15")
         monkeypatch.setenv("NEO_OBSERVER_COOLDOWN", "3")
+        monkeypatch.setenv("NEO_OBSERVER_INGEST_BUDGET", "20")
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 15.0
         assert cfg.cooldown_seconds == 3.0
+        assert cfg.ingest_budget == 20
 
     def test_rejects_garbage(self, monkeypatch):
         monkeypatch.setenv("NEO_OBSERVER_INTERVAL_SECONDS", "junk")
         monkeypatch.setenv("NEO_OBSERVER_COOLDOWN", "-5")
+        monkeypatch.setenv("NEO_OBSERVER_INGEST_BUDGET", "-1")
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 300.0
         assert cfg.cooldown_seconds == 60.0
+        assert cfg.ingest_budget == 8
+
+    def test_ingest_budget_zero_disables(self):
+        from neo.memory.observer import Observer, ObserverConfig
+        obs = Observer(codebase_root="/tmp/x", config=ObserverConfig(ingest_budget=0))
+        # budget 0 -> no transcript work, no adapter built, returns 0
+        assert obs._ingest_transcripts(store=None) == 0
+
+    def test_ingest_transcripts_swallows_errors(self, monkeypatch):
+        # Force an error inside the ingest path; the cycle must not crash.
+        from neo.memory.observer import Observer, ObserverConfig
+        monkeypatch.setattr("neo.config.NeoConfig.load",
+                            staticmethod(lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))))
+        obs = Observer(codebase_root="/tmp/x", config=ObserverConfig(ingest_budget=5))
+        assert obs._ingest_transcripts(store=None) == 0
 
 
 class TestStartObserver:
@@ -269,8 +289,11 @@ class TestObserverCycleUnit:
     """Drive Observer._cycle directly — no daemon, no signals."""
 
     def test_cycle_calls_synthesize_reviews(self, fake_project_id, monkeypatch):
-        from neo.memory.observer import Observer
-        observer = Observer(codebase_root="/some/path")
+        from neo.memory.observer import Observer, ObserverConfig
+        # ingest_budget=0 so this isolates synthesis (otherwise the real ingest
+        # path runs and only passes because it swallows its own failure).
+        observer = Observer(codebase_root="/some/path",
+                            config=ObserverConfig(ingest_budget=0))
 
         call_count = {"n": 0}
 
@@ -292,8 +315,9 @@ class TestObserverCycleUnit:
         assert observer._last_analysis_epoch > 0
 
     def test_cycle_swallows_errors(self, fake_project_id, monkeypatch):
-        from neo.memory.observer import Observer
-        observer = Observer(codebase_root="/some/path")
+        from neo.memory.observer import Observer, ObserverConfig
+        observer = Observer(codebase_root="/some/path",
+                            config=ObserverConfig(ingest_budget=0))
 
         class _BrokenStore:
             def __init__(self, **kwargs):
@@ -301,6 +325,57 @@ class TestObserverCycleUnit:
 
         monkeypatch.setattr("neo.memory.store.FactStore", _BrokenStore)
         observer._cycle()  # must not raise
+
+    def test_cycle_ingests_and_records(self, fake_project_id, monkeypatch, tmp_path):
+        """Positive end-to-end: ingest runs inside _cycle and admits a fact."""
+        import neo.memory.transcript as tr
+        from neo.memory.observer import Observer, ObserverConfig
+
+        monkeypatch.setattr(tr, "SESSIONS_DIR", tmp_path / "sessions")
+        admitted = []
+
+        class _FakeStore:
+            project_id = "testproj"
+
+            def __init__(self, **kwargs):
+                pass
+
+            def initialize(self):
+                pass
+
+            def synthesize_reviews(self):
+                return 0
+
+            def add_fact(self, **kw):
+                admitted.append(kw)
+                return object()
+
+        class _Cfg:
+            provider, model, api_key, base_url = "openai", "m", "k", None
+
+        class _Adapter:
+            def generate(self, messages, **kw):
+                p = messages[0]["content"]
+                if '"lessons"' in p:
+                    return ('{"lessons":[{"kind":"pattern","subject":"s","body":"b",'
+                            '"domain":"testing","evidence_span":"hello world"}]}')
+                return '{"keep": true}'
+
+        ep = tr.Episode(session_id="s", anchor_uuid="u1", last_uuid="u1", timestamp="t",
+                        ask="why", assistant_text=["hello world"], tools=[])
+
+        monkeypatch.setattr("neo.memory.store.FactStore", _FakeStore)
+        monkeypatch.setattr("neo.config.NeoConfig.load", staticmethod(lambda *a, **k: _Cfg()))
+        monkeypatch.setattr("neo.adapters.create_adapter", lambda *a, **k: _Adapter())
+        monkeypatch.setattr(tr, "collect_episodes", lambda root: [ep])
+
+        observer = Observer(codebase_root="/p", config=ObserverConfig(ingest_budget=5))
+        observer._cycle()
+
+        assert len(admitted) == 1                       # a lesson was admitted
+        assert admitted[0]["domain"] == "testing"
+        assert observer._last_ingest_error is None
+        assert "1 mined" in observer._recent_cycles[-1]["text"]
 
 
 class TestCooldown:

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -94,39 +94,37 @@ class TestSpecBuilding:
 
 class TestObserverConfig:
     def test_defaults(self, monkeypatch):
-        for k in ("NEO_OBSERVER_INTERVAL_SECONDS", "NEO_OBSERVER_COOLDOWN",
-                  "NEO_OBSERVER_INGEST_BUDGET"):
+        for k in ("NEO_OBSERVER_INTERVAL_SECONDS", "NEO_OBSERVER_COOLDOWN"):
             monkeypatch.delenv(k, raising=False)
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 300.0
         assert cfg.cooldown_seconds == 60.0
+        # Ingest bounds are committed constants, not env-toggleable.
         assert cfg.ingest_budget == 8
+        assert cfg.ingest_deadline_seconds == 120.0
 
     def test_env_overrides(self, monkeypatch):
         monkeypatch.setenv("NEO_OBSERVER_INTERVAL_SECONDS", "15")
         monkeypatch.setenv("NEO_OBSERVER_COOLDOWN", "3")
-        monkeypatch.setenv("NEO_OBSERVER_INGEST_BUDGET", "20")
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 15.0
         assert cfg.cooldown_seconds == 3.0
-        assert cfg.ingest_budget == 20
 
     def test_rejects_garbage(self, monkeypatch):
         monkeypatch.setenv("NEO_OBSERVER_INTERVAL_SECONDS", "junk")
         monkeypatch.setenv("NEO_OBSERVER_COOLDOWN", "-5")
-        monkeypatch.setenv("NEO_OBSERVER_INGEST_BUDGET", "-1")
         from neo.memory.observer import ObserverConfig
         cfg = ObserverConfig.from_env()
         assert cfg.interval_seconds == 300.0
         assert cfg.cooldown_seconds == 60.0
-        assert cfg.ingest_budget == 8
 
-    def test_ingest_budget_zero_disables(self):
+    def test_zero_budget_is_defensive_noop(self):
+        # Not a feature toggle (budget is a committed constant) — just a guard
+        # so a 0 can't waste an adapter build.
         from neo.memory.observer import Observer, ObserverConfig
         obs = Observer(codebase_root="/tmp/x", config=ObserverConfig(ingest_budget=0))
-        # budget 0 -> no transcript work, no adapter built, returns 0
         assert obs._ingest_transcripts(store=None) == 0
 
     def test_ingest_transcripts_swallows_errors(self, monkeypatch):

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -277,3 +277,52 @@ def test_ingest_skips_nonsubstantive(temp_store):
     ep = Episode(session_id="s", anchor_uuid="u", last_uuid="u", timestamp="t", ask="just asking")
     assert ing.ingest_episode(ep) == 0
     assert ad.calls == []  # no LM calls for a non-substantive episode
+
+
+# --------------------------------------------------------------------------
+# Watermark / incremental ingest
+# --------------------------------------------------------------------------
+
+def _ep(uid, ask):
+    return Episode(session_id="s", anchor_uuid=uid, last_uuid=uid, timestamp="t",
+                   ask=ask, assistant_text=["the venv was missing pytest-asyncio"], tools=["Bash"])
+
+
+_LESSON = {"kind": "pattern", "subject": "verify env", "body": "Check the venv before the code.",
+           "domain": "testing", "evidence_span": "venv was missing pytest-asyncio"}
+
+
+def test_ingest_is_idempotent(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    eps = [_ep("e1", "ask one"), _ep("e2", "ask two")]
+
+    s1 = ing.ingest(episodes=eps)
+    assert s1["episodes_new"] == 2 and s1["episodes_processed"] == 2 and s1["facts_admitted"] == 2
+    calls_after_first = len(ad.calls)
+
+    s2 = ing.ingest(episodes=eps)  # re-run: everything already consumed
+    assert s2["episodes_new"] == 0 and s2["episodes_processed"] == 0
+    assert len(ad.calls) == calls_after_first  # zero new LM calls on re-run
+
+
+def test_ingest_budget_resumes(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    eps = [_ep(f"e{i}", f"ask {i}") for i in range(5)]
+
+    s1 = ing.ingest(episodes=eps, max_episodes=2)
+    assert s1["episodes_new"] == 5 and s1["episodes_processed"] == 2  # budget honored
+
+    s2 = ing.ingest(episodes=eps, max_episodes=10)  # resumes the rest
+    assert s2["episodes_new"] == 3 and s2["episodes_processed"] == 3
+
+
+def test_watermark_persisted(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    ing.ingest(episodes=[_ep("e1", "ask one")])
+    assert ing._load_consumed() == {"e1"}

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,8 +1,14 @@
-"""Tests for Claude Code transcript parsing (Stage A)."""
+"""Tests for Claude Code transcript parsing (Stage A) and ingestion (B/C)."""
 
 import json
 
+import pytest
+
+from neo.memory.models import FactKind
 from neo.memory.transcript import (
+    Episode,
+    TranscriptIngester,
+    _parse_json,
     build_episodes,
     collect_episodes,
     resolve_transcript_dir,
@@ -156,3 +162,118 @@ def test_malformed_lines_skipped(tmp_path):
 
 def test_collect_episodes_missing_dir():
     assert collect_episodes("/nonexistent/path/xyz") == []
+
+
+# --------------------------------------------------------------------------
+# Stage B/C: extraction + verify-at-admission
+# --------------------------------------------------------------------------
+
+class _StubAdapter:
+    """LM boundary stub: returns a canned extract payload, then verify verdicts."""
+
+    def __init__(self, lessons, keep=True):
+        self._lessons = {"lessons": lessons}
+        self._keep = keep
+        self.calls = []
+
+    def generate(self, messages, **kw):
+        prompt = messages[0]["content"]
+        self.calls.append(prompt)
+        if '"lessons"' in prompt:  # extraction prompt
+            return "preamble " + json.dumps(self._lessons) + " trailer"
+        return json.dumps({"keep": self._keep, "reason": "t"})  # verify prompt
+
+
+def _episode(ask="why did the test fail", asst="the venv was missing pytest-asyncio"):
+    return Episode(session_id="s1", anchor_uuid="u1", last_uuid="u2",
+                   timestamp="t", ask=ask, assistant_text=[asst], tools=["Bash"])
+
+
+def test_parse_json_tolerant():
+    assert _parse_json('{"keep": true}')["keep"] is True              # strict
+    assert _parse_json('preamble {"keep": true} trailer')["keep"] is True  # sliced
+    assert _parse_json('{"keep": true} note: see {x}')["keep"] is True     # brace in trailer
+    assert _parse_json("no json here") is None
+    assert _parse_json('[1, 2, 3]') is None                            # non-object
+    assert _parse_json("") is None
+
+
+def test_extract_lessons_parses_and_filters():
+    ad = _StubAdapter([
+        {"kind": "pattern", "subject": "verify env first", "body": "check the venv",
+         "evidence_span": "venv was missing"},
+        {"kind": "pattern", "subject": "no body", "body": ""},  # dropped
+    ])
+    ing = TranscriptIngester(store=None, lm_adapter=ad, codebase_root="/x")
+    lessons = ing.extract_lessons(_episode())
+    assert len(lessons) == 1 and lessons[0]["subject"] == "verify env first"
+
+
+def test_verify_rejects_non_verbatim_evidence():
+    ad = _StubAdapter([], keep=True)  # judge would keep, but evidence is bogus
+    ing = TranscriptIngester(store=None, lm_adapter=ad, codebase_root="/x")
+    lesson = {"subject": "x", "body": "y", "evidence_span": "this phrase is not in the episode"}
+    assert ing.verify(lesson, _episode()) is False
+    assert ad.calls == []  # short-circuits before calling the judge
+
+
+def test_verify_rejects_when_judge_rejects():
+    ad = _StubAdapter([], keep=False)
+    ing = TranscriptIngester(store=None, lm_adapter=ad, codebase_root="/x")
+    lesson = {"subject": "x", "body": "y", "evidence_span": "venv was missing pytest-asyncio"}
+    assert ing.verify(lesson, _episode()) is False
+
+
+def test_verify_accepts_with_verbatim_evidence_and_keep():
+    ad = _StubAdapter([], keep=True)
+    ing = TranscriptIngester(store=None, lm_adapter=ad, codebase_root="/x")
+    lesson = {"subject": "x", "body": "y", "evidence_span": "venv was missing pytest-asyncio"}
+    assert ing.verify(lesson, _episode()) is True
+
+
+@pytest.fixture
+def temp_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEO_METRICS", "off")
+    import neo.memory.store as store_mod
+    monkeypatch.setattr(store_mod, "FACTS_DIR", tmp_path / "facts")
+    return store_mod.FactStore(codebase_root="/tmp/proj_transcript_test", eager_init=False)
+
+
+def test_ingest_episode_admits_capped_pattern(temp_store):
+    ad = _StubAdapter([
+        {"kind": "pattern", "subject": "verify env first",
+         "body": "Stale virtualenvs cause spurious test failures; check the env before the code.",
+         "domain": "testing", "confidence": 0.95,  # should be capped to 0.6
+         "evidence_span": "venv was missing pytest-asyncio"},
+    ], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    n = ing.ingest_episode(_episode())
+    assert n == 1
+    facts = [f for f in temp_store._facts if f.is_valid]
+    assert len(facts) == 1
+    f = facts[0]
+    assert f.kind == FactKind.PATTERN
+    assert "transcript-derived" in f.tags
+    assert f.metadata.confidence <= 0.6
+    assert f.domain == "testing"          # domain lands on the first-class field, not tags
+    assert "testing" not in f.tags
+
+
+def test_admit_handles_non_numeric_confidence_and_bounds_body(temp_store):
+    ad = _StubAdapter([], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    lesson = {"kind": "pattern", "subject": "s", "body": "B" * 5000,
+              "confidence": "high", "domain": "other",
+              "evidence_span": "venv was missing pytest-asyncio"}
+    fact = ing.admit(lesson, _episode())
+    assert fact.metadata.confidence == 0.5          # non-numeric -> conservative default
+    assert len(fact.body) <= 600                     # bounded
+    assert fact.domain is None                       # "other" -> unset
+
+
+def test_ingest_skips_nonsubstantive(temp_store):
+    ad = _StubAdapter([{"kind": "pattern", "subject": "x", "body": "y"}])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    ep = Episode(session_id="s", anchor_uuid="u", last_uuid="u", timestamp="t", ask="just asking")
+    assert ing.ingest_episode(ep) == 0
+    assert ad.calls == []  # no LM calls for a non-substantive episode

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -326,3 +326,18 @@ def test_watermark_persisted(temp_store, tmp_path, monkeypatch):
     ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
     ing.ingest(episodes=[_ep("e1", "ask one")])
     assert ing._load_consumed() == {"e1"}
+
+
+def test_ingest_respects_stop_and_deadline(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
+    eps = [_ep(f"e{i}", f"ask {i}") for i in range(5)]
+
+    # should_stop fires immediately -> nothing dispatched
+    s = ing.ingest(episodes=eps, should_stop=lambda: True)
+    assert s["episodes_processed"] == 0 and len(ad.calls) == 0
+
+    # max_seconds=0 -> deadline already passed before the first episode
+    s = ing.ingest(episodes=eps, max_seconds=0)
+    assert s["episodes_processed"] == 0 and len(ad.calls) == 0

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,158 @@
+"""Tests for Claude Code transcript parsing (Stage A)."""
+
+import json
+
+from neo.memory.transcript import (
+    build_episodes,
+    collect_episodes,
+    resolve_transcript_dir,
+)
+
+
+def _write(path, records):
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+
+def _user(uuid, sid, text=None, blocks=None, **extra):
+    content = text if text is not None else (blocks or [])
+    return {"type": "user", "uuid": uuid, "sessionId": sid,
+            "timestamp": "t", "message": {"role": "user", "content": content}, **extra}
+
+
+def _assistant(uuid, sid, text=None, tools=None, **extra):
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for name in (tools or []):
+        content.append({"type": "tool_use", "name": name})
+    return {"type": "assistant", "uuid": uuid, "sessionId": sid,
+            "timestamp": "t", "message": {"role": "assistant", "content": content}, **extra}
+
+
+def test_resolve_transcript_dir_path_encoding():
+    d = resolve_transcript_dir("/Users/x/git/neo")
+    assert d is not None and d.name == "-Users-x-git-neo"
+    assert resolve_transcript_dir(None) is None
+
+
+def test_basic_episode_capture(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("u1", "s1", text="add retry logic to the client"),
+        _assistant("a1", "s1", text="Sure, editing now", tools=["Edit", "Bash"]),
+    ])
+    eps = build_episodes(fp)
+    assert len(eps) == 1
+    ep = eps[0]
+    assert ep.ask == "add retry logic to the client"
+    assert ep.anchor_uuid == "u1"
+    assert ep.last_uuid == "a1"          # advanced through the assistant record
+    assert ep.tools == ["Edit", "Bash"]
+    assert ep.is_substantive
+
+
+def test_tool_result_is_not_human_text(tmp_path):
+    """A user record whose content is a tool_result must not open an episode."""
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("u1", "s1", text="run the tests"),
+        _assistant("a1", "s1", text="running", tools=["Bash"]),
+        _user("u2", "s1", blocks=[{"type": "tool_result", "is_error": True,
+                                   "content": "ImportError: no module"}]),
+    ])
+    eps = build_episodes(fp)
+    assert len(eps) == 1                  # the tool_result did NOT start a new episode
+    assert eps[0].ask == "run the tests"
+    assert eps[0].errors == ["ImportError: no module"]
+    assert eps[0].last_uuid == "u2"       # watermark advanced over the tool_result
+
+
+def test_episode_boundary_on_new_human_message(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("u1", "s1", text="first task"),
+        _assistant("a1", "s1", text="done"),
+        _user("u2", "s1", text="second task"),
+        _assistant("a2", "s1", text="done too"),
+    ])
+    eps = build_episodes(fp)
+    assert [e.ask for e in eps] == ["first task", "second task"]
+
+
+def test_sidechain_skipped(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("u1", "s1", text="real ask"),
+        _user("u2", "s1", text="sidechain ask", isSidechain=True),
+        _assistant("a1", "s1", text="ok"),
+    ])
+    eps = build_episodes(fp)
+    assert len(eps) == 1
+    assert eps[0].ask == "real ask"
+
+
+def test_synthetic_command_and_control_strings_are_not_human(tmp_path):
+    """CLI/control envelopes wear the user role but are not human asks."""
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("c1", "s1", text="<command-name>/clear</command-name>"),
+        _user("c2", "s1", text="<local-command-stdout>output</local-command-stdout>"),
+        _user("c3", "s1", text="<task-notification>done</task-notification>"),
+        _user("c4", "s1", text="[Request interrupted by user for tool use]"),
+        _user("c5", "s1", blocks=[{"type": "text",
+                                   "text": "<local-command-caveat>Caveat</local-command-caveat>"}]),
+        _assistant("a0", "s1", text="orphan assistant work"),
+        _user("u1", "s1", text="a genuine human request"),
+        _assistant("a1", "s1", text="done"),
+    ])
+    eps = build_episodes(fp)
+    assert len(eps) == 1                         # only the genuine ask opened an episode
+    assert eps[0].ask == "a genuine human request"
+
+
+def test_sessions_are_partitioned(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        _user("u1", "s1", text="ask in session one"),
+        _user("u2", "s2", text="ask in session two"),
+        _assistant("a2", "s2", text="reply"),
+        _assistant("a1", "s1", text="reply"),
+    ])
+    eps = build_episodes(fp)
+    asks = sorted(e.ask for e in eps)
+    assert asks == ["ask in session one", "ask in session two"]
+
+
+def test_records_without_identity_are_dropped(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [
+        {"type": "user", "message": {"role": "user", "content": "no uuid"}},
+        {"type": "ai-title", "aiTitle": "x"},
+        _user("u1", "s1", text="valid ask"),
+        _assistant("a1", "s1", text="ok"),
+    ])
+    eps = build_episodes(fp)
+    assert len(eps) == 1 and eps[0].ask == "valid ask"
+
+
+def test_non_substantive_episode(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    _write(fp, [_user("u1", "s1", text="just a question with no work")])
+    eps = build_episodes(fp)
+    assert len(eps) == 1 and not eps[0].is_substantive
+
+
+def test_malformed_lines_skipped(tmp_path):
+    fp = tmp_path / "s.jsonl"
+    fp.write_text(
+        "not json\n"
+        + json.dumps(_user("u1", "s1", text="valid")) + "\n"
+        + json.dumps(_assistant("a1", "s1", text="ok")) + "\n",
+        encoding="utf-8",
+    )
+    eps = build_episodes(fp)
+    assert len(eps) == 1 and eps[0].ask == "valid"
+
+
+def test_collect_episodes_missing_dir():
+    assert collect_episodes("/nonexistent/path/xyz") == []


### PR DESCRIPTION
## Description

Teaches neo to learn from the **847 MB of Claude Code transcripts** it currently ignores. The observer now mines this session's transcripts each cycle, extracts generalizable engineering lessons via the configured LM, verifies them, and admits them as retrievable PATTERN/FAILURE facts — closing the gap where neo only learned from git commits + its own rare invocations.

Driven by a Phase 0 spike that **retired an initial clustering design** (diverse lessons don't cluster; only paraphrase-dups do) in favor of direct ingestion.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

neo's synthesis was starved: 92 diverse REVIEW facts produced 0 patterns because they don't cluster at cosine 0.85. Meanwhile the rich behavioral signal — corrections, failures, recurring friction — lived in transcripts neo never read. This ingests that signal as high-quality, deduped, retrievable lessons.

## How Has This Been Tested?

- [x] 28 new unit tests (parser, extraction, verify gates, watermark, observer wiring); full suite **977 passed, 3 skipped**
- [x] **End-to-end on 25 real episodes via gpt-5.5**: 40 valid lessons admitted, idempotent re-run (0 new), under cap, domains populated. Sample lessons: "verify behavior, not installs", "pipx injected deps don't auto-upgrade", "pause a background writer before editing its store".

**Test Configuration**: Python 3.14 / macOS / neo 0.20.3 (provider openai, gpt-5.5)

## Design

`docs/solutions/transcript-ingestion.md` (full design + Phase 0 results + validation).

- **Stage A** (`memory/transcript.py`): schema-correct parser → episodes. Distinguishes genuine human text from tool_result envelopes and synthetic CLI/control strings (~31% of episodes were noise until filtered).
- **Stage B/C**: LM extract → verify-at-admission (evidence must appear *verbatim* in source + adversarial judge) → admit as PATTERN/FAILURE (not REVIEW, to stay out of the dud clustering path), capped confidence 0.6, INFERRED provenance, probationary.
- **Dedup**: reuses the existing 0.85 supersession (measured: 269→256); no parallel path.
- **Watermark**: per-episode, advanced only after facts durable; idempotent; project-keyed.
- **Observer**: bounded by episode budget + wall-clock deadline + SIGTERM stop-check so a hung provider can't stonewall shutdown.

## Checklist

- [x] Follows project code style
- [x] Self-reviewed (+ reviewed by @neo and @linus agents at each stage — caught the synthetic-string bug, the dropped-domain bug, and the count-not-time budget bug)
- [x] Documentation updated
- [x] No new warnings
- [x] New and existing tests pass locally

## Additional Notes

The feature is unconditionally on in the observer (bounded by committed constants — 8 episodes/cycle, 120s deadline — not env toggles). Phase 2 (CAR journals) and Phase 3 (org-scoped cross-project) are deferred.