### PR TITLE
test: fix ruff E402 in transcript tests (unblocks v0.22.0 publish)

### DIFF
--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,10 +1,14 @@
 """Tests for Claude Code transcript parsing (Stage A) and ingestion (B/C)."""
 
 import json
+import time as _time
+from dataclasses import dataclass as _dataclass
 
+import numpy as _np
 import pytest
 
 from neo.memory.models import FactKind, FactScope
+from neo.memory.outcomes import OUTCOME_CORRELATION_WINDOW_SECONDS
 from neo.memory.transcript import (
     CarSource,
     CodexSource,
@@ -610,13 +614,6 @@ def test_codex_source_skips_agent_history_wrapper(tmp_path):
 # --------------------------------------------------------------------------
 # Stage D: suggestion-outcome mining (durable ledger <-> transcript episodes)
 # --------------------------------------------------------------------------
-
-import time as _time
-from dataclasses import dataclass as _dataclass
-
-import numpy as _np
-
-from neo.memory.outcomes import OUTCOME_CORRELATION_WINDOW_SECONDS
 
 
 @_dataclass


### PR DESCRIPTION
The v0.22.0 publish workflow failed at ci-check: the Stage-D miner-test imports were appended at the bottom of `tests/test_transcript.py`, tripping ruff E402 under CI's `ruff check src/ tests/` (I only linted `src/` locally). Moved the imports to the top import block. Test-only, no behavior change. `ruff check src/ tests/` and the transcript suite pass.