### PR TITLE
fix: detect outcomes for review/analysis suggestions (close the feedback loop)

### DIFF
--- a/src/neo/memory/outcomes.py
+++ b/src/neo/memory/outcomes.py
@@ -374,6 +374,12 @@ class OutcomeTracker:
             if prev.project_id != self.project_id:
                 continue
 
+            # Merge fact-id links for EVERY same-project session, including
+            # those with no git changes: review-only / UNVERIFIED outcomes
+            # (below) resolve their linked fact through this map, and those
+            # sessions never reach the git-matching branch.
+            merged_fact_ids.update(prev.suggestion_fact_ids)
+
             changed_files = self._get_changed_files_since(prev.timestamp)
             if not changed_files:
                 continue
@@ -386,15 +392,16 @@ class OutcomeTracker:
                 f"{len(prev.suggestion_fact_ids)} linked fact(s)"
             )
 
-            outcomes = self._match_to_suggestions(changed_files, prev)
-            all_outcomes.extend(outcomes)
-            merged_fact_ids.update(prev.suggestion_fact_ids)
+            all_outcomes.extend(self._match_to_suggestions(changed_files, prev))
 
-        # Also check for non-git outcomes (implicit acceptance)
-        non_git = self._detect_non_git_outcomes(sessions)
-        all_outcomes.extend(non_git)
-        for prev in sessions:
-            merged_fact_ids.update(prev.suggestion_fact_ids)
+        # Also check for non-git outcomes (weak implicit acceptance for paths the
+        # git matcher can't see: review docs, /dev/null, docs/).
+        all_outcomes.extend(self._detect_non_git_outcomes(sessions))
+
+        # Collapse to one outcome per file path, strongest signal winning, so a
+        # path that is BOTH git-changed and non-git-trackable doesn't double-bump
+        # the same fact from a single user action.
+        all_outcomes = self._dedup_outcomes(all_outcomes)
 
         # Clear processed sessions from the log
         if clear_processed and (all_outcomes or sessions):
@@ -488,14 +495,78 @@ class OutcomeTracker:
             except OSError:
                 pass
 
+    @staticmethod
+    def _is_review_only_path(file_path: str) -> bool:
+        """True for suggestion paths that are review/analysis output, not a code edit.
+
+        neo's review workload (Linus/Liotta/code-review) emits suggestions whose
+        ``file_path`` names a review *document* (``REVIEW.md``,
+        ``ARCHITECTURAL_REVIEW.md``), lives under a ``review``/``reviews`` path
+        segment, or is the exact ``NO_MODIFY`` / ``/NO_MODIFY`` sentinel. These
+        never correspond to a tracked file, so the git-diff outcome matcher is
+        structurally blind to them — yet they are the most common kind of
+        suggestion. Recognising them lets ``_detect_non_git_outcomes`` emit the
+        same weak-acceptance signal it already gives ``docs/`` and ``/dev/null``
+        suggestions.
+
+        Deliberately narrow to avoid matching real source files (e.g.
+        ``src/review_service.py`` is NOT review-only).
+        """
+        fp = (file_path or "").strip()
+        if not fp:
+            return False
+        if fp in ("NO_MODIFY", "/NO_MODIFY"):
+            return True
+        low = fp.lower()
+        base = low.rsplit("/", 1)[-1]
+        # A markdown review document: REVIEW.md, ARCHITECTURAL_REVIEW.md, ...
+        if base.endswith(".md") and "review" in base:
+            return True
+        # A 'review'/'reviews' directory segment, or an explicit *-review dir
+        # (architecture-review/, code-review/). Only directory segments count,
+        # so review_service.py (a real file) is excluded.
+        dir_segments = low.strip("/").split("/")[:-1]
+        if any(seg in ("review", "reviews") or seg.endswith("-review")
+               for seg in dir_segments):
+            return True
+        return False
+
+    def _dedup_outcomes(self, outcomes: list[Outcome]) -> list[Outcome]:
+        """One outcome per (normalized) file path, strongest signal winning.
+
+        The git matcher's ACCEPTED/MODIFIED/INDEPENDENT are verified, stronger
+        signals than the non-git weak-acceptance heuristic (UNVERIFIED). When a
+        suggestion path is both git-changed and non-git-trackable (e.g. a
+        committed ``docs/`` or review ``.md``), the git outcome wins — preventing
+        a double success_count/confidence bump on one fact from a single user
+        action. Collapsing by path also bounds per-session-in-batch accrual: the
+        same review path queued across several unprocessed sessions counts once.
+        """
+        priority = {
+            OutcomeType.ACCEPTED: 3,
+            OutcomeType.MODIFIED: 3,
+            OutcomeType.INDEPENDENT: 2,
+            OutcomeType.UNVERIFIED: 1,
+        }
+        best: dict[str, Outcome] = {}
+        for o in outcomes:
+            key = self._normalize_path(o.file_path)
+            cur = best.get(key)
+            if cur is None or priority.get(o.outcome_type, 0) > priority.get(cur.outcome_type, 0):
+                best[key] = o
+        return list(best.values())
+
     def _detect_non_git_outcomes(
         self, sessions: list[SessionRecord]
     ) -> list[Outcome]:
         """Detect implicit acceptance for suggestions that can't be tracked by git.
 
-        When a suggestion targets /dev/null or a docs path, and the user invoked
-        neo again afterward, that's a weak acceptance signal — the user continued
-        working rather than abandoning the tool.
+        When a suggestion targets /dev/null, a docs path, or review/analysis
+        output (see _is_review_only_path), and the user invoked neo again
+        afterward, that's a weak acceptance signal — the user continued working
+        rather than abandoning the tool. Review/analysis is neo's most common
+        workload and is invisible to the git-diff matcher, so without this the
+        bulk of suggestions never produce any outcome signal.
 
         All sessions in the log are from PREVIOUS invocations (the current
         session hasn't been written yet when detect_outcomes runs), so we
@@ -516,14 +587,18 @@ class OutcomeTracker:
                     file_path in non_trackable
                     or normalized.startswith("docs/")
                     or "/docs/" in normalized
+                    or self._is_review_only_path(file_path)
                 )
                 if not is_non_trackable:
                     continue
 
-                # User came back and ran neo again — weak acceptance signal
+                # User came back and ran neo again — weak acceptance signal.
+                # Use the raw recorded path (falling back to normalized) so
+                # detect_implicit_feedback resolves the linked
+                # suggestion_fact_id, which is keyed by the path as recorded.
                 outcomes.append(Outcome(
                     outcome_type=OutcomeType.UNVERIFIED,
-                    file_path=normalized,
+                    file_path=file_path or normalized,
                     diff_summary="",
                     suggestion_description=sugg.get("description", ""),
                     suggestion_confidence=sugg.get("confidence", 0.0),

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -308,6 +308,81 @@ class TestDetectOutcomesIndependent:
         assert OutcomeType.INDEPENDENT in types
 
 
+class TestReviewOnlyOutcomes:
+    """Review/analysis suggestions are neo's most common workload but can't be
+    tracked by git diff; they should still yield a weak UNVERIFIED signal."""
+
+    @pytest.mark.parametrize("path", [
+        "/REVIEW.md", "REVIEW.md", "/ARCHITECTURAL_REVIEW.md",
+        "/review/commit-abc-architecture.md", "/architecture-review/foo.md",
+        "NO_MODIFY", "/NO_MODIFY", "/docs/reviews/feedback.md",
+    ])
+    def test_review_path_classified_review_only(self, path):
+        assert OutcomeTracker._is_review_only_path(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "src/review_service.py", "src/foo.py", "review_notes.txt",
+        "src/reviewer.py", "", "/", "N/A",
+    ])
+    def test_real_paths_not_review_only(self, path):
+        assert OutcomeTracker._is_review_only_path(path) is False
+
+    def test_review_suggestion_emits_unverified(self, tracker):
+        """A persisted review-doc suggestion produces an UNVERIFIED outcome
+        even when no files changed in git, preserving the linked fact id."""
+        suggestions = [FakeSuggestion(
+            file_path="/REVIEW.md", description="Linus review", confidence=0.87,
+        )]
+        tracker.save_session(
+            suggestions, "review my diff",
+            suggestion_fact_ids={"/REVIEW.md": "factR"},
+        )
+        with patch.object(tracker, "_get_changed_files_since", return_value=set()):
+            outcomes, fact_ids = tracker.detect_outcomes()
+
+        assert len(outcomes) == 1
+        assert outcomes[0].outcome_type == OutcomeType.UNVERIFIED
+        assert outcomes[0].file_path == "/REVIEW.md"
+        assert fact_ids == {"/REVIEW.md": "factR"}
+
+    def test_git_match_wins_over_non_git_no_double_count(self, tracker):
+        """A docs path that is BOTH git-changed and non-git-trackable must
+        yield ONE outcome (the stronger git signal), not an ACCEPTED + a
+        duplicate UNVERIFIED that double-bumps the same fact."""
+        diff = "+new line"
+        suggestions = [FakeSuggestion(
+            file_path="docs/architecture.md", description="Update arch doc",
+            confidence=0.8, unified_diff=diff,
+        )]
+        tracker.save_session(suggestions, "doc it")
+
+        with patch.object(tracker, "_get_changed_files_since",
+                          return_value={"docs/architecture.md"}), \
+             patch.object(tracker, "_get_file_diff_since", return_value=diff):
+            outcomes, _ = tracker.detect_outcomes()
+
+        paths = [o.file_path for o in outcomes]
+        assert paths.count("docs/architecture.md") == 1
+        assert outcomes[0].outcome_type in (OutcomeType.ACCEPTED, OutcomeType.MODIFIED)
+        assert all(o.outcome_type != OutcomeType.UNVERIFIED for o in outcomes)
+
+    def test_same_review_path_across_sessions_counts_once(self, tracker):
+        """The same review path queued in multiple unprocessed sessions
+        collapses to a single weak-acceptance outcome."""
+        for _ in range(3):
+            tracker.save_session(
+                [FakeSuggestion(file_path="/REVIEW.md", description="review", confidence=0.8)],
+                "review",
+                suggestion_fact_ids={"/REVIEW.md": "factR"},
+            )
+        with patch.object(tracker, "_get_changed_files_since", return_value=set()):
+            outcomes, _ = tracker.detect_outcomes()
+
+        review_outcomes = [o for o in outcomes if o.file_path == "/REVIEW.md"]
+        assert len(review_outcomes) == 1
+        assert review_outcomes[0].outcome_type == OutcomeType.UNVERIFIED
+
+
 class TestGitNotAvailable:
     def test_graceful_when_git_missing(self, tracker):
         suggestions = [FakeSuggestion(file_path="src/foo.py")]


### PR DESCRIPTION
## Description

Close the outcome-detection feedback loop for neo's most common workload — review/analysis — which was structurally invisible to the git-diff outcome matcher, causing memory to plateau instead of grow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Outcome detection only bumps a fact's `success_count` on **ACCEPTED**, which fires only when a suggestion's `file_path` matches a git-changed file. But review/analysis suggestions (Linus/Liotta/code-review — neo's dominant use) carry synthetic paths (`/REVIEW.md`, `/ARCHITECTURAL_REVIEW.md`, `/NO_MODIFY`, `/review/*`) that can never match a git change.

Measured on the live install:
- Only **3 / 123** facts in the neo project ever had `success_count > 0`
- **73%** of valid facts were never re-accessed
- **85%** (43/51) of all recorded suggestions carried a non-git-trackable path

Consequence: facts never met the probation promotion bar (`success_count >= 2` or `access_count >= 2`) and were pruned within the 3-day stale window → adds ≈ prunes → memory churned instead of accumulating.

## What changed

- New `_is_review_only_path` classifier (deliberately narrow: directory segments named `review`/`reviews`/`*-review`, a `.md` basename containing "review", or the exact `NO_MODIFY` sentinel — so real files like `src/review_service.py` are excluded).
- `_detect_non_git_outcomes` extended to emit its existing weak **UNVERIFIED** acceptance signal for review-only paths (UNVERIFIED bumps a *linked* fact's `success_count` + confidence per the store-side contract). Emits the raw recorded path so `detect_implicit_feedback` resolves the linked `suggestion_fact_id`.
- Fixed a **pre-existing double-count** (widened by the above): a path both git-changed and non-git-trackable produced ACCEPTED *and* a duplicate UNVERIFIED on the same fact in one run. New `_dedup_outcomes` collapses to one outcome per normalized path, strongest signal winning; also bounds per-session-in-batch UNVERIFIED accrual.
- Consolidated the `suggestion_fact_ids` merge into the project-filtered loop so no-git-change sessions still register their links.

Reviewed by the Linus agent (verdict: ship with changes — all required changes applied).

## How Has This Been Tested?

- [x] `TestReviewOnlyOutcomes`: classifier positive/negative cases; end-to-end UNVERIFIED emission; git-match-wins-no-double-count; same-path-across-sessions-counts-once
- [x] Verified against live session data: all 53 previously-blind review suggestions now classified review-only
- [x] `tests/test_outcomes.py` + `tests/test_fact_store.py` — 150 pass

**Test Configuration**:
- Python version: 3.13
- OS: macOS
- Neo version: 0.21.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This is the cheap, immediate fix (weak "user continued working" signal). The durable follow-up — mining real accept/modify signals from ingested transcripts — is scoped separately.
