### PR TITLE
fix: purge cold eviction-orphan tombstones on cold start

### DIFF
--- a/src/neo/memory/context.py
+++ b/src/neo/memory/context.py
@@ -197,7 +197,10 @@ class ContextAssembler:
                     f"- **{fact.subject}** ({fact.kind.value}, confidence={conf:.2f}): "
                     f"{_body_for_context(fact, 200)}"
                 )
-                # Inline change annotation
+                # Inline change annotation. The `in old_lookup` guard is
+                # load-bearing, not a style choice: purge_dead_facts reclaims
+                # cold superseded tombstones, so a live fact's `supersedes` may
+                # dangle. Membership-test, never a bare subscript.
                 if fact.supersedes and fact.supersedes in old_lookup:
                     old = old_lookup[fact.supersedes]
                     line += f" (changed from: {_body_for_context(old, 80)})"

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1220,35 +1220,38 @@ class FactStore:
         return our_facts + new_from_disk
 
     def purge_dead_facts(self) -> int:
-        """Remove invalid facts whose chain resolves to a valid successor.
+        """Remove invalid facts that have gone cold (untouched 30+ days).
 
-        Follows supersession chains to find the terminal fact. If the chain
-        ends at a valid fact and the invalid fact hasn't been accessed in
-        30+ days, it's safe to purge.
+        Any fact that is invalid AND hasn't been accessed in 30+ days is
+        dropped, regardless of how it died. Two distinct death modes both
+        qualify:
+
+          - *superseded* tombstones (``superseded_by`` set, replaced by a
+            better fact), and
+          - *eviction orphans* — facts marked invalid by
+            ``_enforce_scope_limit`` for low quality, which carry **no**
+            ``superseded_by`` pointer.
+
+        This mirrors the on-demand compactor (``neo memory prune`` →
+        ``subcommands._compact_fact_file``); keeping the two in sync ensures
+        cold-start maintenance reclaims the same facts the manual command
+        does. The 30-day age gate is the safety net — recently-invalidated
+        facts are retained for contrast in retrieval.
+
+        Previously this additionally required the supersession chain to
+        resolve to a valid successor, which silently retained every eviction
+        orphan forever (they never resolve to a valid fact), letting inactive
+        projects' fact files bloat with dead rows indefinitely.
 
         Returns the number of purged facts.
         """
-        facts_by_id = {f.id: f for f in self._facts}
         now = time.time()
         thirty_days = 30 * 86400
-
-        def chain_resolves_to_valid(fact: Fact) -> bool:
-            """Follow superseded_by chain; return True if it ends at a valid fact."""
-            seen: set[str] = set()
-            current = fact
-            while current and not current.is_valid:
-                if current.id in seen:
-                    return False  # cycle
-                seen.add(current.id)
-                current = facts_by_id.get(current.superseded_by)  # type: ignore[arg-type]
-            return current is not None and current.is_valid
 
         before = len(self._facts)
         self._facts = [
             f for f in self._facts
-            if f.is_valid
-            or (now - f.metadata.last_accessed) < thirty_days
-            or not chain_resolves_to_valid(f)
+            if f.is_valid or (now - f.metadata.last_accessed) < thirty_days
         ]
         purged = before - len(self._facts)
         if purged:

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -631,11 +631,32 @@ class TestPurgeDeadFacts:
         assert store.purge_dead_facts() == 0
         assert len(store._facts) == 2
 
-    def test_keeps_invalid_without_valid_successor(self, store):
-        """Invalid facts whose chain doesn't resolve to a valid fact should be kept."""
+    def test_purges_cold_eviction_orphan(self, store):
+        """Eviction orphans (invalid, no successor) cold for 30+ days are purged.
+
+        Regression test: cold-start purge previously retained these forever
+        because their supersession chain never resolves to a valid fact, so
+        inactive projects' fact files bloated indefinitely.
+        """
+        orphan = Fact(id="orph", subject="Orphan", body="B", is_valid=False,
+                      metadata=FactMetadata(last_accessed=time.time() - 90 * 86400))
+        store._facts.append(orphan)
+        assert store.purge_dead_facts() == 1
+        assert len(store._facts) == 0
+
+    def test_purges_cold_broken_chain_tombstone(self, store):
+        """Invalid facts pointing at a missing successor are also purged when cold."""
         orphan = Fact(id="orph", subject="Orphan", body="B", is_valid=False,
                       superseded_by="gone",
                       metadata=FactMetadata(last_accessed=time.time() - 90 * 86400))
+        store._facts.append(orphan)
+        assert store.purge_dead_facts() == 1
+        assert len(store._facts) == 0
+
+    def test_keeps_recent_eviction_orphan(self, store):
+        """Recently-evicted orphans (< 30 days) are kept for contrast."""
+        orphan = Fact(id="orph", subject="Orphan", body="B", is_valid=False,
+                      metadata=FactMetadata(last_accessed=time.time() - 5 * 86400))
         store._facts.append(orphan)
         assert store.purge_dead_facts() == 0
         assert len(store._facts) == 1


### PR DESCRIPTION
## Description

Cold-start `purge_dead_facts()` never reclaimed tombstones created by scope-cap **eviction**, so per-project fact files accumulated dead rows indefinitely (observed locally: 62–81% dead, files up to 46 MB).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

## Related Issue

N/A — analysis captured inline below.

## Motivation and Context

There were two purge paths with **inconsistent retention rules**:

1. **`FactStore.purge_dead_facts()`** (`store.py:1222`) — runs on every cold start (`store.py:210`). Kept any invalid fact unless its supersession chain `chain_resolves_to_valid` (ended at a valid successor).
2. **`_compact_fact_file()`** — the `neo memory prune` subcommand (`subcommands.py:262`). Drops any fact that is `is_valid=False` **and** untouched ≥30 days. No successor requirement.

`_enforce_scope_limit()` (`store.py:1135`) evicts low-quality over-cap facts by setting `is_valid=False` with **no `superseded_by` pointer** — discarded, not replaced. For these "eviction orphans," `chain_resolves_to_valid` always returns `False`, so `purge_dead_facts` retained them **forever**; cold-start purge only ever collected genuinely *superseded* facts.

Evidence from a live install (2026-06-17):

| project file | tombstones | superseded (purgeable) | orphan-evicted (never purged) |
|---|---|---|---|
| `5f73…` (46 MB) | 1,248 | 155 | **1,093** |
| `fcbc43…` (neo itself, 15 MB) | 486 | 59 | **427** |

`fcbc43…` is neo's own project — cold-started constantly — yet 427 eviction tombstones never cleared.

**Fix:** align `purge_dead_facts()` with the compactor — a dead fact untouched ≥30 days is purgeable regardless of supersession status. The 30-day age gate is the safety net (recent facts retained for contrast); the chain check added nothing on top of it except the orphan leak.

**Safety:** the only consumer of dead-row pointers is the `context.py` inline `(changed from: X)` annotation, guarded by an `in old_lookup` membership test, so a now-dangling `supersedes` pointer fails safe (annotation skipped, no crash). Added a comment there to keep that guard load-bearing. Reviewed by the Linus agent — verdict: ship as-is.

## How Has This Been Tested?

- [x] `tests/test_fact_store.py::TestPurgeDeadFacts` — inverted the test that encoded the bug (`test_keeps_invalid_without_valid_successor` → `test_purges_cold_eviction_orphan`); added broken-chain and recent-orphan coverage
- [x] Full `tests/test_fact_store.py` (77) + all context-assembly tests pass

**Test Configuration**:
- Python version: 3.13 / 3.14
- OS: macOS (darwin 25.5.0)
- Neo version: 0.21.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The pre-commit suite currently fails on an **unrelated** live CAR-daemon connectivity timeout (`ws://127.0.0.1:9100`), not on this change; the fact_store and context suites pass. As a separate cleanup, `test_live_oversized_prompt_does_not_crash_adapter` could accept a connection/daemon-timeout error string (it currently only allows `rpc`/`context`/`token`).
