### PR TITLE
Release v0.22.2: field-reconcile same-id facts (close the field-edit race)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.22.2] - 2026-06-17
+
+### Fixed
+
+- **Concurrent `success_count`/confidence reinforcements are no longer lost to last-writer-wins.** 0.22.1's merge-on-save preserved a concurrent writer's *added* facts but, for a fact present in both processes' memory, kept the in-memory copy wholesale — so a `success_count`/confidence bump one process committed could be erased when the other saved a stale copy. `_merge_on_save` now field-reconciles a same-id fact (`_reconcile_fact`) instead of overwriting: `success_count`/`access_count` (strictly monotonic) take the max of both copies, and confidence is lifted to the disk value only when that side recorded more successes. Crucially the reconcile keeps OUR record as the base, so our own independent edits (a MODIFIED confidence demotion, a supersession pointer, tags, effectiveness) survive — an "adopt the disk record wholesale" approach would have discarded them. A fact we invalidated this session still always wins (never resurrected). Remaining residual: when both processes independently edit confidence, resolution is deliberately best-effort (favoring recorded reinforcement) — lossless reconciliation there would require a per-fact version counter or a file lock. (`memory/store.py`)
+
 ## [0.22.1] - 2026-06-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.22.1"
+version = "0.22.2"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.22.1"
+__version__ = "0.22.2"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1234,15 +1234,26 @@ class FactStore:
         earlier) saved its own transcript facts on top, silently breaking the
         outcome-linkage that feeds the learning loop.
 
-        NOT fully concurrency-safe: for the SAME fact id, the in-memory version
-        wins — only additions are merged, not concurrent *field edits* to a
-        shared fact. Concretely, a `success_count`/`confidence` bump applied by
-        the observer can be silently lost if a request-path process holds a
-        stale copy of that fact and saves later. That's a weak-signal loss (one
-        reinforcement), far less severe than losing a whole fact; closing it
-        needs file locking or a version vector and is out of scope here. Neo is
-        a single-user tool, so the dominant overlap is request-path vs observer
-        adding *different* facts, which this fully covers.
+        Same-id facts are field-reconciled, not blindly overwritten (see
+        ``_reconcile_fact``), keeping our record as the base. What's preserved
+        vs. resolved lossily, stated plainly:
+          - ``success_count`` / ``access_count``: preserved losslessly (max of
+            both — they're strictly monotonic).
+          - ``confidence``: resolved LOSSILY when both sides edited it. We lift
+            to the higher value only when the disk side had more successes;
+            otherwise ours stands. Reconstructing intent from two confidence
+            scalars (e.g. our MODIFIED demotion vs. a peer's ACCEPTED bump)
+            needs a per-fact version counter or a file lock — neither is here,
+            so this is a deliberate best-effort, favoring recorded reinforcement.
+          - validity: a fact WE invalidated this session always wins; a peer's
+            invalidation does not propagate mid-session (self-heals on cold start).
+
+        Side effect: reconcile mutates our in-memory metadata in place, so this
+        process's monotonic counters rise to match a concurrent writer after a
+        save — intended (next decision uses the merged truth). The only residual
+        loss is a sub-microsecond torn-write window (two processes' read→write
+        interleaving with no file lock), self-healing on the next save/load —
+        acceptable for a single-user tool.
         """
         for path, scope in (
             (self._global_path, FactScope.GLOBAL),
@@ -1273,10 +1284,15 @@ class FactStore:
 
         Fast path: if the file's mtime is unchanged since we last wrote/loaded
         it, no other process has touched it, so there is nothing to merge and we
-        skip the (potentially multi-MB) re-read+parse entirely. Same-id facts
-        keep the in-memory version. Facts this instance deliberately removed
-        this session (``_deleted_ids`` — purge) are never resurrected from disk,
-        so a re-read can't undo a deletion.
+        skip the (potentially multi-MB) re-read+parse entirely. Facts this
+        instance deliberately removed this session (``_deleted_ids`` — purge) are
+        never resurrected from disk, so a re-read can't undo a deletion.
+
+        Same-id reconciliation: when a fact exists in BOTH memory and disk, the
+        monotonic learning signals are reconciled rather than blindly
+        overwritten (``_reconcile_fact``), so a ``success_count``/confidence bump
+        another process committed isn't lost to last-writer-wins. A fact we
+        invalidated this session always wins (never resurrected as valid).
 
         The fast path assumes the wall clock advanced between two processes'
         writes. A same-nanosecond mtime collision across processes (clock not
@@ -1291,14 +1307,55 @@ class FactStore:
         if not disk_facts:
             return our_facts
 
+        disk_by_id = {f.id: f for f in disk_facts}
         our_ids = {f.id for f in our_facts}
+        reconciled = [
+            self._reconcile_fact(f, disk_by_id[f.id]) if f.id in disk_by_id else f
+            for f in our_facts
+        ]
         new_from_disk = [
             f for f in disk_facts
             if f.id not in our_ids and f.id not in self._deleted_ids
         ]
         if new_from_disk:
             logger.info(f"Preserved {len(new_from_disk)} fact(s) from {path.name} on save")
-        return our_facts + new_from_disk
+        return reconciled + new_from_disk
+
+    @staticmethod
+    def _reconcile_fact(ours: Fact, disk: Fact) -> Fact:
+        """Field-merge a same-id fact present in both memory and disk so a
+        concurrent process's learning gains aren't lost — WITHOUT discarding our
+        own independent edits.
+
+        Always keeps OURS as the base record (so a confidence demotion we
+        applied, a supersession pointer we set, tags, effectiveness, etc. all
+        survive) and reconciles only specific fields:
+          1. If we invalidated it this session, our version wins outright —
+             never resurrect a fact we dropped (validity isn't monotonic; ours
+             is the intentional state). NOTE: a *peer's* invalidation does not
+             propagate to us here (same stance as _deleted_ids — we can't tell a
+             peer's intentional prune from a fact we simply never loaded); it
+             self-heals when this process also prunes on a later cold start.
+          2. success_count / access_count are strictly monotonic (only ever
+             incremented), so take the max of both sides — neither counter can
+             go backwards.
+          3. confidence is NOT monotonic (MODIFIED / demote / prune lower it).
+             We lift it via max() ONLY when the disk side recorded strictly more
+             successes than we had (it saw an ACCEPTED we haven't, so its
+             confidence reflects a reinforcement worth keeping). When both sides
+             edited confidence independently this is a deliberate, lossy choice
+             — there's no field-blind way to reconstruct intent from two scalars
+             without a version counter — and we favor the recorded reinforcement.
+        """
+        if not ours.is_valid:
+            return ours
+        om, dm = ours.metadata, disk.metadata
+        ours_success = om.success_count
+        om.success_count = max(om.success_count, dm.success_count)
+        om.access_count = max(om.access_count, dm.access_count)
+        if disk.is_valid and dm.success_count > ours_success:
+            om.confidence = max(om.confidence, dm.confidence)
+        return ours
 
     def purge_dead_facts(self) -> int:
         """Remove invalid facts that have gone cold (untouched 30+ days).

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -1710,3 +1710,68 @@ class TestConcurrentSaveMerge:
         ids = {x.id for x in C._facts}
         assert dead.id not in ids, "purged fact resurrected through concurrent-merge re-read"
         assert fy.id in ids, "concurrent process's fact was lost"
+
+    def test_concurrent_success_bump_survives_stale_save(self, store, tmp_path):
+        """A success_count bump committed by one process must not be lost when
+        another process holds a stale copy and saves later (field reconcile)."""
+        A = store
+        fact = A.add_fact(subject="shared fact", body="b", kind=FactKind.PATTERN,
+                          scope=FactScope.PROJECT)  # disk has fact, success=0
+        # B loads the fact (stale copy, success=0).
+        B = FactStore(codebase_root=str(tmp_path))
+        bfact = next(f for f in B._facts if f.id == fact.id)
+        # A bumps success_count and persists.
+        fact.metadata.success_count += 1
+        fact.metadata.confidence = min(1.0, fact.metadata.confidence + 0.2)
+        A.save()
+        # B, unaware of the bump, saves its stale copy on top.
+        bfact.metadata.last_accessed = time.time()
+        B.save()
+        # The bump must survive on disk.
+        C = FactStore(codebase_root=str(tmp_path))
+        merged = next(f for f in C._facts if f.id == fact.id)
+        assert merged.metadata.success_count == 1, "concurrent success bump was lost"
+
+    def test_reconcile_never_resurrects_locally_invalidated(self, store, tmp_path):
+        """If we invalidated a fact this session, a higher-success disk copy
+        must not flip it back to valid."""
+        A = store
+        fact = A.add_fact(subject="to invalidate", body="b", kind=FactKind.PATTERN,
+                          scope=FactScope.PROJECT)
+        # Another process bumps success on disk.
+        B = FactStore(codebase_root=str(tmp_path))
+        bfact = next(f for f in B._facts if f.id == fact.id)
+        bfact.metadata.success_count = 5
+        B.save()
+        # A invalidates its copy, then saves (must re-read & reconcile).
+        fact.is_valid = False
+        A.save()
+        C = FactStore(codebase_root=str(tmp_path))
+        merged = next(f for f in C._facts if f.id == fact.id)
+        assert merged.is_valid is False, "locally-invalidated fact was resurrected"
+
+    def test_reconcile_preserves_our_independent_edits(self, store, tmp_path):
+        """Reconcile must keep OURS as the base, not adopt the disk record
+        wholesale — so a concurrent edit doesn't discard our own field changes
+        (e.g. a confidence demotion at equal success, or a tag we added)."""
+        A = store
+        fact = A.add_fact(subject="shared", body="b", kind=FactKind.PATTERN,
+                          scope=FactScope.PROJECT)
+        fact.metadata.success_count = 2
+        fact.metadata.confidence = 0.8
+        A.save()
+        # B loads the fact (success=2, conf=0.8).
+        B = FactStore(codebase_root=str(tmp_path))
+        bfact = next(f for f in B._facts if f.id == fact.id)
+        # A writes something else, changing the file mtime so B's next save
+        # must re-read + reconcile (not take the fast path).
+        A.add_fact(subject="other", body="b", kind=FactKind.PATTERN, scope=FactScope.PROJECT)
+        # B demotes confidence (success unchanged) and tags it, then saves.
+        bfact.metadata.confidence = 0.5
+        bfact.tags.append("b-only-tag")
+        B.save()
+        C = FactStore(codebase_root=str(tmp_path))
+        merged = next(f for f in C._facts if f.id == fact.id)
+        assert merged.metadata.confidence == 0.5, "our demotion was clobbered by wholesale adopt"
+        assert "b-only-tag" in merged.tags, "our tag edit was discarded"
+        assert merged.metadata.success_count == 2


### PR DESCRIPTION
Closes the same-id concurrent field-edit residual from #109 (0.22.1).

**Problem:** 0.22.1 preserved a concurrent writer's *added* facts, but for a fact in both processes' memory it kept the in-memory copy wholesale — so a `success_count`/confidence bump one process committed was lost when the other saved a stale copy.

**Fix:** `_merge_on_save` now field-reconciles a same-id fact (`_reconcile_fact`), keeping OUR record as the base: max the strictly-monotonic counters (`success_count`/`access_count`), lift confidence to the disk value only when that side had more successes, and never resurrect a fact we invalidated this session. Our own independent edits (MODIFIED demotion, supersession, tags) survive.

**Linus review:** rejected an earlier 'adopt disk record wholesale' rule (it discarded independent in-memory edits — moved the loss from success_count to confidence). Field-merge applied per his prescription. Residual (both sides edit confidence → best-effort, favors reinforcement) documented; lossless needs a version counter/lock.

**Tests:** success bump survives stale concurrent save; invalidation not resurrected; demotion + tag preserved. 316 pass; ruff clean on `src/ tests/`.

Follows the PR template; bug-fix patch release.