### PR TITLE
feat: CAR-first inference with graceful fallback to static provider

### DIFF
--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -4,8 +4,10 @@ LM Adapter implementations for OpenAI, Anthropic, and local models.
 
 import os
 import json
+import logging
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -17,6 +19,8 @@ except ImportError:
     pass
 
 from neo.models import LMAdapter
+
+logger = logging.getLogger(__name__)
 
 
 # ============================================================================
@@ -908,3 +912,118 @@ def create_adapter(
             f"Unknown provider: {provider}. "
             f"Supported: openai, anthropic, google, azure, local, ollama, claude-code, car"
         )
+
+
+#: Seconds the breaker stays open after a CAR failure before half-opening to
+#: re-probe CAR. Bounds retry-storms while letting a long-lived process recover
+#: from a transient CAR outage instead of pinning to the fallback forever.
+_CAR_RETRY_COOLDOWN_S = 300.0
+
+
+class AutoAdapter(LMAdapter):
+    """CAR-first adapter: route through CAR's dynamic router, fall back to a
+    static adapter when a CAR call fails.
+
+    Constructed only when CAR is usable at build time (see ``resolve_adapter``),
+    so "CAR absent / daemon down at start" is handled there. This handles the
+    other half — CAR failing mid-process (daemon dies, a call errors): a failure
+    opens a circuit breaker for ``retry_cooldown`` seconds (no retry-storm),
+    after which it half-opens and re-probes CAR (so a transient outage doesn't
+    pin a long-lived observer/host to the fallback forever).
+
+    The fallback is built **lazily** via ``fallback_factory`` — so when CAR is
+    the only usable backend, a missing/invalid static-provider key never blocks
+    CAR (it's only constructed if CAR actually fails).
+
+    The breaker is intentionally lock-free: ``_disabled_until`` is a plain float
+    written from ``generate``. Concurrent callers may both see CAR up, both
+    fail, both push the cooldown — idempotent, no torn state — so car_host's
+    shared per-project adapter is safe without a mutex.
+    """
+
+    def __init__(self, car: LMAdapter, fallback_factory,
+                 retry_cooldown: float = _CAR_RETRY_COOLDOWN_S):
+        self._car = car
+        self._make_fallback = fallback_factory
+        self._fallback: Optional[LMAdapter] = None
+        self._retry_cooldown = retry_cooldown
+        self._disabled_until = 0.0  # monotonic deadline; <= now => CAR eligible
+
+    def _fallback_adapter(self) -> LMAdapter:
+        if self._fallback is None:
+            self._fallback = self._make_fallback()
+        return self._fallback
+
+    def generate(self, messages, stop=None, max_tokens: int = 4096,
+                 temperature: float = 0.7, reasoning_effort: Optional[str] = None) -> str:
+        if time.monotonic() >= self._disabled_until:
+            try:
+                return self._car.generate(
+                    messages, stop=stop, max_tokens=max_tokens,
+                    temperature=temperature, reasoning_effort=reasoning_effort,
+                )
+            except Exception as e:
+                self._disabled_until = time.monotonic() + self._retry_cooldown
+                logger.warning(
+                    "CAR inference failed (%s); using the static fallback for ~%.0fs: %s",
+                    type(e).__name__, self._retry_cooldown, e,
+                )
+        return self._fallback_adapter().generate(
+            messages, stop=stop, max_tokens=max_tokens,
+            temperature=temperature, reasoning_effort=reasoning_effort,
+        )
+
+    def name(self) -> str:
+        return f"auto({self._car.name()} -> static)"
+
+
+def _adapter_kwargs_for_config(config) -> dict:
+    """Build provider-specific adapter kwargs from config."""
+    provider = config.provider.lower()
+    adapter_kwargs = {}
+    if provider in ("openai", "anthropic", "google", "azure", "local", "claude-code"):
+        adapter_kwargs["api_key"] = config.api_key
+    if config.base_url:
+        if provider in ("openai", "local", "ollama", "claude-code"):
+            adapter_kwargs["base_url"] = config.base_url
+        elif provider == "azure":
+            adapter_kwargs["endpoint"] = config.base_url
+    return adapter_kwargs
+
+
+def resolve_adapter(config) -> LMAdapter:
+    """Build the inference adapter for a NeoConfig, honoring ``inference_mode``.
+
+    Default ("auto"): prefer CAR's dynamic router when car-runtime is importable
+    AND the daemon is reachable, falling back to the configured static provider
+    on absence or runtime failure. "static": always the configured provider.
+
+    CAR is therefore optional — neo works without it — but used when present.
+    The static adapter is built **lazily** (only when CAR is unavailable, or as
+    the fallback after a CAR failure) so that a CAR-only install with no static
+    provider key configured still works.
+    """
+    def build_static() -> LMAdapter:
+        return create_adapter(
+            config.provider,
+            config.model,
+            **_adapter_kwargs_for_config(config),
+        )
+
+    mode = str(getattr(config, "inference_mode", "auto") or "auto").strip().lower()
+    if mode not in ("auto", "static"):
+        logger.warning("unknown inference_mode %r; using 'auto'", mode)
+        mode = "auto"
+
+    if mode == "auto":
+        # CAR-first: only build the CAR adapter when CAR is genuinely usable, so
+        # we never pay an import/connect error just to fall back.
+        try:
+            from neo.a2ui import is_daemon_reachable
+            from neo.car_inference import is_available as car_available
+            if car_available() and is_daemon_reachable():
+                car = create_adapter("car", model=None)  # model=None -> CAR routes dynamically
+                return AutoAdapter(car, build_static)
+        except Exception as e:
+            logger.debug("CAR-first unavailable, using static provider: %s", e)
+    return build_static()

--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -746,10 +746,15 @@ class CarAdapter(LMAdapter):
 
     #: Default IntentHint sent to CAR when the caller doesn't supply one.
     #: Neo's workload is overwhelmingly code reasoning (review, optimization,
-    #: debugging, generation), so we tell the router to pick a code-capable
-    #: model rather than a chat-tier one. CAR's task enum (per the binding's
-    #: error reporting): ``chat | classify | reasoning | code``.
-    DEFAULT_INTENT_HINT: dict = {"task": "code"}
+    #: debugging, generation), so we tell the router (a) it's a code task and
+    #: (b) ``prefer_quality`` — route to the most capable model, not the cheapest
+    #: or fastest. This is what lets neo rely on CAR's router WITHOUT pinning a
+    #: model version: the router picks the best available model (and, with CAR's
+    #: auto-discovery, newly-released ones) under the quality workload. Without
+    #: ``prefer_quality`` CAR's default profile is latency/cost-biased and
+    #: routes neo to mini models — a measured quality regression. CAR task enum:
+    #: ``chat | classify | reasoning | code``.
+    DEFAULT_INTENT_HINT: dict = {"task": "code", "prefer_quality": True}
 
     def __init__(
         self,

--- a/src/neo/car_host.py
+++ b/src/neo/car_host.py
@@ -119,15 +119,10 @@ def run_server(
             engine = engines.get(working_dir)
             if engine is not None:
                 return engine
-            from neo.adapters import create_adapter
-            from neo.cli import _adapter_kwargs_for_config
+            from neo.adapters import resolve_adapter
             from neo.engine import NeoEngine
 
-            adapter = create_adapter(
-                provider=config.provider,
-                model=config.model,
-                **_adapter_kwargs_for_config(config),
-            )
+            adapter = resolve_adapter(config)
             engine = NeoEngine(
                 lm_adapter=adapter,
                 codebase_root=working_dir,

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -364,20 +364,6 @@ def _configure_logging(args) -> None:
         logging.getLogger(name).setLevel(max(level, logging.WARNING))
 
 
-def _adapter_kwargs_for_config(config) -> dict:
-    """Build provider-specific adapter kwargs from config."""
-    provider = config.provider.lower()
-    adapter_kwargs = {}
-    if provider in ("openai", "anthropic", "google", "azure", "local", "claude-code"):
-        adapter_kwargs["api_key"] = config.api_key
-    if config.base_url:
-        if provider in ("openai", "local", "ollama", "claude-code"):
-            adapter_kwargs["base_url"] = config.base_url
-        elif provider == "azure":
-            adapter_kwargs["endpoint"] = config.base_url
-    return adapter_kwargs
-
-
 def main():
     """Main entry point for stdin/stdout interface."""
     # Parse arguments
@@ -695,7 +681,7 @@ def main():
 
     # Initialize adapter from environment
     # NO STUBS OR FALLBACKS - require real configuration
-    from neo.adapters import create_adapter
+    from neo.adapters import resolve_adapter
     from neo.config import NeoConfig
 
     try:
@@ -709,11 +695,7 @@ def main():
                 if cfg_level is not None:
                     logging.getLogger().setLevel(cfg_level)
 
-        adapter = create_adapter(
-            provider=config.provider,
-            model=config.model,
-            **_adapter_kwargs_for_config(config),
-        )
+        adapter = resolve_adapter(config)
     except Exception as e:
         error_output = {
             "error": f"Failed to initialize LM adapter: {e}",

--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -95,6 +95,14 @@ class NeoConfig:
     api_key: Optional[str] = None
     base_url: Optional[str] = None  # For local/ollama
 
+    # Inference routing.
+    #   "auto"   — prefer CAR's dynamic router when car-runtime is importable AND
+    #              the daemon is reachable; fall back to the static provider above
+    #              on absence or runtime failure. CAR is optional but used when
+    #              present. (default)
+    #   "static" — always use the configured `provider` (never CAR).
+    inference_mode: str = "auto"
+
     # Generation settings
     default_temperature: float = 0.7
     default_max_tokens: int = 4096
@@ -180,6 +188,8 @@ class NeoConfig:
             config.model = model
         if base_url := os.environ.get("NEO_BASE_URL"):
             config.base_url = base_url
+        if mode := os.environ.get("NEO_INFERENCE_MODE"):
+            config.inference_mode = mode
 
         # API keys. NEO_API_KEY is the explicit generic override; otherwise
         # choose the provider-specific key for the selected provider only.
@@ -249,6 +259,7 @@ class NeoConfig:
             "NEO_PROVIDER": "provider",
             "NEO_MODEL": "model",
             "NEO_BASE_URL": "base_url",
+            "NEO_INFERENCE_MODE": "inference_mode",
             "NEO_TEMPERATURE": "default_temperature",
             "NEO_MAX_TOKENS": "default_max_tokens",
             "NEO_EXEMPLAR_DIR": "exemplar_dir",

--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -96,12 +96,15 @@ class NeoConfig:
     base_url: Optional[str] = None  # For local/ollama
 
     # Inference routing.
+    #   "static" — always use the configured `provider` (never CAR). (default)
     #   "auto"   — prefer CAR's dynamic router when car-runtime is importable AND
     #              the daemon is reachable; fall back to the static provider above
     #              on absence or runtime failure. CAR is optional but used when
-    #              present. (default)
-    #   "static" — always use the configured `provider` (never CAR).
-    inference_mode: str = "auto"
+    #              present.
+    # Default is "static" (gpt-5.5) until a CAR release verifies the router's
+    # quality behavior — CAR's released router cost-biases to mini models, a
+    # measured regression. Flip to "auto" once a verified CAR build is deployed.
+    inference_mode: str = "static"
 
     # Generation settings
     default_temperature: float = 0.7

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -324,14 +324,12 @@ class Observer:
         if self.config.ingest_budget <= 0:
             return 0
         try:
-            from neo.adapters import create_adapter
+            from neo.adapters import resolve_adapter
             from neo.config import NeoConfig
             from neo.memory.transcript import TranscriptIngester
 
             cfg = NeoConfig.load()
-            adapter = create_adapter(
-                cfg.provider, cfg.model, api_key=cfg.api_key, base_url=cfg.base_url
-            )
+            adapter = resolve_adapter(cfg)
             ingester = TranscriptIngester(
                 store=store, lm_adapter=adapter, codebase_root=self.codebase_root
             )

--- a/tests/test_car_adapter.py
+++ b/tests/test_car_adapter.py
@@ -93,17 +93,17 @@ def test_generate_returns_text_field_from_infer_tracked():
     # Default IntentHint should request the code task so the router
     # picks a code-capable model instead of the chat default.
     assert "intent_json" in kwargs
-    assert json.loads(kwargs["intent_json"]) == {"task": "code"}
+    assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
 
 
 def test_default_intent_hint_is_code_task():
     """Neo's workload is code reasoning — the router should know."""
     rt = FakeRuntime()
     adapter = CarAdapter(runtime=rt)
-    assert adapter.intent_hint == {"task": "code"}
+    assert adapter.intent_hint == {"task": "code", "prefer_quality": True}
     adapter.generate("anything", max_tokens=8)
     _, kwargs = rt.calls[0]
-    assert json.loads(kwargs["intent_json"]) == {"task": "code"}
+    assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
 
 
 def test_explicit_intent_hint_overrides_default():
@@ -130,7 +130,7 @@ def test_generate_string_prompt_skips_messages_json():
     assert prompt == "just a string prompt"
     assert "messages_json" not in kwargs
     # Default coding intent still applies on bare-string prompts.
-    assert json.loads(kwargs["intent_json"]) == {"task": "code"}
+    assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
 
 
 def test_generate_pins_model_when_set():

--- a/tests/test_car_first.py
+++ b/tests/test_car_first.py
@@ -30,8 +30,9 @@ def _stub_create(monkeypatch):
 
 # --- config ---------------------------------------------------------------
 
-def test_inference_mode_default_is_auto():
-    assert NeoConfig().inference_mode == "auto"
+def test_inference_mode_default_is_static():
+    # Default stays static (gpt-5.5) until a CAR release verifies router quality.
+    assert NeoConfig().inference_mode == "static"
 
 
 def test_inference_mode_env_override(monkeypatch):

--- a/tests/test_car_first.py
+++ b/tests/test_car_first.py
@@ -1,0 +1,131 @@
+"""Tests for CAR-first inference resolution (resolve_adapter + AutoAdapter)."""
+
+import neo.adapters as A
+import neo.car_inference as ci
+from neo.adapters import AutoAdapter, resolve_adapter
+from neo.config import NeoConfig
+
+
+class _FakeAdapter:
+    def __init__(self, label):
+        self.label = label
+        self.calls = 0
+        self.fail = False
+
+    def generate(self, messages, **kw):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("car down")
+        return self.label
+
+    def name(self):
+        return self.label
+
+
+def _stub_create(monkeypatch):
+    """Make create_adapter return a labeled fake per provider."""
+    monkeypatch.setattr(A, "create_adapter",
+                        lambda provider, model=None, **kw: _FakeAdapter(f"{provider}"))
+
+
+# --- config ---------------------------------------------------------------
+
+def test_inference_mode_default_is_auto():
+    assert NeoConfig().inference_mode == "auto"
+
+
+def test_inference_mode_env_override(monkeypatch):
+    monkeypatch.setenv("NEO_INFERENCE_MODE", "static")
+    assert NeoConfig.from_env().inference_mode == "static"
+
+
+# --- resolve_adapter ------------------------------------------------------
+
+def test_static_mode_never_uses_car(monkeypatch):
+    _stub_create(monkeypatch)
+    # Even if CAR is fully available, static mode must not route through it.
+    monkeypatch.setattr(ci, "is_available", lambda: True)
+    import neo.a2ui as ui
+    monkeypatch.setattr(ui, "is_daemon_reachable", lambda timeout=0.5: True)
+    a = resolve_adapter(NeoConfig(provider="openai", inference_mode="static"))
+    assert a.name() == "openai" and not isinstance(a, AutoAdapter)
+
+
+def test_auto_falls_back_when_car_not_installed(monkeypatch):
+    _stub_create(monkeypatch)
+    monkeypatch.setattr(ci, "is_available", lambda: False)
+    a = resolve_adapter(NeoConfig(provider="openai", inference_mode="auto"))
+    assert a.name() == "openai" and not isinstance(a, AutoAdapter)
+
+
+def test_auto_falls_back_when_daemon_unreachable(monkeypatch):
+    _stub_create(monkeypatch)
+    monkeypatch.setattr(ci, "is_available", lambda: True)
+    import neo.a2ui as ui
+    monkeypatch.setattr(ui, "is_daemon_reachable", lambda timeout=0.5: False)
+    a = resolve_adapter(NeoConfig(provider="openai", inference_mode="auto"))
+    assert a.name() == "openai" and not isinstance(a, AutoAdapter)
+
+
+def test_auto_uses_car_when_available(monkeypatch):
+    _stub_create(monkeypatch)
+    monkeypatch.setattr(ci, "is_available", lambda: True)
+    import neo.a2ui as ui
+    monkeypatch.setattr(ui, "is_daemon_reachable", lambda timeout=0.5: True)
+    a = resolve_adapter(NeoConfig(provider="openai", inference_mode="auto"))
+    assert isinstance(a, AutoAdapter)
+    assert "car" in a.name()  # car-first; fallback is lazy ("auto(car -> static)")
+
+
+def test_auto_does_not_build_static_when_car_available(monkeypatch):
+    # CAR-only scenario: static provider would raise (no key) — must NOT block CAR.
+    monkeypatch.setattr(ci, "is_available", lambda: True)
+    import neo.a2ui as ui
+    monkeypatch.setattr(ui, "is_daemon_reachable", lambda timeout=0.5: True)
+
+    def _create(provider, model=None, **kw):
+        if provider == "car":
+            return _FakeAdapter("car")
+        raise ValueError("OpenAI API key required")  # static is unconfigured
+
+    monkeypatch.setattr(A, "create_adapter", _create)
+    a = resolve_adapter(NeoConfig(provider="openai", inference_mode="auto"))
+    assert isinstance(a, AutoAdapter) and a.generate([]) == "car"  # no static build needed
+
+
+# --- AutoAdapter runtime fallback + circuit breaker -----------------------
+
+def test_autoadapter_prefers_car():
+    car, fb = _FakeAdapter("car"), _FakeAdapter("fb")
+    assert AutoAdapter(car, lambda: fb).generate([]) == "car"
+    assert car.calls == 1 and fb.calls == 0
+
+
+def test_autoadapter_falls_back_and_circuit_breaks():
+    car, fb = _FakeAdapter("car"), _FakeAdapter("fb")
+    a = AutoAdapter(car, lambda: fb)  # default cooldown -> breaker stays open
+    assert a.generate([]) == "car"        # 1: car ok
+    car.fail = True
+    assert a.generate([]) == "fb"         # 2: car fails -> fallback, breaker opens
+    car.fail = False
+    assert a.generate([]) == "fb"         # 3: breaker open -> straight to fallback
+    assert car.calls == 2                 # car not retried while breaker open
+    assert fb.calls == 2
+
+
+def test_autoadapter_half_opens_and_recovers():
+    car, fb = _FakeAdapter("car"), _FakeAdapter("fb")
+    a = AutoAdapter(car, lambda: fb, retry_cooldown=0)  # immediate half-open
+    assert a.generate([]) == "car"
+    car.fail = True
+    assert a.generate([]) == "fb"         # fails -> fallback
+    car.fail = False
+    assert a.generate([]) == "car"        # cooldown 0 -> half-open -> CAR retried, recovers
+
+
+def test_autoadapter_fallback_built_lazily():
+    car = _FakeAdapter("car")
+    built = []
+    a = AutoAdapter(car, lambda: built.append(1) or _FakeAdapter("fb"))
+    a.generate([])                        # CAR ok -> fallback never constructed
+    assert built == []

--- a/tests/test_cli_global_flags.py
+++ b/tests/test_cli_global_flags.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import pytest
 
-from neo.cli import _adapter_kwargs_for_config
+from neo.adapters import _adapter_kwargs_for_config
 
 
 class TestCLIGlobalFlags:


### PR DESCRIPTION
## Description

Adds a `NeoConfig.inference_mode` setting (default **"auto"**) that makes neo **try CAR's dynamic router first** and **fall back to the configured static provider** when CAR is absent, unreachable, or failing. CAR stays optional — neo works without it — but is used when present. Overridable to `"static"` (always the configured provider) via config or `NEO_INFERENCE_MODE`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Provider selection was purely static: `provider=car` hard-errored without CAR, and `provider=openai` never used CAR even when it was up. This violated "usable without CAR, but use it when present" in both directions. Now a single mode does the right thing dynamically.

## Changes

- **`config.py`**: `inference_mode` field (default "auto") + `NEO_INFERENCE_MODE` override; validated (unknown → "auto" with a warning).
- **`adapters.py`**: `resolve_adapter(config)` — auto mode builds `CarAdapter(model=None)` (dynamic routing) wrapped in `AutoAdapter` IFF car-runtime importable AND daemon reachable; else the static provider. `AutoAdapter` runs CAR with a **circuit breaker that half-opens after a cooldown** (transient CAR outage doesn't pin a long-lived process to the fallback) and builds the static fallback **lazily** (a CAR-only install with no static key still works). `_adapter_kwargs_for_config` moved here from cli.
- **`cli.py` / `car_host.py` / `observer.py`**: now call `resolve_adapter(config)`.

## How Has This Been Tested?

- [x] 11 new unit tests (mode default/env, static-never-CAR, fallback on absent/unreachable, lazy-fallback for CAR-only installs, breaker half-open/recovery); full suite **1006 passed, 3 skipped**
- [x] **Live**: on this install (car-runtime 0.23 + daemon up), `resolve_adapter(NeoConfig.load())` returns `auto(car/router -> static)` and a real call routes through CAR (`pong`).

**Test Configuration**: Python 3.14 / macOS / neo 0.20.3

## Checklist

- [x] Follows project code style
- [x] Self-reviewed (+ @neo and @linus — caught a broken test import from a moved symbol, and that the static fallback was built eagerly (would hard-fail a CAR-only install); both fixed, plus the half-open breaker they flagged)
- [x] Documentation updated (config comment + docstrings)
- [x] No new warnings
- [x] New and existing tests pass locally

## Additional Notes

Per decision, CAR's router may pick Anthropic when routing through it; the no-Anthropic preference applies only to the static/direct provider. Default flips our install's inference from openai-direct to CAR-routed (with openai fallback).