### PR TITLE
Release v0.22.1: merge-on-save for all scopes (concurrency fix)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.22.1] - 2026-06-17
+
+### Fixed
+
+A concurrency fix that protects the learning loop's integrity — found by exercising 0.22.0 end-to-end.
+
+- **`FactStore.save()` no longer lets the observer and a request-path invocation clobber each other's facts.** The async observer and an interactive `neo` run are separate processes writing the same `facts_project_<id>.json`. `save()` previously merged only the *global* scope on write and overwrote the *project*/*org* scopes with its in-memory snapshot — so whichever process saved last erased the other's just-added facts. Observed live: a `neo` invocation's linked reasoning fact was erased moments after creation because the observer (which had loaded the file earlier) saved its transcript facts on top, leaving the suggestion ledger pointing at a fact that no longer existed and silently breaking outcome linkage. The merge-on-save (re-read the file, preserve facts present on disk but absent from memory) now runs for **all** scopes, so a concurrent writer's additions survive. Two guards keep it correct and fast: facts physically removed this session (`_deleted_ids`, i.e. `purge_dead_facts`) are never resurrected by the re-read, so purge isn't undone; and an mtime fast-path skips the re-read+parse entirely when no other process has written since (avoiding a multi-MB re-parse on every `add_fact`). Same-id concurrent *field* edits (e.g. a `success_count` bump) remain last-writer-wins — a documented weak-signal residual that needs locking to close. (`memory/store.py`)
+
 ## [0.22.0] - 2026-06-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.22.0"
+version = "0.22.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -157,6 +157,15 @@ class FactStore:
         self._facts: list[Fact] = []
         self._cap_pending = False  # Set by _cap_independent_facts(save=False)
 
+        # Concurrency bookkeeping for the merge-on-save (see save()).
+        # _deleted_ids: facts this instance physically removed (purge/prune) —
+        #   excluded from the merge so a re-read can't resurrect them.
+        # _scope_mtimes: last mtime_ns we observed per scope file, so the merge
+        #   skips its re-read+parse when nothing else has written since (the
+        #   common single-process case; avoids re-parsing a multi-MB file per add).
+        self._deleted_ids: set[str] = set()
+        self._scope_mtimes: dict[str, int] = {}
+
         # Embedding model (lazy-initialized on first use to avoid slow startup)
         self._embedder = None
         self._embedder_initialized = False
@@ -1214,38 +1223,81 @@ class FactStore:
     def save(self) -> None:
         """Save facts to scoped JSON files.
 
-        Global facts use best-effort merge: re-reads the global file before
-        writing to preserve facts added by other FactStore instances since
-        load(). This is NOT concurrency-safe (no file locking). Neo is a
-        single-user CLI tool — concurrent writes are rare but possible if
-        multiple terminals invoke neo simultaneously. In that case, last
-        writer wins for same-ID facts, but cross-project additions survive.
+        EVERY scope file is written with a best-effort merge (not just global):
+        re-read the file and preserve any fact present on disk but absent from
+        memory, so a concurrent writer's *additions* survive. This matters most
+        for the PROJECT scope: the async observer and a request-path neo
+        invocation are separate processes writing the same
+        ``facts_project_<id>.json``. Without the merge, whichever saved last
+        clobbered the other's just-added facts — e.g. a neo invocation's linked
+        reasoning fact vanishing because the observer (which loaded the file
+        earlier) saved its own transcript facts on top, silently breaking the
+        outcome-linkage that feeds the learning loop.
+
+        NOT fully concurrency-safe: for the SAME fact id, the in-memory version
+        wins — only additions are merged, not concurrent *field edits* to a
+        shared fact. Concretely, a `success_count`/`confidence` bump applied by
+        the observer can be silently lost if a request-path process holds a
+        stale copy of that fact and saves later. That's a weak-signal loss (one
+        reinforcement), far less severe than losing a whole fact; closing it
+        needs file locking or a version vector and is out of scope here. Neo is
+        a single-user tool, so the dominant overlap is request-path vs observer
+        adding *different* facts, which this fully covers.
         """
-        global_facts = [f for f in self._facts if f.scope == FactScope.GLOBAL]
-        org_facts = [f for f in self._facts if f.scope == FactScope.ORG]
-        project_facts = [f for f in self._facts if f.scope == FactScope.PROJECT]
+        for path, scope in (
+            (self._global_path, FactScope.GLOBAL),
+            (self._org_path, FactScope.ORG),
+            (self._project_path, FactScope.PROJECT),
+        ):
+            if not path:
+                continue
+            scoped = [f for f in self._facts if f.scope == scope]
+            self._save_file(path, self._merge_on_save(path, scoped))
+            # Record the mtime we just wrote, so the next save can detect
+            # whether another process has written since (and skip the re-read).
+            mt = self._file_mtime(path)
+            if mt is not None:
+                self._scope_mtimes[str(path)] = mt
 
-        merged_global = self._merge_global_on_save(global_facts)
-        self._save_file(self._global_path, merged_global)
-        if self._org_path:
-            self._save_file(self._org_path, org_facts)
-        if self._project_path:
-            self._save_file(self._project_path, project_facts)
+    @staticmethod
+    def _file_mtime(path: "Path") -> Optional[int]:
+        """Return a file's mtime in ns, or None if it doesn't exist."""
+        try:
+            return path.stat().st_mtime_ns
+        except OSError:
+            return None
 
-    def _merge_global_on_save(self, our_facts: list[Fact]) -> list[Fact]:
-        """Best-effort merge: keep disk facts we don't have in memory.
+    def _merge_on_save(self, path: "Path", our_facts: list[Fact]) -> list[Fact]:
+        """Best-effort merge for one scope file: keep disk facts we don't have
+        in memory, so a concurrent writer's additions aren't clobbered.
 
-        Not concurrency-safe. Reduces data loss from sequential (not
-        simultaneous) cross-project saves, which is the common case.
+        Fast path: if the file's mtime is unchanged since we last wrote/loaded
+        it, no other process has touched it, so there is nothing to merge and we
+        skip the (potentially multi-MB) re-read+parse entirely. Same-id facts
+        keep the in-memory version. Facts this instance deliberately removed
+        this session (``_deleted_ids`` — purge) are never resurrected from disk,
+        so a re-read can't undo a deletion.
+
+        The fast path assumes the wall clock advanced between two processes'
+        writes. A same-nanosecond mtime collision across processes (clock not
+        monotonic) would skip a needed merge — a single-fact loss, self-healing
+        on either side's next load(). Not realistic for a single-user tool.
         """
-        disk_facts = self._load_file(self._global_path)
+        current = self._file_mtime(path)
+        if current is not None and current == self._scope_mtimes.get(str(path)):
+            return our_facts  # we were the last writer; disk has nothing new
+
+        disk_facts = self._load_file(path)
         if not disk_facts:
             return our_facts
 
         our_ids = {f.id for f in our_facts}
-        new_from_disk = [f for f in disk_facts if f.id not in our_ids]
+        new_from_disk = [
+            f for f in disk_facts
+            if f.id not in our_ids and f.id not in self._deleted_ids
+        ]
         if new_from_disk:
-            logger.info(f"Preserved {len(new_from_disk)} global fact(s) from disk")
+            logger.info(f"Preserved {len(new_from_disk)} fact(s) from {path.name} on save")
         return our_facts + new_from_disk
 
     def purge_dead_facts(self) -> int:
@@ -1277,13 +1329,18 @@ class FactStore:
         now = time.time()
         thirty_days = 30 * 86400
 
-        before = len(self._facts)
-        self._facts = [
-            f for f in self._facts
-            if f.is_valid or (now - f.metadata.last_accessed) < thirty_days
-        ]
-        purged = before - len(self._facts)
+        kept, removed_ids = [], []
+        for f in self._facts:
+            if f.is_valid or (now - f.metadata.last_accessed) < thirty_days:
+                kept.append(f)
+            else:
+                removed_ids.append(f.id)
+        purged = len(removed_ids)
         if purged:
+            self._facts = kept
+            # Record physical deletions so the merge-on-save can't resurrect
+            # them from another process's stale copy on disk.
+            self._deleted_ids.update(removed_ids)
             self.save()
             logger.info(f"Purged {purged} dead invalid facts")
         return purged
@@ -1404,11 +1461,17 @@ class FactStore:
     def load(self) -> None:
         """Load facts from all scoped files and merge."""
         self._facts = []
-        self._facts.extend(self._load_file(self._global_path))
-        if self._org_path:
-            self._facts.extend(self._load_file(self._org_path))
-        if self._project_path:
-            self._facts.extend(self._load_file(self._project_path))
+        # Fresh load = fresh concurrency bookkeeping: forget prior deletions
+        # and re-baseline the per-file mtimes we compare against on save.
+        self._deleted_ids = set()
+        self._scope_mtimes = {}
+        for path in (self._global_path, self._org_path, self._project_path):
+            if not path:
+                continue
+            self._facts.extend(self._load_file(path))
+            mt = self._file_mtime(path)
+            if mt is not None:
+                self._scope_mtimes[str(path)] = mt
         logger.info(f"FactStore: Loaded {len(self._facts)} facts")
         # Cap runs in-memory only; save is deferred to initialize()
         self._cap_independent_facts(save=False)

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -1640,3 +1640,73 @@ class TestConstraintEmbeddings:
 
         constraints = [f for f in s._facts if f.kind == FactKind.CONSTRAINT]
         assert any(f.metadata.source_file == str(agents_md) for f in constraints)
+
+
+class TestConcurrentSaveMerge:
+    """save() must not let one process clobber facts another just added —
+    the observer-vs-request-path clobber that erased linked reasoning facts."""
+
+    def test_project_addition_survives_concurrent_save(self, store, tmp_path):
+        A = store  # "process A", project = testproj1234
+        # "process B" loads the (currently empty) project file.
+        B = FactStore(codebase_root=str(tmp_path))
+
+        # A adds a project fact and persists it to disk.
+        fx = A.add_fact(subject="Fact X from process A", body="b",
+                        kind=FactKind.REVIEW, scope=FactScope.PROJECT)
+        # B, which never saw X, adds its own fact and saves on top.
+        fy = B.add_fact(subject="Fact Y from process B", body="b",
+                        kind=FactKind.REVIEW, scope=FactScope.PROJECT)
+
+        # A fresh load from disk must contain BOTH.
+        C = FactStore(codebase_root=str(tmp_path))
+        ids = {f.id for f in C._facts}
+        assert fx.id in ids, "process A's project fact was clobbered by B's save"
+        assert fy.id in ids
+
+    def test_global_addition_still_survives_concurrent_save(self, store, tmp_path):
+        # Regression guard that generalizing the merge didn't break the
+        # original global-scope behavior.
+        A = store
+        B = FactStore(codebase_root=str(tmp_path))
+        fx = A.add_fact(subject="Global X", body="b", kind=FactKind.PATTERN,
+                        scope=FactScope.GLOBAL)
+        fy = B.add_fact(subject="Global Y", body="b", kind=FactKind.PATTERN,
+                        scope=FactScope.GLOBAL)
+        C = FactStore(codebase_root=str(tmp_path))
+        ids = {f.id for f in C._facts}
+        assert fx.id in ids and fy.id in ids
+
+    def test_purge_not_resurrected_by_merge(self, store, tmp_path):
+        """A physically purged fact must stay gone — the merge-on-save re-read
+        must not re-append it from the about-to-be-overwritten file."""
+        f = store.add_fact(subject="dead fact", body="b", kind=FactKind.REVIEW,
+                           scope=FactScope.PROJECT)
+        f.is_valid = False
+        f.metadata.last_accessed = time.time() - 40 * 86400  # cold (>30d)
+        store.save()
+        assert store.purge_dead_facts() == 1
+        # Reload from disk: the purged fact must not be present.
+        C = FactStore(codebase_root=str(tmp_path))
+        assert f.id not in {x.id for x in C._facts}, "purged fact was resurrected by merge"
+
+    def test_concurrent_purge_not_resurrected_via_merge(self, store, tmp_path):
+        """When another process writes the file (forcing a merge re-read), a
+        fact this process purged must still be excluded via _deleted_ids."""
+        A = store
+        dead = A.add_fact(subject="cold dead", body="b", kind=FactKind.REVIEW,
+                          scope=FactScope.PROJECT)  # disk now has `dead`
+        # B loads (sees `dead`) and writes its own fact -> changes file mtime,
+        # so A's next save can no longer take the mtime fast-path.
+        B = FactStore(codebase_root=str(tmp_path))
+        fy = B.add_fact(subject="B fact", body="b", kind=FactKind.REVIEW,
+                        scope=FactScope.PROJECT)
+        # A purges `dead`; its save must re-read (mtime changed) yet not
+        # resurrect `dead`, while still preserving B's addition.
+        dead.is_valid = False
+        dead.metadata.last_accessed = time.time() - 40 * 86400
+        assert A.purge_dead_facts() == 1
+        C = FactStore(codebase_root=str(tmp_path))
+        ids = {x.id for x in C._facts}
+        assert dead.id not in ids, "purged fact resurrected through concurrent-merge re-read"
+        assert fy.id in ids, "concurrent process's fact was lost"


### PR DESCRIPTION
## Description

Release **v0.22.1**. A concurrency fix that protects the learning loop's integrity — found by exercising 0.22.0 end-to-end against the live install.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The async observer and an interactive `neo` invocation are separate processes writing the same `facts_project_<id>.json`. `save()` merged only the **global** scope on write and overwrote **project**/**org** with its in-memory snapshot — so whichever process saved last erased the other's just-added facts.

Caught live while exercising 0.22.0: a `neo` invocation's linked reasoning fact (`de5ff03e…`) was erased seconds after creation because the observer (which had loaded the file earlier) saved its transcript facts on top — leaving the suggestion ledger pointing at a fact that no longer existed and silently breaking the outcome linkage 0.22.0 had just added.

## What changed

- Generalize the existing global id-union **merge-on-save** to **all** scopes: re-read the file at save time and preserve facts on disk but absent from memory, so a concurrent writer's additions survive.
- **`_deleted_ids` guard:** facts physically removed this session (`purge_dead_facts` — the only physical-removal path; prune/demote/evict/cap invalidate in place) are excluded from the re-read union, so the merge can't resurrect them and undo a purge (which would reintroduce the tombstone bloat #102 fixed).
- **mtime fast-path:** skip the re-read+parse entirely when the file is unchanged since we last wrote it — avoids a multi-MB re-parse on every `add_fact`.
- Same-id concurrent *field* edits (e.g. a `success_count` bump) remain last-writer-wins — a documented weak-signal residual that needs locking to close.

Reviewed by Linus across two rounds (v1 verdict: needs work → two mandatory fixes applied; v2 verdict: ship as-is, both fixes independently verified against every deletion path).

## How Has This Been Tested?

- [x] `TestConcurrentSaveMerge`: added-fact survives a concurrent save (project + global); purged fact not resurrected (single-process and via the concurrent re-read path)
- [x] 313 pass across store/outcomes/transcript/context/serialization/models/import-health; `ruff check src/ tests/` clean
- [x] Distributions build clean (`neo_reasoner-0.22.1`)

**Test Configuration**:
- Python: 3.13 / OS: macOS / Neo: 0.22.1

## Checklist

- [x] Code follows project style
- [x] Self-review performed; hard-to-follow areas commented
- [x] Tests added that prove the fix
- [x] New and existing unit tests pass locally
- [x] CHANGELOG and all version files updated
