### PR TITLE
feat: multi-source transcript learning + CAR adapter

### DIFF
--- a/docs/solutions/transcript-ingestion.md
+++ b/docs/solutions/transcript-ingestion.md
@@ -1,10 +1,50 @@
 # Transcript & journal ingestion — feeding synthesis from AI-tool artifacts
 
-**Status:** proposal v3 (2026-06-13). Phase 0 spike complete (results below).
-v1 → v2 corrected integration claims after @neo + @linus review; Phase 0 then
-**retired the clustering approach** and v3 pivots the Design to direct ingestion
-of verified lessons as PATTERN/FAILURE facts + cosine semantic dedup. This is the
-architecture being implemented.
+**Status:** v4 (2026-06-13). v3 shipped Claude Code ingestion (PR #97). v4
+generalizes to **multiple AI-tool sources** behind a `TranscriptSource` adapter
+interface and adds **CAR** as the second source. (History: v1→v2 corrected
+integration claims after @neo + @linus review; Phase 0 retired the clustering
+approach; v3 pivoted to direct PATTERN/FAILURE admission.)
+
+## Multi-source architecture (v4)
+
+The goal is to learn from **every AI coding tool**, not just Claude Code. The
+extract→verify→admit pipeline, probation, dedup, and watermark are all
+tool-agnostic; only *parsing* is tool-specific. So each tool is a
+`TranscriptSource` adapter (`name`, `scope`, `collect_episodes() -> [Episode]`)
+and the ingester iterates a list of them:
+
+- **`ClaudeCodeSource`** (scope PROJECT) — `~/.claude/projects/{path}/*.jsonl`.
+- **`CarSource`** (scope GLOBAL) — `~/.car/sessions/*.json` task conversations.
+  CAR is cross-agent / not repo-bound, hence global scope. One session = one
+  episode (no per-message ids → session id is the watermark anchor). Guards:
+  ingest only **finished** sessions (session files mutate across runs, so an
+  in-flight one would be permanently skipped once watermarked), and **dedup by
+  normalized ask** (CAR's multi-agent fan-out creates many identical-task
+  sessions — 311 raw → 37 unique). CAR **journals** (`~/.car/journals`) are
+  intentionally NOT a source: thin action-lifecycle audit logs whose
+  rejection/violation records carry empty `data` — nothing extractable.
+- Codex / others: drop in as new adapters yielding the same `Episode`.
+
+Watermarks are namespaced per `(source, scope-suffix)` so sources never collide;
+project sources key on `project_id`, global sources on the literal `global`. The
+per-cycle budget/deadline is **shared across all sources** (one bound per cycle);
+sources run in list order, so a deep first-source backlog can defer later sources
+for a few cycles until it drains (self-healing, not permanent starvation).
+
+**Caveat (today):** CAR's current corpus is ~100% stale toy/test tasks
+("What is 6\*7?", "Capital of France?"), so the verify gate rejects nearly all of
+it; the adapter pays off as CAR accrues real work. GLOBAL-scoped facts surface in
+*all* projects (that is what global scope means, and is the chosen behavior) — if
+toy-data spill becomes a problem before CAR has real data, the mitigation is to
+drop `CarSource` from the default `sources` list (one line) or add source-aware
+retrieval filtering.
+
+**v4 validation (2026-06-13):** CAR source end-to-end via gpt-5.5 — 311 raw
+sessions → 37 episodes (finished + ask-dedup) → **3 admitted**, all GLOBAL (2
+pattern, 1 failure); the verify gate **rejected 34/37** toy episodes. Re-run: 0
+new (idempotent). Confirms the quality wall holds on a low-signal source and that
+scope/watermark threading is correct. Claude Code source unchanged from #97.
 
 ## Problem
 

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -339,6 +339,86 @@ class ClaudeCodeSource:
         return collect_episodes(self.codebase_root)
 
 
+CAR_SESSIONS_DIR = Path.home() / ".car" / "sessions"
+
+
+class CarSource:
+    """CAR agent session transcripts (``~/.car/sessions/*.json``).
+
+    CAR sessions are ``{id, task, messages:[{role, content}], ...}`` task
+    conversations. They are cross-agent and not bound to a git repo, so derived
+    facts are GLOBAL-scoped. Each session maps to one episode — there are no
+    per-message ids, so the session id is the watermark anchor. (The sibling
+    ``~/.car/journals`` are thin action-lifecycle audit logs with no extractable
+    content, so they are intentionally not a source.)
+    """
+
+    name = "car"
+    scope = FactScope.GLOBAL
+
+    def __init__(self, sessions_dir: Optional[Path] = None):
+        self._dir = sessions_dir or CAR_SESSIONS_DIR
+
+    def collect_episodes(self) -> list[Episode]:
+        if not self._dir.is_dir():
+            return []
+        episodes: list[Episode] = []
+        seen_asks: set[str] = set()
+        for fp in sorted(self._dir.glob("*.json")):
+            ep = self._session_to_episode(fp)
+            if ep is None:
+                continue
+            # CAR's multi-agent fan-out creates many sessions with identical
+            # tasks (e.g. dozens of "What is 6*7?"). Collapse by normalized ask
+            # so the toy-duplicate flood never reaches the (global, 200-cap) store.
+            sig = ep.ask.strip().lower()
+            if sig in seen_asks:
+                continue
+            seen_asks.add(sig)
+            episodes.append(ep)
+        return episodes
+
+    @staticmethod
+    def _session_to_episode(fp: Path) -> Optional[Episode]:
+        try:
+            d = json.loads(fp.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(d, dict):
+            return None
+        # Only finished sessions are immutable. An in-flight session can gain
+        # turns across runs, and we watermark by session id — so mining it early
+        # would permanently skip the finished, substantive version. Skip until done.
+        if d.get("finished") is not True:
+            return None
+        sid = str(d.get("id") or fp.stem)
+        user_texts, asst_texts = [], []
+        for m in d.get("messages") or []:
+            if not isinstance(m, dict):
+                continue
+            content = m.get("content")
+            if content is None:
+                continue  # skip empty messages rather than emit a literal "null"
+            if not isinstance(content, str):
+                content = json.dumps(content)
+            if m.get("role") == "user":
+                user_texts.append(content)
+            elif m.get("role") == "assistant":
+                asst_texts.append(content)
+        # The first user message is the actual prompt; fall back to the task field.
+        ask = (user_texts[0] if user_texts else str(d.get("task") or "")).strip()
+        if not ask:
+            return None
+        return Episode(
+            session_id=sid,
+            anchor_uuid=sid,
+            last_uuid=sid,
+            timestamp=str(d.get("created_at") or ""),
+            ask=ask[:_MAX_ASK_CHARS],
+            assistant_text=asst_texts,
+        )
+
+
 class TranscriptIngester:
     """Extract verified, generalizable lessons from transcript episodes and
     admit them directly as PATTERN/FAILURE facts.
@@ -357,6 +437,7 @@ class TranscriptIngester:
         # Default source set; add Codex/etc. here as adapters land.
         self.sources = sources if sources is not None else [
             ClaudeCodeSource(self.codebase_root),
+            CarSource(),
         ]
 
     # -- Stage B ---------------------------------------------------------

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -27,7 +27,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterator, Optional
+from typing import Callable, Iterator, Optional, Protocol
 
 from neo.memory.io_utils import atomic_write_json
 from neo.memory.metrics import record as metrics_record
@@ -305,6 +305,40 @@ def _normalize_ws(s: str) -> str:
     return " ".join(s.split())
 
 
+# ---------------------------------------------------------------------------
+# Source adapters — one per AI tool. Each yields the common Episode shape so the
+# extract→verify→admit pipeline and per-source watermark are reused unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TranscriptSource(Protocol):
+    """A tool whose transcripts neo mines.
+
+    ``name`` namespaces the watermark; ``scope`` is the FactScope for facts
+    derived from this source (PROJECT for repo-bound tools, GLOBAL for
+    cross-agent tools that aren't tied to one repo).
+    """
+
+    name: str
+    scope: FactScope
+
+    def collect_episodes(self) -> list[Episode]:
+        ...
+
+
+class ClaudeCodeSource:
+    """Claude Code session transcripts for one project."""
+
+    name = "claude-code"
+    scope = FactScope.PROJECT
+
+    def __init__(self, codebase_root: Optional[str]):
+        self.codebase_root = codebase_root
+
+    def collect_episodes(self) -> list[Episode]:
+        return collect_episodes(self.codebase_root)
+
+
 class TranscriptIngester:
     """Extract verified, generalizable lessons from transcript episodes and
     admit them directly as PATTERN/FAILURE facts.
@@ -315,10 +349,15 @@ class TranscriptIngester:
     episode (provable evidence, not claimed).
     """
 
-    def __init__(self, store, lm_adapter, codebase_root: Optional[str] = None):
+    def __init__(self, store, lm_adapter, codebase_root: Optional[str] = None,
+                 sources: Optional[list] = None):
         self._store = store
         self._lm = lm_adapter
         self.codebase_root = codebase_root or getattr(store, "codebase_root", None)
+        # Default source set; add Codex/etc. here as adapters land.
+        self.sources = sources if sources is not None else [
+            ClaudeCodeSource(self.codebase_root),
+        ]
 
     # -- Stage B ---------------------------------------------------------
     def extract_lessons(self, ep: Episode) -> list[dict]:
@@ -355,7 +394,7 @@ class TranscriptIngester:
         return bool(data and data.get("keep") is True)
 
     # -- admission -------------------------------------------------------
-    def admit(self, lesson: dict, ep: Episode):
+    def admit(self, lesson: dict, ep: Episode, scope: FactScope = FactScope.PROJECT):
         kind = FactKind.FAILURE if lesson.get("kind") == "failure" else FactKind.PATTERN
         try:
             raw_conf = float(lesson.get("confidence", 0.5) or 0.5)
@@ -369,7 +408,7 @@ class TranscriptIngester:
             subject=str(lesson.get("subject", ""))[:120],
             body=str(lesson.get("body", ""))[:_MAX_BODY_CHARS],
             kind=kind,
-            scope=FactScope.PROJECT,
+            scope=scope,
             confidence=confidence,
             source_prompt=ep.ask[:200],
             tags=[_TRANSCRIPT_TAG],
@@ -377,7 +416,7 @@ class TranscriptIngester:
             domain=domain,  # first-class field so retrieve_relevant(domain=...) matches
         )
 
-    def ingest_episode(self, ep: Episode) -> int:
+    def ingest_episode(self, ep: Episode, scope: FactScope = FactScope.PROJECT) -> int:
         """Full per-episode pipeline; returns number of facts admitted.
 
         ``store.add_fact`` saves to disk on each call, so an episode's facts
@@ -388,60 +427,77 @@ class TranscriptIngester:
         admitted = 0
         for lesson in self.extract_lessons(ep):
             if self.verify(lesson, ep):
-                self.admit(lesson, ep)
+                self.admit(lesson, ep, scope)
                 admitted += 1
         return admitted
 
-    # -- incremental ingest with watermark -------------------------------
-    def ingest(self, episodes: Optional[list[Episode]] = None,
-               max_episodes: Optional[int] = None,
+    # -- incremental ingest with per-source watermark --------------------
+    def ingest(self, max_episodes: Optional[int] = None,
                max_seconds: Optional[float] = None,
                should_stop: Optional[Callable[[], bool]] = None) -> dict:
-        """Ingest not-yet-consumed episodes, advancing the watermark per episode.
+        """Mine all configured sources, advancing each source's watermark per
+        episode.
 
-        Idempotent: an episode's ``anchor_uuid`` is recorded as consumed only
-        *after* its facts are durably written, so a re-run skips it and a crash
-        mid-episode simply reprocesses it (dedup absorbs any partial). The
-        watermark is keyed by project, not by transcript path, so it survives
-        worktrees/clones that share the same git remote.
+        Idempotent per source: an episode's ``anchor_uuid`` is recorded as
+        consumed only *after* its facts are durably written, so a re-run skips it
+        and a crash mid-episode simply reprocesses it (dedup absorbs any partial).
+        Watermarks are namespaced by source and (for project-scoped sources) by
+        project_id, so sources never collide and the key survives worktrees/clones
+        that share the same git remote.
 
-        ``max_episodes`` caps episode count; ``max_seconds`` caps wall time and
-        ``should_stop`` caps on an external signal (SIGTERM). Both bounds stop
-        *dispatching new* episodes — an LM call already in flight runs to its own
-        timeout — which collapses a hung pass from N×(call timeout) to ~1, and
-        keeps the supervised observer responsive to shutdown. The watermark
-        drains the remaining backlog on the next cycle.
+        ``max_episodes`` / ``max_seconds`` / ``should_stop`` are SHARED across all
+        sources (a single per-cycle budget). They stop *dispatching new* episodes
+        — an LM call already in flight runs to its own timeout — collapsing a hung
+        pass from N×(call timeout) to ~1 and keeping the supervised observer
+        responsive to shutdown. The watermark drains the remaining backlog next
+        cycle.
         """
-        if episodes is None:
-            episodes = collect_episodes(self.codebase_root)
-        consumed = self._load_consumed()
-        new = [e for e in episodes if e.anchor_uuid not in consumed]
-        stats = {"episodes_total": len(episodes), "episodes_new": len(new),
+        stats = {"episodes_total": 0, "episodes_new": 0,
                  "episodes_processed": 0, "facts_admitted": 0}
         start = time.monotonic()
-        for ep in new:
+
+        def stop_now() -> bool:
             if max_episodes is not None and stats["episodes_processed"] >= max_episodes:
-                break
+                return True
             if max_seconds is not None and (time.monotonic() - start) >= max_seconds:
+                return True
+            return bool(should_stop is not None and should_stop())
+
+        for source in self.sources:
+            if stop_now():
                 break
-            if should_stop is not None and should_stop():
-                break
-            stats["facts_admitted"] += self.ingest_episode(ep)
-            consumed.add(ep.anchor_uuid)
-            self._persist_consumed(consumed)   # advance only after facts are durable
-            stats["episodes_processed"] += 1
+            consumed = self._load_consumed(source)
+            try:
+                episodes = source.collect_episodes()
+            except Exception as e:  # one bad source must not sink the others
+                logger.warning("transcript: source %s collect failed: %s", source.name, e)
+                continue
+            new = [e for e in episodes if e.anchor_uuid not in consumed]
+            stats["episodes_total"] += len(episodes)
+            stats["episodes_new"] += len(new)
+            for ep in new:
+                if stop_now():
+                    break
+                stats["facts_admitted"] += self.ingest_episode(ep, source.scope)
+                consumed.add(ep.anchor_uuid)
+                self._persist_consumed(source, consumed)  # advance only after durable
+                stats["episodes_processed"] += 1
         if stats["episodes_processed"]:
             metrics_record("transcript_ingest", **stats)
         return stats
 
-    def _watermark_path(self) -> Optional[Path]:
-        pid = getattr(self._store, "project_id", None)
-        if not pid:
-            return None
-        return SESSIONS_DIR / f"transcript_watermark_{pid}.json"
+    def _watermark_path(self, source) -> Optional[Path]:
+        if source.scope == FactScope.PROJECT:
+            pid = getattr(self._store, "project_id", None)
+            if not pid:
+                return None
+            suffix = pid
+        else:
+            suffix = "global"
+        return SESSIONS_DIR / f"transcript_watermark_{source.name}_{suffix}.json"
 
-    def _load_consumed(self) -> set:
-        path = self._watermark_path()
+    def _load_consumed(self, source) -> set:
+        path = self._watermark_path(source)
         if not path or not path.exists():
             return set()
         try:
@@ -449,8 +505,8 @@ class TranscriptIngester:
         except (OSError, json.JSONDecodeError):
             return set()
 
-    def _persist_consumed(self, consumed: set) -> None:
-        path = self._watermark_path()
+    def _persist_consumed(self, source, consumed: set) -> None:
+        path = self._watermark_path(source)
         if not path:
             return
         try:

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -6,6 +6,7 @@ import pytest
 
 from neo.memory.models import FactKind, FactScope
 from neo.memory.transcript import (
+    CarSource,
     Episode,
     TranscriptIngester,
     _parse_json,
@@ -395,3 +396,83 @@ def test_shared_budget_across_sources(temp_store, tmp_path, monkeypatch):
     stats = ing.ingest(max_episodes=1)
     assert stats["episodes_processed"] == 1
     assert ing._load_consumed(s2) == set()  # second source never reached
+
+
+# --------------------------------------------------------------------------
+# CAR source adapter
+# --------------------------------------------------------------------------
+
+def _write_session(path, d):
+    path.write_text(json.dumps(d), encoding="utf-8")
+
+
+def test_car_source_parses_session(tmp_path):
+    sdir = tmp_path / "car_sessions"
+    sdir.mkdir()
+    _write_session(sdir / "abc.json", {
+        "id": "abc", "task": "do thing", "created_at": 123.0, "provider": "openai",
+        "finished": True,
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "fix the flaky test"},
+            {"role": "assistant", "content": "I retried and found the race"},
+        ],
+    })
+    src = CarSource(sessions_dir=sdir)
+    assert src.name == "car" and src.scope == FactScope.GLOBAL
+    eps = src.collect_episodes()
+    assert len(eps) == 1
+    ep = eps[0]
+    assert ep.ask == "fix the flaky test"          # first user msg, not the task field
+    assert ep.anchor_uuid == "abc"                 # session id = watermark anchor
+    assert ep.assistant_text == ["I retried and found the race"]
+    assert ep.is_substantive
+
+
+def test_car_source_falls_back_to_task(tmp_path):
+    sdir = tmp_path / "s"
+    sdir.mkdir()
+    _write_session(sdir / "x.json",
+                   {"id": "x", "task": "the task", "finished": True,
+                    "messages": [{"role": "assistant", "content": "did it"}]})
+    eps = CarSource(sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1 and eps[0].ask == "the task"
+
+
+def test_car_source_skips_unfinished_sessions(tmp_path):
+    sdir = tmp_path / "s"
+    sdir.mkdir()
+    _write_session(sdir / "live.json",
+                   {"id": "live", "task": "in progress", "finished": False,
+                    "messages": [{"role": "assistant", "content": "working"}]})
+    # no `finished` key at all -> also skipped (treated as in-flight)
+    _write_session(sdir / "nokey.json",
+                   {"id": "nokey", "task": "t",
+                    "messages": [{"role": "assistant", "content": "x"}]})
+    assert CarSource(sessions_dir=sdir).collect_episodes() == []
+
+
+def test_car_source_dedups_identical_asks(tmp_path):
+    sdir = tmp_path / "s"
+    sdir.mkdir()
+    for i in range(4):
+        _write_session(sdir / f"dup{i}.json",
+                       {"id": f"dup{i}", "task": "What is 6 * 7?", "finished": True,
+                        "messages": [{"role": "user", "content": "What is 6 * 7?"},
+                                     {"role": "assistant", "content": "42"}]})
+    eps = CarSource(sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1  # the fan-out duplicates collapse to one episode
+
+
+def test_car_source_skips_bad_and_missing(tmp_path):
+    sdir = tmp_path / "s"
+    sdir.mkdir()
+    (sdir / "bad.json").write_text("not json", encoding="utf-8")
+    _write_session(sdir / "noask.json", {"id": "e", "messages": []})  # no ask -> skipped
+    assert CarSource(sessions_dir=sdir).collect_episodes() == []
+    assert CarSource(sessions_dir=tmp_path / "nope").collect_episodes() == []
+
+
+def test_default_sources_include_car(temp_store):
+    ing = TranscriptIngester(store=temp_store, lm_adapter=_StubAdapter([]), codebase_root="/x")
+    assert {s.name for s in ing.sources} >= {"claude-code", "car"}

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from neo.memory.models import FactKind
+from neo.memory.models import FactKind, FactScope
 from neo.memory.transcript import (
     Episode,
     TranscriptIngester,
@@ -13,6 +13,19 @@ from neo.memory.transcript import (
     collect_episodes,
     resolve_transcript_dir,
 )
+
+
+class _StaticSource:
+    """Test source yielding a fixed episode list."""
+
+    name = "test"
+    scope = FactScope.PROJECT
+
+    def __init__(self, episodes):
+        self._episodes = list(episodes)
+
+    def collect_episodes(self):
+        return list(self._episodes)
 
 
 def _write(path, records):
@@ -295,14 +308,14 @@ _LESSON = {"kind": "pattern", "subject": "verify env", "body": "Check the venv b
 def test_ingest_is_idempotent(temp_store, tmp_path, monkeypatch):
     monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
     ad = _StubAdapter([_LESSON], keep=True)
-    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
-    eps = [_ep("e1", "ask one"), _ep("e2", "ask two")]
+    src = _StaticSource([_ep("e1", "ask one"), _ep("e2", "ask two")])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[src])
 
-    s1 = ing.ingest(episodes=eps)
+    s1 = ing.ingest()
     assert s1["episodes_new"] == 2 and s1["episodes_processed"] == 2 and s1["facts_admitted"] == 2
     calls_after_first = len(ad.calls)
 
-    s2 = ing.ingest(episodes=eps)  # re-run: everything already consumed
+    s2 = ing.ingest()  # re-run: everything already consumed
     assert s2["episodes_new"] == 0 and s2["episodes_processed"] == 0
     assert len(ad.calls) == calls_after_first  # zero new LM calls on re-run
 
@@ -310,34 +323,75 @@ def test_ingest_is_idempotent(temp_store, tmp_path, monkeypatch):
 def test_ingest_budget_resumes(temp_store, tmp_path, monkeypatch):
     monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
     ad = _StubAdapter([_LESSON], keep=True)
-    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
-    eps = [_ep(f"e{i}", f"ask {i}") for i in range(5)]
+    src = _StaticSource([_ep(f"e{i}", f"ask {i}") for i in range(5)])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[src])
 
-    s1 = ing.ingest(episodes=eps, max_episodes=2)
+    s1 = ing.ingest(max_episodes=2)
     assert s1["episodes_new"] == 5 and s1["episodes_processed"] == 2  # budget honored
 
-    s2 = ing.ingest(episodes=eps, max_episodes=10)  # resumes the rest
+    s2 = ing.ingest(max_episodes=10)  # resumes the rest
     assert s2["episodes_new"] == 3 and s2["episodes_processed"] == 3
 
 
 def test_watermark_persisted(temp_store, tmp_path, monkeypatch):
     monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
     ad = _StubAdapter([_LESSON], keep=True)
-    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
-    ing.ingest(episodes=[_ep("e1", "ask one")])
-    assert ing._load_consumed() == {"e1"}
+    src = _StaticSource([_ep("e1", "ask one")])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[src])
+    ing.ingest()
+    assert ing._load_consumed(src) == {"e1"}
 
 
 def test_ingest_respects_stop_and_deadline(temp_store, tmp_path, monkeypatch):
     monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
     ad = _StubAdapter([_LESSON], keep=True)
-    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, codebase_root="/x")
-    eps = [_ep(f"e{i}", f"ask {i}") for i in range(5)]
+    src = _StaticSource([_ep(f"e{i}", f"ask {i}") for i in range(5)])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[src])
 
     # should_stop fires immediately -> nothing dispatched
-    s = ing.ingest(episodes=eps, should_stop=lambda: True)
+    s = ing.ingest(should_stop=lambda: True)
     assert s["episodes_processed"] == 0 and len(ad.calls) == 0
 
     # max_seconds=0 -> deadline already passed before the first episode
-    s = ing.ingest(episodes=eps, max_seconds=0)
+    s = ing.ingest(max_seconds=0)
     assert s["episodes_processed"] == 0 and len(ad.calls) == 0
+
+
+class _GlobalSource(_StaticSource):
+    name = "carlike"
+    scope = FactScope.GLOBAL
+
+
+def test_default_sources_include_claude_code(temp_store):
+    ing = TranscriptIngester(store=temp_store, lm_adapter=_StubAdapter([]), codebase_root="/x")
+    assert any(s.name == "claude-code" for s in ing.sources)
+
+
+def test_multiple_sources_independent_watermarks_and_scope(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    s_proj = _StaticSource([_ep("p1", "project ask")])
+    s_glob = _GlobalSource([_ep("g1", "global ask")])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[s_proj, s_glob])
+
+    stats = ing.ingest()
+    assert stats["episodes_processed"] == 2
+    # watermarks are namespaced per source — no collision
+    assert ing._load_consumed(s_proj) == {"p1"}
+    assert ing._load_consumed(s_glob) == {"g1"}
+    # facts admitted at each source's scope
+    scopes = {f.scope for f in temp_store._facts if f.is_valid}
+    assert FactScope.PROJECT in scopes
+    assert FactScope.GLOBAL in scopes
+
+
+def test_shared_budget_across_sources(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    ad = _StubAdapter([_LESSON], keep=True)
+    s1 = _StaticSource([_ep("a1", "ask"), _ep("a2", "ask")])
+    s2 = _GlobalSource([_ep("b1", "ask")])
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[s1, s2])
+    # budget of 1 is shared: only the first source's first episode is processed
+    stats = ing.ingest(max_episodes=1)
+    assert stats["episodes_processed"] == 1
+    assert ing._load_consumed(s2) == set()  # second source never reached


### PR DESCRIPTION
## Description

Generalizes transcript learning (shipped for Claude Code in #97) to **all AI coding tools** via a `TranscriptSource` adapter interface, and adds **CAR** as the second source. The goal: neo learns from the full record of AI-assisted work, not one tool.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code cleanup/refactoring

## Motivation and Context

The extract→verify→admit pipeline, probation, dedup, and watermark are tool-agnostic; only *parsing* is tool-specific. So each tool becomes a `TranscriptSource` (`name`, `scope`, `collect_episodes() -> [Episode]`) and the ingester iterates a list of them. This makes Codex/Cursor/etc. drop-in adapters.

## Changes

- **`TranscriptSource` interface** + `ClaudeCodeSource` (refactor of the existing parser, scope PROJECT). No behavior change to the Claude Code path.
- **`CarSource`** — mines `~/.car/sessions/*.json` task conversations, scope **GLOBAL** (cross-agent, not repo-bound). One session = one episode (session id is the watermark anchor). Two store-integrity guards from review: only ingest **finished** sessions (session files mutate across runs), and **dedup by normalized ask** (CAR fan-out creates many identical-task sessions; 311 raw → 37). CAR *journals* are intentionally excluded (thin audit logs, no extractable content).
- Ingester iterates sources with a **shared per-cycle budget/deadline**; watermarks namespaced per `(source, scope)` so sources never collide; `admit()` threads each source's scope.

## How Has This Been Tested?

- [x] 12 new unit tests (interface, multi-source watermark isolation, shared budget, scope threading, CarSource parsing/finished/dedup); full suite **986 passed, 3 skipped**
- [x] **CAR end-to-end via gpt-5.5**: 311 sessions → 37 episodes → 3 admitted (all GLOBAL); verify gate rejected 34/37 toy episodes; idempotent re-run (0 new). Confirms the quality wall holds on a low-signal source.

**Test Configuration**: Python 3.14 / macOS / neo 0.20.3 (openai, gpt-5.5)

## Design

`docs/solutions/transcript-ingestion.md` (v4 section + CAR validation).

## Checklist

- [x] Follows project code style
- [x] Self-reviewed (+ @neo and @linus reviewed the interface and CAR adapter — caught the duplicate-task flood and the mutable-file watermark bug)
- [x] Documentation updated
- [x] No new warnings
- [x] New and existing tests pass locally

## Additional Notes

CAR's current corpus is ~100% stale toy/test tasks, so it yields little today (the verify gate rejects most) — the adapter pays off as CAR accrues real work. GLOBAL-scoped facts surface in all projects by design; if toy-data spill becomes an issue before CAR has real data, dropping `CarSource` from the default sources is one line. Codex and other tools are future adapters behind the same interface.