### PR TITLE
feat: mine weak acceptance signals from transcripts via a durable ledger

### DIFF
--- a/src/neo/memory/outcomes.py
+++ b/src/neo/memory/outcomes.py
@@ -34,6 +34,17 @@ SESSIONS_DIR = Path.home() / ".neo" / "sessions"
 MAX_INDEPENDENT_OUTCOMES = 5
 CODE_OVERLAP_ACCEPTED_THRESHOLD = 0.8
 
+# Durable suggestion ledger + transcript outcome mining.
+# The session log is consumed (cleared) by git-based outcome detection on the
+# next invocation, so it can't be relied on for asynchronous, transcript-driven
+# correlation. The ledger is an append-only record of linked suggestions that
+# the async miner (TranscriptIngester.mine_suggestion_outcomes) drains on its
+# own cadence, independent of how soon neo is re-invoked.
+OUTCOME_CORRELATION_WINDOW_SECONDS = 2 * 3600  # episode must follow a suggestion within 2h
+OUTCOME_CORRELATION_SIMILARITY = 0.6           # min cosine(description, episode) to call it a match
+MAX_MINED_OUTCOMES_PER_CYCLE = 20              # bound observer work + confidence churn per cycle
+SUGGESTION_LEDGER_TTL_DAYS = 30                # ledger entries older than this are compacted away
+
 
 class OutcomeType(enum.Enum):
     """Classification of what the user did after a neo suggestion."""
@@ -217,6 +228,7 @@ class OutcomeTracker:
         self.project_id = project_id
         self._session_path = self._get_session_path()
         self._session_log_path = self._get_session_log_path()
+        self._suggestion_ledger_path = self._get_suggestion_ledger_path()
 
     def _get_session_path(self) -> Optional[Path]:
         if not self.project_id:
@@ -230,6 +242,108 @@ class OutcomeTracker:
             return None
         SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
         return SESSIONS_DIR / f"session_log_{self.project_id}.jsonl"
+
+    def _get_suggestion_ledger_path(self) -> Optional[Path]:
+        """Path for the durable, append-only suggestion ledger.
+
+        Distinct from the session log: the session log is consumed by
+        git-based outcome detection, while the ledger persists until the
+        transcript outcome miner drains it (or it ages out), so asynchronous
+        correlation never races the request path.
+        """
+        if not self.project_id:
+            return None
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        return SESSIONS_DIR / f"suggestion_ledger_{self.project_id}.jsonl"
+
+    def append_suggestion_ledger(
+        self, suggestions: list, prompt: str,
+        suggestion_fact_ids: Optional[dict[str, str]] = None,
+    ) -> None:
+        """Append linked suggestions to the durable ledger for later mining.
+
+        Only suggestions that carry a linked ``fact_id`` are recorded — the
+        miner can only reinforce a fact it can resolve. Best-effort: a write
+        failure must never break the request path.
+        """
+        path = self._suggestion_ledger_path
+        if not path or not suggestion_fact_ids:
+            return
+        ts = time.time()
+        rows = []
+        for s in suggestions:
+            file_path = getattr(s, "file_path", "")
+            fid = suggestion_fact_ids.get(file_path) if file_path else None
+            if not fid:
+                continue
+            rows.append({
+                "id": f"{ts:.6f}:{fid}:{file_path}",
+                "ts": ts,
+                "project_id": self.project_id,
+                "prompt": prompt[:200],
+                "file_path": file_path,
+                "description": getattr(s, "description", "")[:500],
+                "confidence": getattr(s, "confidence", 0.0),
+                "fact_id": fid,
+            })
+        if not rows:
+            return
+        try:
+            with open(path, "a") as f:
+                for r in rows:
+                    f.write(json.dumps(r) + "\n")
+        except OSError as e:
+            logger.warning(f"Failed to append suggestion ledger: {e}")
+
+    def load_suggestion_ledger(self) -> list[dict]:
+        """Return all current ledger entries (skipping any corrupt lines)."""
+        path = self._suggestion_ledger_path
+        if not path or not path.exists():
+            return []
+        entries: list[dict] = []
+        try:
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError as e:
+            logger.warning(f"Failed to read suggestion ledger: {e}")
+        return entries
+
+    def compact_suggestion_ledger(
+        self, *, drop_ids: Optional[set] = None,
+        max_age_days: int = SUGGESTION_LEDGER_TTL_DAYS,
+    ) -> None:
+        """Rewrite the ledger, dropping mined/expired entries to keep it bounded.
+
+        Load→filter→tmp→replace. The replace is atomic (no corruption), but this
+        is unlocked: a save_session append (request process) landing between the
+        load and the replace is lost. That's acceptable here — the mined signal
+        is weak and plentiful, so losing the occasional suggestion is harmless;
+        not worth a cross-process file lock.
+        """
+        path = self._suggestion_ledger_path
+        if not path or not path.exists():
+            return
+        drop_ids = drop_ids or set()
+        cutoff = time.time() - max_age_days * 86400
+        kept = [
+            e for e in self.load_suggestion_ledger()
+            if e.get("id") not in drop_ids and float(e.get("ts", 0) or 0) >= cutoff
+        ]
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        try:
+            with open(tmp, "w") as f:
+                for e in kept:
+                    f.write(json.dumps(e) + "\n")
+            tmp.replace(path)
+        except OSError as e:
+            logger.warning(f"Failed to compact suggestion ledger: {e}")
 
     def save_session(
         self,
@@ -282,6 +396,10 @@ class OutcomeTracker:
             if log_path:
                 with open(log_path, "a") as f:
                     f.write(json.dumps(asdict(session)) + "\n")
+
+            # Durable ledger for async transcript outcome mining (survives the
+            # session-log clearing done by git-based outcome detection).
+            self.append_suggestion_ledger(suggestions, prompt, suggestion_fact_ids)
 
             logger.info(
                 f"Saved session: {len(records)} suggestion(s), "

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1100,6 +1100,35 @@ class FactStore:
 
         return stats
 
+    def apply_mined_outcomes(self, fact_ids: list[str]) -> int:
+        """Weakly reinforce facts linked to transcript-mined suggestion matches.
+
+        ``fact_ids`` come from ``TranscriptIngester.mine_suggestion_outcomes``,
+        which correlates a past suggestion to a later episode by *topic
+        similarity* — evidence the suggestion's area recurred in subsequent work,
+        not verified diff-overlap acceptance. So each match earns the same weak
+        delta neo gives its other non-git signals (UNVERIFIED): +0.1 confidence
+        and a success_count bump — enough to promote a fact off probation —
+        never the strong +0.2 the git matcher reserves for proven acceptance.
+        The ledger records the suggestion→fact link directly, so this applies by
+        fact_id without the path lookup ``detect_implicit_feedback`` needs.
+        Returns the number of facts updated.
+        """
+        by_id = {f.id: f for f in self._facts}
+        applied = 0
+        for fid in fact_ids:
+            fact = by_id.get(fid)
+            if fact is None or not fact.is_valid:
+                continue
+            fact.metadata.confidence = min(1.0, fact.metadata.confidence + 0.1)
+            fact.metadata.success_count += 1
+            update_effectiveness(fact, outcome="better")
+            fact.metadata.last_accessed = time.time()
+            applied += 1
+        if applied:
+            self.save()
+        return applied
+
     @property
     def entries(self) -> list[Fact]:
         """Backward-compatible access to all facts."""

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -22,6 +22,7 @@ live in the ingester that consumes these episodes.
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import re
@@ -30,10 +31,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Iterator, Optional, Protocol
 
+from neo.math_utils import cosine_similarity
 from neo.memory.io_utils import atomic_write_json
 from neo.memory.metrics import record as metrics_record
 from neo.memory.models import FactKind, FactScope, Provenance
-from neo.memory.outcomes import SESSIONS_DIR
+from neo.memory.outcomes import (
+    MAX_MINED_OUTCOMES_PER_CYCLE,
+    OUTCOME_CORRELATION_SIMILARITY,
+    OUTCOME_CORRELATION_WINDOW_SECONDS,
+    SESSIONS_DIR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +311,24 @@ def _parse_json(text: str) -> Optional[dict]:
 
 def _normalize_ws(s: str) -> str:
     return " ".join(s.split())
+
+
+def _episode_epoch(ts: str) -> Optional[float]:
+    """Parse an Episode timestamp to epoch seconds.
+
+    Transcript timestamps are ISO-8601 (``2026-06-17T15:37:23.572Z``); some
+    sources may already store epoch floats. Returns None if unparseable.
+    """
+    if not ts:
+        return None
+    try:
+        return float(ts)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -696,6 +721,7 @@ class TranscriptIngester:
                 return True
             return bool(should_stop is not None and should_stop())
 
+        all_episodes: list[Episode] = []
         for source in self.sources:
             if stop_now():
                 break
@@ -705,6 +731,7 @@ class TranscriptIngester:
             except Exception as e:  # one bad source must not sink the others
                 logger.warning("transcript: source %s collect failed: %s", source.name, e)
                 continue
+            all_episodes.extend(episodes)
             new = [e for e in episodes if e.anchor_uuid not in consumed]
             stats["episodes_total"] += len(episodes)
             stats["episodes_new"] += len(new)
@@ -715,9 +742,115 @@ class TranscriptIngester:
                 consumed.add(ep.anchor_uuid)
                 self._persist_consumed(source, consumed)  # advance only after durable
                 stats["episodes_processed"] += 1
-        if stats["episodes_processed"]:
+
+        # Correlate neo's own past suggestions (durable ledger) against all
+        # collected episodes to derive real accept/modify outcomes. Best-effort:
+        # a failure here must not sink the lesson-ingest stats above.
+        try:
+            stats["outcomes_mined"] = self.mine_suggestion_outcomes(all_episodes)
+        except Exception as e:
+            logger.warning("transcript: suggestion-outcome mining failed: %s", e)
+            stats["outcomes_mined"] = 0
+
+        if stats["episodes_processed"] or stats.get("outcomes_mined"):
             metrics_record("transcript_ingest", **stats)
         return stats
+
+    # -- Stage D: suggestion-outcome mining ------------------------------
+    def _match_episode(self, description: str, candidates: list) -> Optional["Episode"]:
+        """Return the candidate episode whose text best matches a suggestion
+        description above the similarity floor, or None.
+
+        Uses the store's embedder (Jina) — same vectors as fact retrieval, so no
+        extra model is loaded and no LM call is made. Cost is
+        O(entries × candidates) embed lookups per cycle; bounded because the
+        ledger is compacted every cycle and matching is capped at
+        MAX_MINED_OUTCOMES_PER_CYCLE.
+        """
+        embed = getattr(self._store, "_embed_text", None)
+        if embed is None or not description or not candidates:
+            return None
+        try:
+            dvec = embed(description)
+        except Exception:
+            return None
+        if dvec is None:
+            return None
+        best, best_sim = None, OUTCOME_CORRELATION_SIMILARITY
+        for ep in candidates:
+            text = " ".join([ep.ask, *ep.assistant_text])[:_MAX_ASST_CHARS]
+            if not text.strip():
+                continue
+            try:
+                evec = embed(text)
+            except Exception:
+                continue
+            if evec is None:
+                continue
+            sim = cosine_similarity(dvec, evec)
+            if sim >= best_sim:
+                best, best_sim = ep, sim
+        return best
+
+    def mine_suggestion_outcomes(self, episodes: list) -> int:
+        """Weakly reinforce facts whose past suggestion recurs in later work.
+
+        The durable-ledger, semantically-correlated complement to
+        OutcomeTracker._detect_non_git_outcomes: a suggestion whose description
+        matches a *subsequent* transcript episode is evidence the suggestion's
+        area recurred in later work — weak implicit acceptance, not verified
+        diff-overlap. So a match earns the same weak UNVERIFIED delta as neo's
+        other non-git signals (see store.apply_mined_outcomes), NOT the strong
+        ACCEPTED reward the git matcher reserves for proven acceptance. The
+        episode does not contain neo's suggestion text, so this is topic
+        recurrence — deliberately not classified as accept-vs-modify (a matched
+        episode's tool errors are its own process noise, unrelated to the
+        suggestion's fate). Entries that find no match before their correlation
+        window lapses are dropped so the ledger stays bounded. Returns the number
+        of facts reinforced.
+        """
+        tracker = getattr(self._store, "_outcome_tracker", None)
+        if tracker is None or not hasattr(tracker, "load_suggestion_ledger"):
+            return 0
+        ledger = tracker.load_suggestion_ledger()
+        if not ledger:
+            return 0
+
+        dated = [(t, e) for e in episodes if (t := _episode_epoch(e.timestamp)) is not None]
+        now = time.time()
+        matched_fact_ids: list[str] = []
+        done_ids: set = set()
+
+        # Ledger order is append order (oldest first) — the right drain order,
+        # since oldest entries are closest to window-expiry.
+        for entry in ledger:
+            if len(matched_fact_ids) >= MAX_MINED_OUTCOMES_PER_CYCLE:
+                break
+            eid = entry.get("id", "")
+            fid = entry.get("fact_id", "")
+            ets = float(entry.get("ts", 0) or 0)
+            if not fid:
+                done_ids.add(eid)
+                continue
+            window_end = ets + OUTCOME_CORRELATION_WINDOW_SECONDS
+            cands = [e for t, e in dated if ets <= t <= window_end]
+            if self._match_episode(entry.get("description", ""), cands) is not None:
+                matched_fact_ids.append(fid)
+                done_ids.add(eid)
+            elif now > window_end:
+                done_ids.add(eid)  # window lapsed with no match — give up
+
+        # Compact BEFORE applying, and unconditionally:
+        #  - before, because apply_mined_outcomes is NOT idempotent (it bumps the
+        #    monotonic success_count); a crash between apply and compaction would
+        #    re-mine the entry and double-count. Dropping the ledger entry first
+        #    means a crash loses a (noisy, plentiful) signal rather than
+        #    corrupting the counter that gates community contribution.
+        #  - unconditionally, so the TTL cutoff inside compact_suggestion_ledger
+        #    always runs; gating it on done_ids let a ledger of young-unmatched
+        #    entries grow without the backstop ever firing.
+        tracker.compact_suggestion_ledger(drop_ids=done_ids)
+        return self._store.apply_mined_outcomes(matched_fact_ids) if matched_fact_ids else 0
 
     def _watermark_path(self, source) -> Optional[Path]:
         if source.scope == FactScope.PROJECT:

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -83,6 +83,43 @@ class TestSaveAndLoadSession:
         assert tracker._load_previous_session() is None
 
 
+class TestSuggestionLedger:
+    """The durable, append-only ledger that survives session-log clearing and
+    feeds the async transcript outcome miner."""
+
+    def test_save_session_appends_linked_suggestions(self, tracker):
+        tracker.save_session(
+            [FakeSuggestion(file_path="/REVIEW.md", description="review verdict", confidence=0.8)],
+            "review my diff",
+            suggestion_fact_ids={"/REVIEW.md": "factR"},
+        )
+        led = tracker.load_suggestion_ledger()
+        assert len(led) == 1
+        assert led[0]["fact_id"] == "factR"
+        assert led[0]["file_path"] == "/REVIEW.md"
+        assert led[0]["ts"] > 0
+
+    def test_ledger_skips_unlinked_suggestions(self, tracker):
+        # No suggestion_fact_ids → nothing to reinforce → nothing recorded.
+        tracker.save_session([FakeSuggestion(file_path="src/x.py")], "prompt")
+        assert tracker.load_suggestion_ledger() == []
+
+    def test_compact_drops_expired_and_specified(self, tracker):
+        import json
+        now = time.time()
+        path = tracker._suggestion_ledger_path
+        rows = [
+            {"id": "fresh", "ts": now, "fact_id": "f1", "file_path": "/A", "description": "a"},
+            {"id": "old", "ts": now - 40 * 86400, "fact_id": "f2", "file_path": "/B", "description": "b"},
+            {"id": "drop", "ts": now, "fact_id": "f3", "file_path": "/C", "description": "c"},
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+        tracker.compact_suggestion_ledger(drop_ids={"drop"}, max_age_days=30)
+        remaining = {e["id"] for e in tracker.load_suggestion_ledger()}
+        assert remaining == {"fresh"}  # 'old' aged out, 'drop' explicitly removed
+
+
 class TestSessionRecordWithFactIds:
     def test_save_and_load_with_fact_ids(self, tracker):
         suggestions = [

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -605,3 +605,118 @@ def test_codex_source_skips_agent_history_wrapper(tmp_path):
     ])
     eps = CodexSource(codebase_root="/work/proj", sessions_dir=sdir).collect_episodes()
     assert len(eps) == 1 and eps[0].ask == "a genuine ask"
+
+
+# --------------------------------------------------------------------------
+# Stage D: suggestion-outcome mining (durable ledger <-> transcript episodes)
+# --------------------------------------------------------------------------
+
+import time as _time
+from dataclasses import dataclass as _dataclass
+
+import numpy as _np
+
+from neo.memory.outcomes import OUTCOME_CORRELATION_WINDOW_SECONDS
+
+
+@_dataclass
+class _Sugg:
+    file_path: str = ""
+    description: str = ""
+    confidence: float = 0.8
+    unified_diff: str = ""
+    code_block: str = ""
+
+
+@pytest.fixture
+def mining_store(tmp_path, monkeypatch):
+    """Real FactStore + OutcomeTracker, both rooted in tmp, with a deterministic
+    embedder so correlation is controllable (vector keyed on 'validation')."""
+    monkeypatch.setenv("NEO_METRICS", "off")
+    import neo.memory.outcomes as out_mod
+    import neo.memory.store as store_mod
+    monkeypatch.setattr(store_mod, "FACTS_DIR", tmp_path / "facts")
+    monkeypatch.setattr(out_mod, "SESSIONS_DIR", tmp_path / "sessions")
+    st = store_mod.FactStore(codebase_root="/tmp/proj_mining_test", eager_init=False)
+
+    def fake_embed(text):
+        return _np.array([1.0, 0.0]) if "validation" in (text or "").lower() else _np.array([0.0, 1.0])
+
+    monkeypatch.setattr(st, "_embed_text", fake_embed)
+    return st
+
+
+def _linked_review_fact(st, body="apply the validation fix"):
+    fact = st.add_fact(subject="Validation review", body=body,
+                       kind=FactKind.REVIEW, scope=FactScope.PROJECT, confidence=0.5)
+    st._outcome_tracker.append_suggestion_ledger(
+        [_Sugg(file_path="/REVIEW.md", description=body, confidence=0.8)],
+        "review", {"/REVIEW.md": fact.id},
+    )
+    return fact
+
+
+def test_mine_match_is_weak_reinforcement(mining_store):
+    st = mining_store
+    fact = _linked_review_fact(st)
+    ts = st._outcome_tracker.load_suggestion_ledger()[0]["ts"]
+    ep = Episode(session_id="s", anchor_uuid="a", last_uuid="b",
+                 timestamp=str(ts + 60), ask="please apply the validation fix", errors=[])
+
+    ing = TranscriptIngester(store=st, lm_adapter=None, sources=[])
+    applied = ing.mine_suggestion_outcomes([ep])
+
+    assert applied == 1
+    # Weak UNVERIFIED delta: +1 success (enough to promote off probation) and
+    # +0.1 confidence — never the strong +0.2 reserved for verified acceptance.
+    assert fact.metadata.success_count == 1
+    assert fact.metadata.confidence == pytest.approx(0.6)
+    assert st._outcome_tracker.load_suggestion_ledger() == []  # entry consumed
+
+
+def test_mine_ignores_episode_errors(mining_store):
+    """Tool errors in the matched episode are the assistant's process noise, not
+    a 'modify' signal about the suggestion — the reinforcement is unchanged."""
+    st = mining_store
+    fact = _linked_review_fact(st)
+    ts = st._outcome_tracker.load_suggestion_ledger()[0]["ts"]
+    ep = Episode(session_id="s", anchor_uuid="a", last_uuid="b",
+                 timestamp=str(ts + 60), ask="please apply the validation fix",
+                 errors=["TypeError: boom"])
+
+    ing = TranscriptIngester(store=st, lm_adapter=None, sources=[])
+    applied = ing.mine_suggestion_outcomes([ep])
+
+    assert applied == 1
+    assert fact.metadata.success_count == 1          # still reinforced, not demoted
+    assert fact.metadata.confidence == pytest.approx(0.6)
+
+
+def test_mine_no_match_keeps_entry_until_window_lapses(mining_store):
+    st = mining_store
+    fact = _linked_review_fact(st)
+    ts = st._outcome_tracker.load_suggestion_ledger()[0]["ts"]
+    # An unrelated episode within the window must not match.
+    ep = Episode(session_id="s", anchor_uuid="a", last_uuid="b",
+                 timestamp=str(ts + 60), ask="completely unrelated chatter", errors=[])
+
+    ing = TranscriptIngester(store=st, lm_adapter=None, sources=[])
+    assert ing.mine_suggestion_outcomes([ep]) == 0
+    assert fact.metadata.success_count == 0
+    assert len(st._outcome_tracker.load_suggestion_ledger()) == 1  # still pending
+
+
+def test_mine_gives_up_after_window(mining_store):
+    import json
+    st = mining_store
+    fact = _linked_review_fact(st)
+    # Backdate the ledger entry past the correlation window: no episode will come.
+    path = st._outcome_tracker._suggestion_ledger_path
+    entry = st._outcome_tracker.load_suggestion_ledger()[0]
+    entry["ts"] = _time.time() - OUTCOME_CORRELATION_WINDOW_SECONDS - 100
+    path.write_text(json.dumps(entry) + "\n")
+
+    ing = TranscriptIngester(store=st, lm_adapter=None, sources=[])
+    assert ing.mine_suggestion_outcomes([]) == 0
+    assert st._outcome_tracker.load_suggestion_ledger() == []  # expired, dropped
+    assert fact.metadata.success_count == 0


### PR DESCRIPTION
## Description

Add an asynchronous, higher-targeting outcome signal for neo's learning loop: correlate neo's own past suggestions against later AI-tool transcript episodes, via a **durable suggestion ledger**. Follow-up to #104 (merged), the durable counterpart to that cheap fix.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

The git-diff outcome matcher and the review-path heuristic (#104) both fire only at neo invocation time, off neo's **session log** — which the request path clears on the next run. So an observer-side correlator on a 300s cadence would miss any suggestion followed by another neo run within the interval. This decouples the signal from that race.

## What changed

- **Durable ledger** (`OutcomeTracker.save_session` → `suggestion_ledger_<project>.jsonl`, append-only): records linked suggestions (`fact_id` + description + ts), independent of session-log clearing. New `append/load/compact` methods.
- **Miner** (`TranscriptIngester.mine_suggestion_outcomes`, runs in the async observer after lesson-ingest): for each ledger entry, find transcript episodes within a 2h window whose embedded text (reusing Jina vectors — no LM call) matches the suggestion description ≥0.6 cosine. A match → **weak UNVERIFIED** reinforcement of the linked fact.
- **`store.apply_mined_outcomes`**: applies the weak delta (+0.1 confidence, +1 `success_count` — enough to promote a fact off probation) by `fact_id`.
- **Bounded ledger**: entries dropped when matched or window-lapsed; TTL + mined compaction every cycle; capped at 20 mined/cycle.

**Defaults:** correlation window 2h; embedding pass observer-only (off the request hot path).

## Design decisions (from Linus review — verdict: ship with changes, all applied)

1. **Weak signal, not strong.** The episode doesn't contain neo's suggestion text, so a ≥0.6 match is *topic recurrence*, not verified acceptance. Paying the strong +0.2/accept reward for that would manufacture false-accepted signals — the exact failure this subsystem exists to avoid — so the mined match earns the weak UNVERIFIED delta. The accept-vs-modify-by-tool-errors classification was dropped (a matched episode's errors are its own process noise).
2. **Compact before apply, unconditionally.** `apply_mined_outcomes` bumps the monotonic `success_count` (not idempotent), so the ledger entry is dropped *before* applying — a crash loses a noisy signal rather than double-counting. Compaction is unconditional so the TTL backstop always runs.
3. Documented the unlocked append-vs-rewrite race (acceptable for a weak, plentiful signal) and the embedding-cost/bounded-ledger dependency.

## How Has This Been Tested?

- [x] `TestSuggestionLedger`: append, skip-unlinked, compact (TTL + explicit drop)
- [x] Stage-D miner tests: weak reinforcement on match, errors-ignored, no-match-keeps-entry, give-up-after-window
- [x] 223 pass across `test_transcript` / `test_outcomes` / `test_fact_store` / `test_context_assembly`; ruff clean

**Test Configuration**:
- Python version: 3.13
- OS: macOS
- Neo version: 0.21.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Supersedes #105 (auto-closed when #104's branch was deleted). Takes effect on the live install only after a release/reinstall (pipx venv), same as #104.
