### PR TITLE
feat: add Codex source adapter (project-scoped transcript learning)

### DIFF
--- a/docs/solutions/transcript-ingestion.md
+++ b/docs/solutions/transcript-ingestion.md
@@ -15,6 +15,17 @@ tool-agnostic; only *parsing* is tool-specific. So each tool is a
 and the ingester iterates a list of them:
 
 - **`ClaudeCodeSource`** (scope PROJECT) — `~/.claude/projects/{path}/*.jsonl`.
+- **`CodexSource`** (scope PROJECT) — `~/.codex/sessions/**/rollout-*.jsonl`.
+  Codex records `session_meta.cwd`, so rollouts ARE project-attributable
+  (unlike CAR) → project-scoped, filtered to rollouts whose cwd is within
+  `codebase_root` (cheap first-line read). Episodes anchor on
+  `event_msg/user_message`; assistant text from `agent_message`; tools from
+  `response_item/function_call`. **Errors** come from
+  `response_item/function_call_output` (`exited with code N` / `timed out`) —
+  verified the only error channel in 73% of sessions and all 6 of this repo's
+  rollouts — plus `patch_apply_end` failures, with `exec_command_end` kept for
+  older rollouts. Codex's synthetic "agent history" review-wrapper is filtered
+  out of `user_message`. Append-only, so `(session_id, msg_idx)` is the anchor.
 - **`CarSource`** (scope GLOBAL) — `~/.car/sessions/*.json` task conversations.
   CAR is cross-agent / not repo-bound, hence global scope. One session = one
   episode (no per-message ids → session id is the watermark anchor). Guards:
@@ -24,7 +35,12 @@ and the ingester iterates a list of them:
   sessions — 311 raw → 37 unique). CAR **journals** (`~/.car/journals`) are
   intentionally NOT a source: thin action-lifecycle audit logs whose
   rejection/violation records carry empty `data` — nothing extractable.
-- Codex / others: drop in as new adapters yielding the same `Episode`.
+- **Cursor: deferred** — not installed, so there is no real transcript schema to
+  build and verify against. Building a parser from a guessed schema is the
+  anti-pattern that bit both the Claude Code (synthetic-string) and CAR
+  (journals-vs-sessions) adapters; the Cursor adapter will be built when Cursor
+  is installed and has real transcripts on disk.
+- Other tools: drop in as new adapters yielding the same `Episode`.
 
 Watermarks are namespaced per `(source, scope-suffix)` so sources never collide;
 project sources key on `project_id`, global sources on the literal `global`. The
@@ -45,6 +61,14 @@ sessions → 37 episodes (finished + ask-dedup) → **3 admitted**, all GLOBAL (
 pattern, 1 failure); the verify gate **rejected 34/37** toy episodes. Re-run: 0
 new (idempotent). Confirms the quality wall holds on a low-signal source and that
 scope/watermark threading is correct. Claude Code source unchanged from #97.
+
+**Codex validation (2026-06-13):** CodexSource on the 6 real `~/git/neo` rollouts
+— 44 episodes → **77 admitted**, all PROJECT (34 failure, 43 pattern; domains
+spanning workflow/debugging/architecture/testing/security/git). Re-run: 0 new
+(idempotent). The 34 failures confirm the `function_call_output` error channel
+fix — the original `exec_command_end`-only capture would have found ~zero (those
+rollouts emit none). Codex is the highest-signal source: project-scoped real
+engineering work.
 
 ## Problem
 

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -419,6 +420,156 @@ class CarSource:
         )
 
 
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+# Sanity ceiling only. Rollouts are parsed line-by-line (bounded memory), and
+# real working sessions legitimately reach hundreds of MB (inline command
+# output), so this is set high — it exists to skip a truly broken file, not to
+# drop real data. Logged, not silent.
+_CODEX_MAX_ROLLOUT_BYTES = 2 * 1024 * 1024 * 1024
+# Codex injects a synthetic "agent history" review wrapper as a user_message;
+# it is not a human ask and must not anchor an episode.
+_CODEX_SYNTHETIC_PREFIX = "The following is the Codex agent history"
+_CODEX_EXIT_RE = re.compile(r"exited with code (\d+)")
+
+
+def _codex_output_error(output: str) -> Optional[str]:
+    """Return a failure snippet from a function_call_output blob, else None.
+
+    Codex command results land in ``function_call_output.output`` as text like
+    ``Process exited with code 1\n...`` or ``command timed out after ...`` — the
+    only error channel in the modern rollout format. Success blobs say
+    ``exited with code 0`` and are ignored.
+    """
+    if not output:
+        return None
+    m = _CODEX_EXIT_RE.search(output)
+    failed = (m is not None and m.group(1) != "0") or "timed out" in output.lower()
+    return output.strip()[:300] if failed else None
+
+
+class CodexSource:
+    """Codex CLI session rollouts (``~/.codex/sessions/**/rollout-*.jsonl``).
+
+    Rollouts are ``{timestamp, type, payload}`` JSONL whose first record is a
+    ``session_meta`` carrying ``cwd``. Unlike CAR, that makes them
+    project-attributable, so this is PROJECT-scoped: only rollouts whose cwd is
+    within the current ``codebase_root`` are ingested. Conversation lives in
+    ``event_msg`` records (``user_message`` anchors an episode, ``agent_message``
+    is assistant text), tools in ``response_item`` ``function_call`` names, and
+    errors in ``exec_command_end`` with a non-zero ``exit_code``. Rollouts are
+    append-only, so ``(session_id, record-timestamp)`` is a stable watermark
+    anchor.
+    """
+
+    name = "codex"
+    scope = FactScope.PROJECT
+
+    def __init__(self, codebase_root: Optional[str], sessions_dir: Optional[Path] = None):
+        self.codebase_root = codebase_root
+        self._dir = sessions_dir or CODEX_SESSIONS_DIR
+
+    def collect_episodes(self) -> list[Episode]:
+        root = self.codebase_root
+        if not root or not self._dir.is_dir():
+            return []
+        episodes: list[Episode] = []
+        for fp in sorted(self._dir.glob("**/rollout-*.jsonl")):
+            if not self._cwd_within_root(fp, root):
+                continue
+            try:
+                if fp.stat().st_size > _CODEX_MAX_ROLLOUT_BYTES:
+                    logger.warning("transcript: skipping oversized codex rollout %s", fp.name)
+                    continue
+            except OSError:
+                continue
+            episodes.extend(self._rollout_to_episodes(fp))
+        return episodes
+
+    @staticmethod
+    def _cwd_within_root(fp: Path, root: str) -> bool:
+        """Cheap project filter: read only the first record (session_meta)."""
+        try:
+            with fp.open(encoding="utf-8") as f:
+                first = f.readline()
+            r = json.loads(first)
+        except (OSError, json.JSONDecodeError):
+            return False
+        if r.get("type") != "session_meta":
+            return False
+        cwd = (r.get("payload") or {}).get("cwd") or ""
+        return cwd == root or cwd.startswith(root.rstrip("/") + "/")
+
+    @staticmethod
+    def _rollout_to_episodes(fp: Path) -> list[Episode]:
+        episodes: list[Episode] = []
+        sid = fp.stem
+        msg_idx = 0  # monotonic per-session index keeps anchors unique even if
+        # two records share a timestamp; stable across runs (append-only order).
+        cur: Optional[Episode] = None
+        try:
+            handle = fp.open(encoding="utf-8")
+        except OSError:
+            return []
+        with handle as f:
+            for line in f:
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = r.get("type")
+                p = r.get("payload")
+                if not isinstance(p, dict):
+                    continue
+                if t == "session_meta":
+                    sid = str(p.get("id") or sid)
+                elif t == "event_msg":
+                    pt = p.get("type")
+                    if pt == "user_message":
+                        msg = str(p.get("message") or "").strip()
+                        if msg and not _is_synthetic(msg) \
+                                and not msg.startswith(_CODEX_SYNTHETIC_PREFIX):
+                            if cur:
+                                episodes.append(cur)
+                            # (sid, msg_idx) is already unique + stable under the
+                            # append-only ordering; no timestamp needed.
+                            anchor = f"{sid}:{msg_idx}"
+                            msg_idx += 1
+                            cur = Episode(
+                                session_id=sid, anchor_uuid=anchor, last_uuid=anchor,
+                                timestamp=str(r.get("timestamp", "")),
+                                ask=msg[:_MAX_ASK_CHARS],
+                            )
+                    elif pt == "agent_message" and cur is not None:
+                        # Use agent_message (not response_item/message, role=assistant)
+                        # for assistant text — they are byte-identical duplicates;
+                        # reading both would double every assistant turn.
+                        m = str(p.get("message") or "").strip()
+                        if m:
+                            cur.assistant_text.append(m)
+                    elif pt == "exec_command_end" and cur is not None:
+                        # Older-format error channel; modern rollouts use
+                        # function_call_output below.
+                        if p.get("exit_code") not in (0, None):
+                            err = str(p.get("stderr") or "").strip()[:300] or f"exit {p.get('exit_code')}"
+                            cur.errors.append(err)
+                    elif pt == "patch_apply_end" and cur is not None:
+                        if p.get("success") is False:
+                            err = str(p.get("stderr") or "").strip()[:300] or "patch apply failed"
+                            cur.errors.append(err)
+                elif t == "response_item" and cur is not None:
+                    pt = p.get("type")
+                    if pt == "function_call" and p.get("name"):
+                        cur.tools.append(str(p["name"]))
+                    elif pt == "function_call_output":
+                        # The primary error channel in the modern rollout format.
+                        err = _codex_output_error(str(p.get("output") or ""))
+                        if err:
+                            cur.errors.append(err)
+        if cur:
+            episodes.append(cur)
+        return episodes
+
+
 class TranscriptIngester:
     """Extract verified, generalizable lessons from transcript episodes and
     admit them directly as PATTERN/FAILURE facts.
@@ -434,9 +585,10 @@ class TranscriptIngester:
         self._store = store
         self._lm = lm_adapter
         self.codebase_root = codebase_root or getattr(store, "codebase_root", None)
-        # Default source set; add Codex/etc. here as adapters land.
+        # Default source set; add new tool adapters here as they land.
         self.sources = sources if sources is not None else [
             ClaudeCodeSource(self.codebase_root),
+            CodexSource(self.codebase_root),
             CarSource(),
         ]
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -7,6 +7,7 @@ import pytest
 from neo.memory.models import FactKind, FactScope
 from neo.memory.transcript import (
     CarSource,
+    CodexSource,
     Episode,
     TranscriptIngester,
     _parse_json,
@@ -476,3 +477,131 @@ def test_car_source_skips_bad_and_missing(tmp_path):
 def test_default_sources_include_car(temp_store):
     ing = TranscriptIngester(store=temp_store, lm_adapter=_StubAdapter([]), codebase_root="/x")
     assert {s.name for s in ing.sources} >= {"claude-code", "car"}
+
+
+# --------------------------------------------------------------------------
+# Codex source adapter
+# --------------------------------------------------------------------------
+
+def _write_rollout(path, cwd, sid, records):
+    lines = [{"timestamp": "t0", "type": "session_meta", "payload": {"id": sid, "cwd": cwd}}]
+    lines += records
+    path.write_text("\n".join(json.dumps(r) for r in lines), encoding="utf-8")
+
+
+def _ev(pt, **payload):
+    return {"timestamp": "t", "type": "event_msg", "payload": {"type": pt, **payload}}
+
+
+def _ri(pt, **payload):
+    return {"timestamp": "t", "type": "response_item", "payload": {"type": pt, **payload}}
+
+
+def test_codex_source_parses_rollout(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-1.jsonl", cwd="/work/proj", sid="sess1", records=[
+        _ev("user_message", message="fix the failing build"),
+        _ev("agent_message", message="tracing the build failure"),
+        _ri("function_call", name="exec_command", arguments="{}"),
+        _ev("exec_command_end", exit_code=1, stderr="compile error: missing symbol"),
+    ])
+    src = CodexSource(codebase_root="/work/proj", sessions_dir=sdir)
+    assert src.name == "codex" and src.scope == FactScope.PROJECT
+    eps = src.collect_episodes()
+    assert len(eps) == 1
+    ep = eps[0]
+    assert ep.ask == "fix the failing build"
+    assert ep.assistant_text == ["tracing the build failure"]
+    assert ep.tools == ["exec_command"]
+    assert ep.errors == ["compile error: missing symbol"]
+    assert ep.anchor_uuid.startswith("sess1:")
+
+
+def test_codex_source_filters_by_cwd(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-other.jsonl", cwd="/some/other/repo", sid="s",
+                   records=[_ev("user_message", message="not my project")])
+    _write_rollout(sdir / "rollout-sub.jsonl", cwd="/work/proj/subdir", sid="s2",
+                   records=[_ev("user_message", message="within the repo"),
+                            _ev("agent_message", message="ok")])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1 and eps[0].ask == "within the repo"  # only the in-repo cwd
+
+
+def test_codex_source_multiple_user_messages(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-m.jsonl", cwd="/work/proj", sid="s", records=[
+        _ev("user_message", message="first ask"),
+        _ev("agent_message", message="a1"),
+        _ev("user_message", message="second ask"),
+        _ev("agent_message", message="a2"),
+    ])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert [e.ask for e in eps] == ["first ask", "second ask"]
+    assert eps[0].anchor_uuid != eps[1].anchor_uuid
+
+
+def test_codex_source_skips_synthetic_user_message(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-s.jsonl", cwd="/work/proj", sid="s", records=[
+        _ev("user_message", message="<task-notification>x</task-notification>"),
+        _ev("user_message", message="a real ask"),
+        _ev("agent_message", message="ok"),
+    ])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1 and eps[0].ask == "a real ask"
+
+
+def test_codex_source_no_root_or_missing_dir(tmp_path):
+    assert CodexSource(codebase_root=None, sessions_dir=tmp_path).collect_episodes() == []
+    assert CodexSource(codebase_root="/x", sessions_dir=tmp_path / "nope").collect_episodes() == []
+
+
+def test_default_sources_include_codex(temp_store):
+    ing = TranscriptIngester(store=temp_store, lm_adapter=_StubAdapter([]), codebase_root="/x")
+    assert {s.name for s in ing.sources} >= {"claude-code", "codex", "car"}
+
+
+def test_codex_source_captures_function_call_output_errors(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-e.jsonl", cwd="/work/proj", sid="s", records=[
+        _ev("user_message", message="run the migration"),
+        _ri("function_call", name="exec_command"),
+        _ri("function_call_output", output="Process exited with code 1\nsed: no such file"),
+        _ri("function_call", name="exec_command"),
+        _ri("function_call_output", output="Process exited with code 0\nOutput:\nok"),  # success: ignored
+    ])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1
+    assert len(eps[0].errors) == 1 and "code 1" in eps[0].errors[0]  # only the failure
+
+
+def test_codex_source_captures_timeout_and_patch_failure(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-t.jsonl", cwd="/work/proj", sid="s", records=[
+        _ev("user_message", message="apply the patch"),
+        _ri("function_call_output", output="command timed out after 120015 milliseconds"),
+        _ev("patch_apply_end", success=False, stderr="hunk failed to apply"),
+    ])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1
+    joined = " ".join(eps[0].errors)
+    assert "timed out" in joined and "hunk failed" in joined
+
+
+def test_codex_source_skips_agent_history_wrapper(tmp_path):
+    sdir = tmp_path / "codex"
+    sdir.mkdir()
+    _write_rollout(sdir / "rollout-w.jsonl", cwd="/work/proj", sid="s", records=[
+        _ev("user_message", message="The following is the Codex agent history whose request action you are assessing..."),
+        _ev("user_message", message="a genuine ask"),
+        _ev("agent_message", message="ok"),
+    ])
+    eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
+    assert len(eps) == 1 and eps[0].ask == "a genuine ask"


### PR DESCRIPTION
## Description

Adds **Codex** as a third transcript-learning source behind the `TranscriptSource` interface. Codex rollouts record their working directory, so — unlike CAR — they are **project-attributable** and ingested PROJECT-scoped.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Continues the "learn from all AI tools" goal. Codex on this repo is real, substantive engineering work, so it's the highest-signal source yet (77 facts from 6 sessions vs CAR's 3).

## Changes

- **`CodexSource`** (scope PROJECT) — `~/.codex/sessions/**/rollout-*.jsonl`. Filters to rollouts whose `session_meta.cwd` is within `codebase_root` (cheap first-line read). Episodes anchor on `event_msg/user_message`; assistant text from `agent_message`; tools from `response_item/function_call`; **errors from `response_item/function_call_output`** (`exited with code N` / `timed out`) + `patch_apply_end` failures, with `exec_command_end` kept for older rollouts. Filters Codex's synthetic "agent history" review-wrapper. `(session_id, msg_idx)` anchor (append-only). Added to default sources.
- **Cursor: deferred** — not installed, no real schema to verify against; won't build a parser blind.

## How Has This Been Tested?

- [x] 9 new unit tests (cwd filtering, multi-message episodes, error channels — `function_call_output`/timeout/`patch_apply_end`, wrapper rejection); full suite **995 passed, 3 skipped**
- [x] **End-to-end via gpt-5.5** on the 6 real `~/git/neo` rollouts: 44 episodes → 77 admitted (all PROJECT, 34 failure / 43 pattern), idempotent re-run. The 34 failures confirm the `function_call_output` error fix (the original `exec_command_end`-only capture would have found zero).

**Test Configuration**: Python 3.14 / macOS / neo 0.20.3 (openai, gpt-5.5)

## Checklist

- [x] Follows project code style
- [x] Self-reviewed (+ @neo and @linus reviewed — both caught that errors live in `function_call_output`, not `exec_command_end` which is absent from all 6 neo rollouts; Neo caught the synthetic review-wrapper leak)
- [x] Documentation updated (`docs/solutions/transcript-ingestion.md`)
- [x] No new warnings
- [x] New and existing tests pass locally

## Additional Notes

Three live sources now: Claude Code (project), Codex (project), CAR (global). Cursor and other tools are future adapters behind the same interface, built when their real transcripts are available to verify against.