### PR TITLE
Release v0.22.4: dedupe outcome reinforcement per fact (suggestion fan-out)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.22.4] - 2026-06-17
+
+### Fixed
+
+- **Outcome detection no longer over-reinforces a fact via suggestion fan-out.** One neo invocation links *all* its suggestions to a single reasoning fact (`engine._build_suggestion_fact_ids`), so both outcome paths could apply several reinforcements to that one fact from what is really a single acceptance/recurrence — inflating `success_count`, which gates probation-promotion *and* community contribution (`find_contributable`, `min_successes=3`). Now deduped per fact: the transcript miner (`mine_suggestion_outcomes`) reinforces each fact at most once per cycle (and compacts the fan-out sibling ledger entries so they can't drip later), and `detect_implicit_feedback` reinforces/demotes a given fact at most once per call (skipping duplicate MODIFIED REVIEW facts too). Mixed accept/modify across files of one fan-out resolves deterministically to the first outcome in suggestion order. Note: `MAX_MINED_OUTCOMES_PER_CYCLE` now bounds *distinct facts* per cycle rather than ledger entries — a more meaningful budget. Surfaced by having neo review its own codebase. (`memory/store.py`, `memory/transcript.py`)
+
 ## [0.22.3] - 2026-06-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.22.3"
+version = "0.22.4"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.22.3"
+__version__ = "0.22.4"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -860,6 +860,13 @@ class FactStore:
 
         facts_by_id = {f.id: f for f in self._facts}
         linked_count = 0
+        # One neo invocation links ALL its suggestions to a SINGLE reasoning
+        # fact, so several outcomes here can resolve to the same fact_id (each
+        # suggested file that changed). Reinforce/demote a given fact at most
+        # once per call — otherwise a multi-file suggestion ratchets one fact's
+        # success_count/confidence (and spawns duplicate MODIFIED REVIEWs) from
+        # what is really one acceptance/correction.
+        touched_fact_ids: set[str] = set()
 
         normalized_fact_ids: dict[str, str] = {}
         for path, fid in suggestion_fact_ids.items():
@@ -890,6 +897,8 @@ class FactStore:
                 original_fact = facts_by_id.get(fact_id) if fact_id else None
 
                 if original_fact and original_fact.is_valid:
+                    if original_fact.id in touched_fact_ids:
+                        continue  # fan-out dedup: already reinforced this fact
                     # Boost original fact instead of creating orphan REVIEW.
                     # Base +0.2; modulated by arch delta so a session that
                     # regressed structure earns less trust than one that didn't.
@@ -900,6 +909,7 @@ class FactStore:
                     original_fact.metadata.success_count += 1
                     update_effectiveness(original_fact, outcome="better")
                     original_fact.metadata.last_accessed = time.time()
+                    touched_fact_ids.add(original_fact.id)
                     linked_count += 1
                     continue
 
@@ -937,19 +947,25 @@ class FactStore:
                 fact_id = _lookup_fact_id(outcome.file_path)
                 original_fact = facts_by_id.get(fact_id) if fact_id else None
                 if original_fact and original_fact.is_valid:
+                    if original_fact.id in touched_fact_ids:
+                        continue  # fan-out dedup: skip duplicate demote + REVIEW
                     penalty = min(-0.05, -0.2 + arch_mod)
                     original_fact.metadata.confidence = max(
                         0.1, original_fact.metadata.confidence + penalty
                     )
                     update_effectiveness(original_fact, outcome="worse")
                     original_fact.metadata.last_accessed = time.time()
+                    touched_fact_ids.add(original_fact.id)
                     linked_count += 1
             elif outcome.outcome_type == OutcomeType.UNVERIFIED:
                 # Suggested file changed, but no diff to compare — weak signal.
                 # Only update linked fact; never create standalone REVIEW.
                 fact_id = _lookup_fact_id(outcome.file_path)
                 original_fact = facts_by_id.get(fact_id) if fact_id else None
-                if original_fact and original_fact.is_valid:
+                if (
+                    original_fact and original_fact.is_valid
+                    and original_fact.id not in touched_fact_ids
+                ):
                     boost = max(-0.05, 0.1 + arch_mod)
                     original_fact.metadata.confidence = min(
                         1.0, max(0.0, original_fact.metadata.confidence + boost)
@@ -957,6 +973,7 @@ class FactStore:
                     original_fact.metadata.success_count += 1
                     update_effectiveness(original_fact, outcome="better")
                     original_fact.metadata.last_accessed = time.time()
+                    touched_fact_ids.add(original_fact.id)
                     linked_count += 1
                 continue  # Never create a REVIEW fact for unverified outcomes
             elif outcome.outcome_type == OutcomeType.INDEPENDENT:

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -818,8 +818,8 @@ class TranscriptIngester:
 
         dated = [(t, e) for e in episodes if (t := _episode_epoch(e.timestamp)) is not None]
         now = time.time()
-        matched_fact_ids: list[str] = []
-        done_ids: set = set()
+        matched_fact_ids: set[str] = set()  # dedup: one reinforcement per fact per cycle
+        done_ids: set[str] = set()
 
         # Ledger order is append order (oldest first) — the right drain order,
         # since oldest entries are closest to window-expiry.
@@ -835,10 +835,22 @@ class TranscriptIngester:
             window_end = ets + OUTCOME_CORRELATION_WINDOW_SECONDS
             cands = [e for t, e in dated if ets <= t <= window_end]
             if self._match_episode(entry.get("description", ""), cands) is not None:
-                matched_fact_ids.append(fid)
+                matched_fact_ids.add(fid)
                 done_ids.add(eid)
             elif now > window_end:
                 done_ids.add(eid)  # window lapsed with no match — give up
+
+        # Fan-out dedup: one neo invocation links ALL its suggestions to a
+        # SINGLE reasoning fact, so the ledger holds many entries per fact_id.
+        # We reinforce each fact at most once per cycle (set above); consume the
+        # *other* still-pending entries for any reinforced fact too, so they
+        # can't drip extra bumps for the same fact in later cycles. (Genuinely
+        # later, post-compaction re-logging can still reinforce — that's a new
+        # recurrence, not this fan-out.)
+        if matched_fact_ids:
+            for entry in ledger:
+                if entry.get("fact_id") in matched_fact_ids:
+                    done_ids.add(entry.get("id", ""))
 
         # Compact BEFORE applying, and unconditionally:
         #  - before, because apply_mined_outcomes is NOT idempotent (it bumps the
@@ -850,7 +862,7 @@ class TranscriptIngester:
         #    always runs; gating it on done_ids let a ledger of young-unmatched
         #    entries grow without the backstop ever firing.
         tracker.compact_suggestion_ledger(drop_ids=done_ids)
-        return self._store.apply_mined_outcomes(matched_fact_ids) if matched_fact_ids else 0
+        return self._store.apply_mined_outcomes(list(matched_fact_ids)) if matched_fact_ids else 0
 
     def _watermark_path(self, source) -> Optional[Path]:
         if source.scope == FactScope.PROJECT:

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -1802,3 +1802,56 @@ class TestConcurrentSaveMerge:
         C = FactStore(codebase_root=str(tmp_path))
         ids = {f.id for f in C._facts}
         assert {fa.id, fb.id, fa2.id} <= ids
+
+    def test_detect_feedback_dedupes_multi_suggestion_fan_out(self, store, tmp_path):
+        """Multiple ACCEPTED outcomes that resolve to the SAME reasoning fact
+        (one invocation links all its suggestions to one fact) must reinforce
+        that fact ONCE, not once per suggestion."""
+        f = store.add_fact(subject="reasoning", body="b", kind=FactKind.DECISION,
+                           scope=FactScope.PROJECT, confidence=0.5)
+        before_succ = f.metadata.success_count
+        # Three accepted outcomes for three suggested files, all linked to f.
+        sfi = {"a.py": f.id, "b.py": f.id, "c.py": f.id}
+        outcomes = [
+            Outcome(outcome_type=OutcomeType.ACCEPTED, file_path=p, diff_summary="+x",
+                    suggestion_description="d", suggestion_confidence=0.8)
+            for p in ("a.py", "b.py", "c.py")
+        ]
+        with patch.object(store._outcome_tracker, "detect_outcomes",
+                          return_value=(outcomes, sfi)), \
+             patch.object(store._outcome_tracker, "compute_arch_delta", return_value=None):
+            store.detect_implicit_feedback({"prompt": "p"}, [])
+        assert f.metadata.success_count == before_succ + 1, "fan-out double-counted success"
+
+    def test_detect_feedback_modified_fan_out_demotes_once_one_review(self, store, tmp_path):
+        """Multiple MODIFIED outcomes resolving to one reasoning fact must demote
+        it ONCE and create exactly ONE correction REVIEW — not one per file."""
+        f = store.add_fact(subject="reasoning-mod", body="b", kind=FactKind.DECISION,
+                           scope=FactScope.PROJECT, confidence=0.8)
+        sfi = {p: f.id for p in ("a.py", "b.py", "c.py")}
+        outcomes = [
+            Outcome(outcome_type=OutcomeType.MODIFIED, file_path=p, diff_summary="+x",
+                    suggestion_description="d", suggestion_confidence=0.8)
+            for p in ("a.py", "b.py", "c.py")
+        ]
+        with patch.object(store._outcome_tracker, "detect_outcomes",
+                          return_value=(outcomes, sfi)), \
+             patch.object(store._outcome_tracker, "compute_arch_delta", return_value=None):
+            store.detect_implicit_feedback({"prompt": "p"}, [])
+        assert f.metadata.confidence == pytest.approx(0.6), "fan-out demoted more than once"
+        modified_reviews = [x for x in store._facts if x.is_valid and "modified" in x.tags]
+        assert len(modified_reviews) == 1, "duplicate MODIFIED REVIEW per file"
+
+    def test_detect_feedback_modified_without_link_still_reviews(self, store, tmp_path):
+        """A MODIFIED outcome with no linked fact must still record its REVIEW
+        (the dedup guard must not suppress the no-link fallback)."""
+        outcomes = [
+            Outcome(outcome_type=OutcomeType.MODIFIED, file_path="unlinked.py",
+                    diff_summary="+x", suggestion_description="d", suggestion_confidence=0.8)
+        ]
+        with patch.object(store._outcome_tracker, "detect_outcomes",
+                          return_value=(outcomes, {})), \
+             patch.object(store._outcome_tracker, "compute_arch_delta", return_value=None):
+            store.detect_implicit_feedback({"prompt": "p"}, [])
+        modified_reviews = [x for x in store._facts if x.is_valid and "modified" in x.tags]
+        assert len(modified_reviews) == 1


### PR DESCRIPTION
**Found by having the installed neo review its own codebase** — it flagged an over-reinforcement risk in the feedback loop; the exact trigger and minimal fix were pinned down on follow-up.

**Bug:** `engine._build_suggestion_fact_ids` links *all* of one invocation's suggestions to a single reasoning fact, so both outcome paths could reinforce that one fact multiple times from a single acceptance/recurrence — inflating `success_count`, which gates probation promotion AND community contribution (`find_contributable`, `min_successes=3`).

**Fix (per-fact dedup, not a durable event-id system):**
- Transcript miner: `matched_fact_ids` is a set (one reinforcement/fact/cycle); fan-out sibling ledger entries for a reinforced fact are compacted out so they can't drip later.
- Git path `detect_implicit_feedback`: a `touched_fact_ids` set; a fact is reinforced/demoted at most once per call (and no duplicate MODIFIED REVIEW). INDEPENDENT / no-link fallbacks unaffected.
- Mixed accept/modify across one fan-out resolves deterministically to first-in-suggestion-order (documented). `MAX_MINED_OUTCOMES_PER_CYCLE` now bounds distinct facts/cycle — a more meaningful budget.

**Linus review:** accept; mandatory items applied (MODIFIED-branch tests added — demote-once + one REVIEW + no-link still reviews; `set[str]` annotations).

**Tests:** ACCEPTED/MODIFIED fan-out reinforce once; one REVIEW not per-file; no-link MODIFIED still reviews. 301 pass; ruff clean on `src/ tests/`.

Bug-fix patch release; follows the PR template.