### PR TITLE
feat: neo memory issues — surface recurring frictions mined from transcripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,17 @@
     specific project's fact file, use `neo memory prune [--all] [--dry-run]`
     (`neo/subcommands.py:_compact_fact_file` — at the package root, not
     under `memory/`).
+  - Diagnostics: `neo memory issues [--since 14d] [--min-cluster 3] [--json]`
+    surfaces recurring frictions mined from transcript history (Claude Code /
+    Codex / CAR) as ranked, evidence-cited issues (categories: `missing-tool`,
+    `absent-guardrail`, `vague-rule`). **Read-only**: it reuses the ingester's
+    `TranscriptSource` episodes but never admits facts or touches the
+    `transcript_watermark_*` watermark — decoupled from fact admission and
+    idempotent (`neo/memory/issues.py:find_issues`). Gate mirrors synthesis
+    discipline (≥`min_cluster` members, ≥2 sessions, ≥2 frictional, verbatim
+    evidence). LM-free in v1; clusters at `SYNTHESIS_SIMILARITY` via the shared
+    `math_utils.cluster_by_similarity`. See
+    `docs/solutions/conversation-mined-issues.md`.
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/docs/solutions/conversation-mined-issues.md
+++ b/docs/solutions/conversation-mined-issues.md
@@ -1,0 +1,91 @@
+# Conversation-mined issue diagnostic — `neo memory issues`
+
+**Status:** v1 (2026-06-19). LM-free detectors over the existing multi-source
+transcript episodes. Read-only view; no fact admission, no watermark mutation.
+
+## Why
+
+The memory ingester ([transcript-ingestion](transcript-ingestion.md)) already
+parses Claude Code / Codex / CAR transcripts into `Episode`s and silently
+admits PATTERN/FAILURE lessons that improve future retrieval. The friction
+*signals* it computes (errors, assistant clarification) were never surfaced to
+the human. This diagnostic flips the output mode: instead of quietly enriching
+memory, it **reports recurring frictions as actionable issues** — the
+memory-side instance of the continuous quality flywheel ("diagnose failures by
+clustering root causes") and an automation of the manual advice *"add a rule
+every time the agent does something it should not do again."*
+
+## What it is
+
+```
+neo memory issues [--since 14d] [--min-cluster 3] [--json] [--cwd PATH]
+```
+
+A pull command. Pipeline (`neo/memory/issues.py`), all LM-free in v1:
+
+1. **Collect** — episodes from every `TranscriptSource` within the `--since`
+   window (reuses `ClaudeCodeSource` / `CodexSource` / `CarSource`). Filters
+   `Episode.is_substantive`.
+2. **Tag** (`tag_signals`) — per-episode friction derived purely from
+   `Episode` fields: `has_tool_error` + normalized `error_class` (from
+   `Episode.errors`), and `asst_asked_clarification` (clarification regex
+   vocabulary lifted from `prompt.analyzer.CONFUSION_PATTERNS`, but applied to
+   episode assistant text rather than the analyzer's Claude-only message dicts).
+3. **Cluster** (`detect_issues`) — embed each ask (sharpened with its first
+   error line when present) via the store's `_embed_text` (Jina — same vectors
+   as fact retrieval, no extra model, no LM) and complete-linkage cluster at
+   `CLUSTER_SIMILARITY = 0.85` (== `store.SYNTHESIS_SIMILARITY`), reusing
+   `math_utils.cluster_by_similarity`.
+4. **Gate** — a cluster becomes an `Issue` only if it has **≥ `min_cluster`
+   members**, spans **≥ 2 distinct sessions**, has **≥ 2 frictional members**,
+   and yields **≥ 1 verbatim evidence span** (Stage-C discipline: provable, not
+   paraphrased). Pure-recurrence-without-friction clusters are dropped.
+5. **Categorize + score** — precedence `missing-tool` > `absent-guardrail` >
+   `vague-rule` (most structural signal wins; one cluster → one category,
+   mapped to the harness failure taxonomy). Confidence =
+   `0.4·size + 0.3·session-spread + 0.3·recency` (local exp decay, 14-day
+   half-life, on episode epochs). Sorted descending.
+
+## Read-only / no-consume contract
+
+`find_issues` collects episodes within the window but **never constructs the
+`TranscriptIngester`** and never reads or writes the ingester watermark
+(`SESSIONS_DIR/transcript_watermark_*`). It is fully decoupled from fact
+admission, idempotent, and safe to run repeatedly. Guarded by
+`test_find_issues_is_read_only_never_invokes_ingester`.
+
+## Design choices
+
+- **Conservative by default.** A wrong issue wastes scarce human attention, so
+  the gate is strict (≥3, ≥2 sessions, ≥2 frictional, verbatim evidence).
+  Better to under-report in v1. On this repo's own 53 substantive episodes (12
+  frictional), v1 reports zero — friction was real but scattered, never
+  recurring on one topic across sessions. That is the correct answer, not a bug.
+- **Episodes, not the analyzer's message model.** Episodes are the watermarked,
+  multi-tool substrate; we lift the analyzer's regex vocabulary but operate on
+  Episodes so Codex/CAR are covered for free.
+- **Error relevance filter (learned from real data).** `Episode.errors` is
+  dominated by signal that is *not* a project issue: Claude Code's own
+  `<tool_use_error>` tool-protocol guards (read-before-edit, replace_all,
+  file-modified, sleep-blocked) and bare command banners ("Exit code 2"). A
+  probe across 8 local projects showed these produced 7 low-value "issues" on
+  the busiest repo. `_episode_errors` now drops `<tool_use_error>` envelopes and
+  banner-only errors, and `_substantive_error_line` skips a leading banner so a
+  Codex `"Process exited with code 1\n<traceback>"` keeps the traceback as its
+  class. Post-filter, that same repo surfaced one genuine recurring friction
+  ("git merge repeatedly blocked by local changes," 7 sessions) and otherwise
+  stayed quiet — the intended behavior.
+- **Clustering reuse.** The complete-linkage loop was extracted from
+  `store._cluster_by_similarity` into `math_utils.cluster_by_similarity(items,
+  embed_fn, threshold)`; both synthesis and this diagnostic share one
+  implementation.
+
+## Deferred (post-v1)
+
+- `--suggest-rules`: one gated LM call per surviving cluster to phrase a
+  proposed AGENTS.md/CLAUDE.md rule (Stage-B style). `Issue.suggested_rule` is
+  the placeholder.
+- Dedup against existing FAILURE facts (annotate "already in memory").
+- Detectors 5–6: artifact drift (CLAUDE.md asserts X, transcripts show not-X)
+  and contradiction (CLAUDE.md vs AGENTS.md vs Neo facts) — need an LM judge +
+  `scanner.scan_claude_mds`.

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -214,6 +214,24 @@ def parse_args():
         )
         observer_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
+        issues_p = subparsers.add_parser(
+            'issues',
+            help='Surface recurring frictions mined from transcript history (read-only)',
+        )
+        issues_p.add_argument(
+            '--since',
+            default='14d',
+            help='Only consider episodes within this window, e.g. 14d, 48h, 30m (default: 14d)',
+        )
+        issues_p.add_argument(
+            '--min-cluster',
+            type=int,
+            default=3,
+            help='Minimum recurring episodes before a friction is reported (default: 3)',
+        )
+        issues_p.add_argument('--json', action='store_true', help='Emit issues as JSON')
+        issues_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
+
         args = p.parse_args(sys.argv[2:])
         args.command = 'memory'
         args.memory_action = args.action

--- a/src/neo/math_utils.py
+++ b/src/neo/math_utils.py
@@ -118,6 +118,52 @@ def batched_cosine(
         sims[idx] = float(c)
     return sims
 
+def cluster_by_similarity(
+    items: list,
+    embed_fn,
+    threshold: float,
+) -> list[list]:
+    """Greedy complete-linkage clustering of items by cosine similarity.
+
+    ``embed_fn(item)`` returns the item's embedding (an ``np.ndarray``) or
+    ``None``; items with no embedding are dropped. A candidate joins a cluster
+    only if it is similar (cosine >= ``threshold``) to *all* current members
+    (complete-linkage), so every item in a returned cluster is mutually
+    similar. Clusters are seeded greedily in input order, which makes the
+    partition order-dependent — callers that need determinism should pass a
+    stably-ordered ``items`` list.
+
+    Returns a list of clusters, each a list of the original items.
+    """
+    embedded: list[tuple] = []
+    for item in items:
+        emb = embed_fn(item)
+        if emb is not None:
+            embedded.append((item, emb))
+    if not embedded:
+        return []
+
+    assigned = [False] * len(embedded)
+    clusters: list[list] = []
+    for i, (item_i, emb_i) in enumerate(embedded):
+        if assigned[i]:
+            continue
+        cluster = [item_i]
+        cluster_embs = [emb_i]
+        assigned[i] = True
+        for j in range(i + 1, len(embedded)):
+            if assigned[j]:
+                continue
+            item_j, emb_j = embedded[j]
+            # Complete-linkage: must be similar to ALL current members.
+            if all(cosine_similarity(m, emb_j) >= threshold for m in cluster_embs):
+                cluster.append(item_j)
+                cluster_embs.append(emb_j)
+                assigned[j] = True
+        clusters.append(cluster)
+    return clusters
+
+
 NumberLike = Union[int, float, Decimal, str]
 
 

--- a/src/neo/memory/issues.py
+++ b/src/neo/memory/issues.py
@@ -1,0 +1,499 @@
+"""
+Conversation-mined issue diagnostic.
+
+Surfaces *recurring frictions* mined from the same multi-source transcript
+episodes the memory ingester consumes (Claude Code / Codex / CAR), but as a
+read-only VIEW: it never extracts facts, never calls an LM, and never touches
+the ingester watermark. Re-running it is idempotent and mutates nothing.
+
+Pipeline (all LM-free in v1):
+
+    collect episodes  ->  tag per-episode signals  ->  cluster by ask embedding
+    ->  gate (>= min_cluster members, >= 2 distinct sessions, friction present,
+        verbatim evidence)  ->  categorize + score  ->  ranked Issue list
+
+Signals are derived from ``Episode`` fields (``errors``, ``assistant_text``).
+The clarification vocabulary is lifted from :mod:`neo.prompt.analyzer`, but we
+operate on ``Episode`` objects (the watermarked, multi-tool substrate) rather
+than the analyzer's Claude-only message dicts.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from neo.math_utils import cluster_by_similarity
+
+logger = logging.getLogger(__name__)
+
+# Same threshold the REVIEW->PATTERN synthesis uses (store.SYNTHESIS_SIMILARITY);
+# kept as a local constant so this module imports nothing heavy at import time.
+CLUSTER_SIMILARITY = 0.85
+
+# Issue categories, mapped to the harness failure taxonomy ("most agent failures
+# are configuration failures: a missing tool, a vague rule, an absent guardrail").
+CATEGORY_MISSING_TOOL = "missing-tool"
+CATEGORY_ABSENT_GUARDRAIL = "absent-guardrail"
+CATEGORY_VAGUE_RULE = "vague-rule"
+
+# Confidence weights: cluster size / session spread / recency.
+_W_SIZE = 0.4
+_W_SPREAD = 0.3
+_W_RECENCY = 0.3
+_RECENCY_HALFLIFE_DAYS = 14.0
+
+# Clarification/confusion phrases an assistant uses when the ask was
+# under-specified (lifted from prompt.analyzer.CONFUSION_PATTERNS).
+_CLARIFICATION_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"could you clarify",
+        r"can you clarify",
+        r"i'm not sure",
+        r"i am not sure",
+        r"i need more information",
+        r"can you provide more context",
+        r"what do you mean by",
+        r"please specify",
+        r"could you be more specific",
+        r"it's unclear",
+        r"i cannot determine",
+        r"which (?:file|one|approach|option) (?:did you mean|do you want)",
+    )
+]
+
+# Claude Code's own tool-protocol guards surface as <tool_use_error> envelopes
+# (read-before-edit, replace_all, file-modified-since-read, sleep-blocked, …).
+# They are agent/harness churn, not project issues, so they never count as
+# friction.
+_HARNESS_ENVELOPE_RE = re.compile(r"^\s*<tool_use_error>", re.IGNORECASE)
+
+# Generic command-outcome banners carry no actionable error class on their own
+# (a bare "Exit code 2" says nothing about what failed). When an error is only
+# banners, it is dropped; when a banner precedes real output (Codex emits
+# "Process exited with code 1\n<traceback>"), the banner is skipped and the
+# substantive line is used.
+_GENERIC_BANNER_RE = re.compile(
+    r"^\s*(?:process )?exit(?:ed with)? code \d+"
+    r"|^\s*command (?:timed out|failed)$"
+    r"|^\s*\[request interrupted",
+    re.IGNORECASE,
+)
+
+# A non-zero exit captures the command's whole output, which is often not an
+# error message at all (section headers, diffs, code being edited). Require a
+# line to look like a diagnostic, not merely contain the substring "error" — a
+# type like `Result<T, WorkflowError>` is code, not an error occurrence. So we
+# match error words only at diagnostic positions (prefix-with-colon/paren, or a
+# typed exception followed by a colon), lint codes, and a curated set of
+# standalone failure phrases that rarely appear as code identifiers.
+_ERROR_SIGNAL_RE = re.compile(
+    # "error:", "fatal:", "panic(", "traceback (" as a line/segment prefix
+    r"(?:^|[\s>|\]])(?:error|errno|fatal|panic|exception|traceback)\b\s*[:(]"
+    # typed exception carrying a message: "TypeError: …", "ModuleNotFoundError: …"
+    r"|\b\w*(?:error|exception)\b\s*:"
+    # linter / compiler codes: E402, C0301, …
+    r"|\b[A-Za-z]\d{3,}\b"
+    # curated standalone failure phrases
+    r"|command not found|no such file|not a git repository|would be overwritten"
+    r"|permission denied|access denied|segmentation fault|stack overflow"
+    r"|connection (?:refused|reset|timed out)|operation not permitted"
+    r"|cannot find|could not|couldn'?t|unable to|failed to|not recognized"
+    r"|undefined (?:reference|symbol|variable|method)"
+    r"|(?:tests?|build|compilation|assertion) failed",
+    re.IGNORECASE,
+)
+
+# Error shapes that point specifically at a missing/unavailable *tool* (vs. a
+# missing file or a logic bug). Kept narrow: "no such file or directory" is a
+# missing path, not a missing tool, so it is deliberately excluded and falls to
+# absent-guardrail.
+_MISSING_TOOL_RE = re.compile(
+    r"command not found|: not found$|unknown command"
+    r"|is not recognized|executable file not found|no such command",
+    re.IGNORECASE,
+)
+
+# How many evidence spans to attach per issue.
+_MAX_EVIDENCE = 3
+# Window (chars) captured around a clarification match for the evidence span.
+_CLARIFICATION_SPAN_CHARS = 160
+
+
+@dataclass
+class IssueEvidence:
+    """A single, provable citation for an issue.
+
+    ``span`` is a verbatim substring of the source episode (Stage-C discipline:
+    provable evidence, not a paraphrase).
+    """
+
+    session_id: str
+    timestamp: str
+    span: str
+
+
+@dataclass
+class Issue:
+    """A recurring friction surfaced from transcript history."""
+
+    title: str
+    category: str
+    confidence: float
+    evidence: list[IssueEvidence]
+    session_count: int
+    member_count: int
+    suggested_rule: Optional[str] = None  # filled by --suggest-rules (post-v1)
+
+
+@dataclass
+class EpisodeSignals:
+    """Per-episode friction signals, derived purely from episode fields."""
+
+    has_tool_error: bool = False
+    error_class: Optional[str] = None
+    asst_asked_clarification: bool = False
+
+    @property
+    def has_friction(self) -> bool:
+        return self.has_tool_error or self.asst_asked_clarification
+
+
+def _substantive_error_line(text: str) -> Optional[str]:
+    """First error-like line in an error blob, or None.
+
+    Skips generic command-outcome banners ("Exit code 2", "command timed out")
+    and non-error command output (section headers, diffs), returning the first
+    line that actually looks like an error. So a banner+traceback (Codex:
+    "Process exited with code 1\\nModuleNotFoundError: …") yields the traceback
+    line, while a non-zero exit whose output is just "=== section ===" yields
+    None and is dropped as friction.
+    """
+    for line in (text or "").splitlines():
+        s = line.strip()
+        if not s or _GENERIC_BANNER_RE.match(s):
+            continue
+        if _ERROR_SIGNAL_RE.search(s):
+            return s
+    return None
+
+
+def _episode_errors(ep) -> list[str]:
+    """Project-relevant error strings for an episode.
+
+    Drops (a) empty/whitespace entries, (b) Claude Code ``<tool_use_error>``
+    tool-protocol guards (agent/harness churn, not project issues), and
+    (c) banner-only outcomes (a bare exit code says nothing about what failed).
+    What remains is substantive enough to anchor an issue.
+    """
+    out: list[str] = []
+    for e in getattr(ep, "errors", None) or []:
+        if not e or not e.strip():
+            continue
+        if _HARNESS_ENVELOPE_RE.match(e):
+            continue
+        if _substantive_error_line(e) is None:
+            continue
+        out.append(e)
+    return out
+
+
+def _first_line(text: str) -> str:
+    text = (text or "").strip()
+    if not text:
+        return ""
+    return text.splitlines()[0].strip()
+
+
+def _normalize_error(text: str) -> Optional[str]:
+    """Reduce an error message to a stable class key for grouping.
+
+    Strips the volatile bits (line numbers, hex addresses, absolute paths) so
+    the same error recurring with different coordinates groups together. Uses
+    the first substantive (non-banner) line.
+    """
+    line = _substantive_error_line(text)
+    if not line:
+        return None
+    s = re.sub(r"0x[0-9a-fA-F]+", "", line)
+    s = re.sub(r"(?:/[^\s:'\"]+)+", "", s)  # absolute paths
+    s = re.sub(r"\b\d+\b", "", s)  # line numbers / counts
+    s = re.sub(r"\s+", " ", s).strip().lower()
+    return s[:80] or None
+
+
+def tag_signals(ep) -> EpisodeSignals:
+    """Derive friction signals from one ``Episode``. Pure; no LM, no I/O."""
+    errors = _episode_errors(ep)
+    has_tool_error = bool(errors)
+    error_class = _normalize_error(errors[0]) if has_tool_error else None
+
+    clarified = any(
+        turn and any(p.search(turn) for p in _CLARIFICATION_PATTERNS)
+        for turn in (getattr(ep, "assistant_text", None) or [])
+    )
+
+    return EpisodeSignals(
+        has_tool_error=has_tool_error,
+        error_class=error_class,
+        asst_asked_clarification=clarified,
+    )
+
+
+def _clarification_span(ep) -> Optional[str]:
+    """A verbatim window around the first clarification phrase, or None.
+
+    Matches within a single assistant turn so the returned span is a true
+    substring of one source field (not a join-reconstructed string).
+    """
+    for turn in getattr(ep, "assistant_text", None) or []:
+        if not turn:
+            continue
+        for pat in _CLARIFICATION_PATTERNS:
+            m = pat.search(turn)
+            if m:
+                start = max(0, m.start() - 40)
+                end = min(len(turn), m.end() + (_CLARIFICATION_SPAN_CHARS - 40))
+                return turn[start:end].strip()
+    return None
+
+
+def _evidence_span(ep, sig: EpisodeSignals) -> Optional[str]:
+    """Build a verbatim evidence span for a frictional episode, or None."""
+    if sig.has_tool_error:
+        errors = _episode_errors(ep)
+        if errors:
+            line = _substantive_error_line(errors[0]) or _first_line(errors[0])
+            if line:
+                return line[:_CLARIFICATION_SPAN_CHARS]
+    if sig.asst_asked_clarification:
+        return _clarification_span(ep)
+    return None
+
+
+def _episode_epoch_safe(ep) -> Optional[float]:
+    from neo.memory.transcript import _episode_epoch
+
+    return _episode_epoch(getattr(ep, "timestamp", "") or "")
+
+
+def _representative_topic(members: list) -> str:
+    """A short topic label from the shortest substantive ask in the cluster."""
+    asks = [(_first_line(getattr(m, "ask", "")) or "") for m in members]
+    asks = [a for a in asks if a]
+    if not asks:
+        return "(unknown)"
+    topic = min(asks, key=len)
+    return topic[:60] + ("…" if len(topic) > 60 else "")
+
+
+def _categorize(members: list, sigs: list[EpisodeSignals]) -> tuple[str, str]:
+    """Return (category, title) for a frictional cluster.
+
+    Precedence: missing-tool > absent-guardrail > vague-rule (most structural
+    signal wins, so one cluster maps to exactly one category).
+    """
+    tool_errs = [s for s in sigs if s.has_tool_error]
+    topic = _representative_topic(members)
+
+    if tool_errs:
+        if any(_MISSING_TOOL_RE.search(s.error_class or "") for s in tool_errs):
+            label = _most_common_error(tool_errs) or topic
+            return CATEGORY_MISSING_TOOL, f"Repeated tool failure: {label}"
+        label = _most_common_error(tool_errs) or topic
+        return CATEGORY_ABSENT_GUARDRAIL, f"Recurring error: {label}"
+
+    return CATEGORY_VAGUE_RULE, f"Repeated clarification: {topic}"
+
+
+def _most_common_error(sigs: list[EpisodeSignals]) -> Optional[str]:
+    counts: dict[str, int] = {}
+    for s in sigs:
+        if s.error_class:
+            counts[s.error_class] = counts.get(s.error_class, 0) + 1
+    if not counts:
+        return None
+    return max(counts, key=lambda k: counts[k])
+
+
+def _confidence(member_count: int, session_count: int, members: list, now: float) -> float:
+    size_term = min(1.0, member_count / 6.0)
+    spread_term = min(1.0, session_count / 3.0)
+
+    epochs = [e for m in members if (e := _episode_epoch_safe(m)) is not None]
+    if epochs:
+        age_days = max(0.0, (now - max(epochs)) / 86400.0)
+        # True half-life: term == 0.5 at exactly _RECENCY_HALFLIFE_DAYS.
+        recency_term = math.exp(-age_days * math.log(2) / _RECENCY_HALFLIFE_DAYS)
+    else:
+        recency_term = 0.5  # unknown age -> neutral
+
+    score = _W_SIZE * size_term + _W_SPREAD * spread_term + _W_RECENCY * recency_term
+    return round(score, 2)
+
+
+def detect_issues(
+    episodes: list,
+    signals: list[EpisodeSignals],
+    embeddings: list,
+    *,
+    min_cluster: int,
+    now: float,
+) -> list[Issue]:
+    """Cluster episodes by ask embedding and emit gated, scored issues.
+
+    Gate per cluster: >= ``min_cluster`` members, >= 2 distinct sessions,
+    >= 2 members carrying a friction signal, and at least one verbatim
+    evidence span. Clusters that are merely recurring topics with no friction
+    are dropped (conservative: a wrong issue wastes scarce human attention).
+    """
+    indices = list(range(len(episodes)))
+    clusters = cluster_by_similarity(
+        indices, embed_fn=lambda i: embeddings[i], threshold=CLUSTER_SIMILARITY
+    )
+
+    issues: list[Issue] = []
+    for cluster in clusters:
+        if len(cluster) < min_cluster:
+            continue
+
+        members = [episodes[i] for i in cluster]
+        sigs = [signals[i] for i in cluster]
+
+        sessions = {getattr(m, "session_id", "") for m in members}
+        if len(sessions) < 2:
+            continue
+
+        frictional = [(m, s) for m, s in zip(members, sigs) if s.has_friction]
+        if len(frictional) < 2:
+            continue
+
+        # Evidence: most recent frictional members first, verbatim spans only.
+        frictional.sort(key=lambda ms: _episode_epoch_safe(ms[0]) or 0.0, reverse=True)
+        evidence: list[IssueEvidence] = []
+        for m, s in frictional:
+            span = _evidence_span(m, s)
+            if not span:
+                continue
+            evidence.append(
+                IssueEvidence(
+                    session_id=getattr(m, "session_id", ""),
+                    timestamp=getattr(m, "timestamp", "") or "",
+                    span=span,
+                )
+            )
+            if len(evidence) >= _MAX_EVIDENCE:
+                break
+        if not evidence:
+            continue
+
+        category, title = _categorize(members, sigs)
+        confidence = _confidence(len(members), len(sessions), members, now)
+        issues.append(
+            Issue(
+                title=title,
+                category=category,
+                confidence=confidence,
+                evidence=evidence,
+                session_count=len(sessions),
+                member_count=len(members),
+            )
+        )
+
+    issues.sort(key=lambda iss: iss.confidence, reverse=True)
+    return issues
+
+
+def _embed_text_for(ep, embed: Optional[Callable]) -> Optional[object]:
+    """Embed the ask, sharpened with the first error line when present.
+
+    Terse asks ("fix it") cluster poorly; folding in the error line gives the
+    clusterer more signal for frictional episodes.
+    """
+    if embed is None:
+        return None
+    text = getattr(ep, "ask", "") or ""
+    errors = _episode_errors(ep)
+    if errors:
+        line = _substantive_error_line(errors[0]) or _first_line(errors[0])
+        if line:
+            text = f"{text}\n{line}" if text else line
+    if not text:
+        return None
+    try:
+        return embed(text)
+    except Exception:
+        return None
+
+
+def find_issues(
+    store,
+    *,
+    since_seconds: Optional[float] = None,
+    min_cluster: int = 3,
+    sources: Optional[list] = None,
+    now: Optional[float] = None,
+) -> list[Issue]:
+    """Collect recent episodes across all transcript sources and detect issues.
+
+    Read-only: collects episodes within the ``since_seconds`` window but never
+    consults or writes the ingester watermark, so it is fully decoupled from
+    fact admission and safe to run repeatedly.
+    """
+    import time
+
+    from neo.memory.transcript import (
+        CarSource,
+        ClaudeCodeSource,
+        CodexSource,
+        _episode_epoch,
+    )
+
+    if now is None:
+        now = time.time()
+
+    root = getattr(store, "codebase_root", None)
+    if sources is None:
+        sources = [ClaudeCodeSource(root), CodexSource(root), CarSource()]
+
+    cutoff = (now - since_seconds) if since_seconds else None
+
+    episodes: list = []
+    for src in sources:
+        try:
+            collected = src.collect_episodes()
+        except Exception:
+            continue
+        for ep in collected:
+            if not ep.is_substantive:
+                continue
+            if cutoff is not None:
+                ts = _episode_epoch(getattr(ep, "timestamp", "") or "")
+                if ts is not None and ts < cutoff:
+                    continue
+            episodes.append(ep)
+
+    if len(episodes) < min_cluster:
+        return []
+
+    embed = getattr(store, "_embed_text", None)
+    embeddings = [_embed_text_for(ep, embed) for ep in episodes]
+    # Distinguish a genuine "no recurring frictions" from an embedder that
+    # never loaded (offline / missing model) — the latter silently drops every
+    # episode in clustering and would otherwise look like a clean result.
+    if all(e is None for e in embeddings):
+        logger.warning(
+            "memory issues: no embeddings produced for %d episode(s); "
+            "cannot cluster (embedder unavailable?)",
+            len(episodes),
+        )
+        return []
+    signals = [tag_signals(ep) for ep in episodes]
+
+    return detect_issues(
+        episodes, signals, embeddings, min_cluster=min_cluster, now=now
+    )

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover - non-POSIX fallback
 
 import numpy as np
 
-from neo.math_utils import batched_cosine, cosine_similarity
+from neo.math_utils import batched_cosine, cluster_by_similarity, cosine_similarity
 from neo.memory.bm25 import BM25, tokenize
 from neo.memory.query_routing import QueryShape, decompose as _decompose_query
 from neo.memory.claude_memory import ClaudeMemoryIngester
@@ -2145,34 +2145,9 @@ class FactStore:
 
         Returns list of clusters (each a list of facts).
         """
-        embedded = [f for f in facts if f.embedding is not None]
-        if not embedded:
-            return []
-
-        assigned: set[str] = set()
-        clusters: list[list[Fact]] = []
-
-        for fact in embedded:
-            if fact.id in assigned:
-                continue
-
-            cluster = [fact]
-            assigned.add(fact.id)
-
-            for other in embedded:
-                if other.id in assigned:
-                    continue
-                # Complete-linkage: must be similar to ALL cluster members
-                if all(
-                    self._cosine_similarity(member.embedding, other.embedding) >= threshold  # type: ignore[arg-type]
-                    for member in cluster
-                ):
-                    cluster.append(other)
-                    assigned.add(other.id)
-
-            clusters.append(cluster)
-
-        return clusters
+        return cluster_by_similarity(
+            facts, embed_fn=lambda f: f.embedding, threshold=threshold
+        )
 
     def _synthesize_cluster(
         self, cluster: list[Fact], group_key: str

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -340,11 +340,84 @@ def _handle_observer(args) -> None:
     print(" ".join(parts))
 
 
+def _parse_since(value: str) -> Optional[float]:
+    """Parse a duration like ``14d`` / ``48h`` / ``30m`` / ``3600s`` to seconds.
+
+    Returns None for an empty value or ``all`` (no window). A bare number is
+    treated as seconds. Raises ValueError on anything else.
+    """
+    if not value:
+        return None
+    v = value.strip().lower()
+    if v in ("all", "0"):
+        return None
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+    if v[-1] in units and v[:-1].replace(".", "", 1).isdigit():
+        return float(v[:-1]) * units[v[-1]]
+    if v.replace(".", "", 1).isdigit():
+        return float(v)
+    raise ValueError(f"invalid --since value: {value!r} (use e.g. 14d, 48h, 30m)")
+
+
+def _handle_issues(args) -> None:
+    """Surface recurring frictions mined from transcript history (read-only)."""
+    from neo.config import NeoConfig
+    from neo.memory.issues import find_issues
+    from neo.memory.store import FactStore
+
+    root = getattr(args, "cwd", None) or os.getcwd()
+    try:
+        since_seconds = _parse_since(getattr(args, "since", "14d"))
+    except ValueError as e:
+        print(f"[Neo] {e}", file=sys.stderr)
+        return
+    min_cluster = getattr(args, "min_cluster", 3)
+
+    config = NeoConfig.load()
+    store = FactStore(codebase_root=root, config=config, eager_init=False)
+    issues = find_issues(store, since_seconds=since_seconds, min_cluster=min_cluster)
+
+    if getattr(args, "json", False):
+        payload = [
+            {
+                "title": iss.title,
+                "category": iss.category,
+                "confidence": iss.confidence,
+                "session_count": iss.session_count,
+                "member_count": iss.member_count,
+                "evidence": [
+                    {"session_id": ev.session_id, "timestamp": ev.timestamp, "span": ev.span}
+                    for ev in iss.evidence
+                ],
+                "suggested_rule": iss.suggested_rule,
+            }
+            for iss in issues
+        ]
+        print(json.dumps(payload, indent=2))
+        return
+
+    window = getattr(args, "since", "14d")
+    if not issues:
+        print(f"[Neo] memory issues: no recurring frictions found (window: {window}).")
+        return
+
+    print(f"[Neo] memory issues — {len(issues)} issue(s) (window: {window})\n")
+    for iss in issues:
+        print(f"[{iss.confidence:.2f}] {iss.title}    ·{iss.category}")
+        print(f"  {iss.member_count} episodes across {iss.session_count} sessions")
+        for ev in iss.evidence:
+            print(f"    {ev.timestamp or '?'}  {ev.span}")
+        print()
+
+
 def handle_memory(args):
     """Memory maintenance subcommands."""
     action = getattr(args, "memory_action", None)
     if action == "observer":
         _handle_observer(args)
+        return
+    if action == "issues":
+        _handle_issues(args)
         return
     if action == "prune":
         files = _fact_files_for_prune(
@@ -383,7 +456,7 @@ def handle_memory(args):
         return
 
     if action != "replay-feedback":
-        print("Usage: neo memory {replay-feedback|prune|observer} ...")
+        print("Usage: neo memory {replay-feedback|prune|observer|issues} ...")
         return
 
     from neo.config import NeoConfig

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,396 @@
+"""Tests for the conversation-mined issue diagnostic (neo.memory.issues).
+
+Model-free and deterministic: a fake embedder maps text to fixed unit vectors
+and episodes are hand-built, so no Jina model loads and clustering is exact.
+"""
+
+import numpy as np
+
+from neo.memory.issues import (
+    CATEGORY_ABSENT_GUARDRAIL,
+    CATEGORY_MISSING_TOOL,
+    CATEGORY_VAGUE_RULE,
+    Issue,
+    IssueEvidence,
+    detect_issues,
+    find_issues,
+    tag_signals,
+)
+from neo.memory.models import FactScope
+from neo.memory.transcript import Episode
+
+NOW = 1_000_000.0
+RECENT = str(NOW - 100)
+STALE = str(NOW - 40 * 86400)
+
+_TESTS = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+_LINT = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+_OTHER = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+
+def fake_embed(text):
+    """Keyword -> fixed vector, so 'same topic' clusters exactly."""
+    t = (text or "").lower()
+    if "pytest" in t or "unittest" in t or "test framework" in t:
+        return _TESTS
+    if "ruff" in t or "import" in t or "e402" in t:
+        return _LINT
+    return _OTHER
+
+
+class _StaticSource:
+    name = "test"
+    scope = FactScope.PROJECT
+
+    def __init__(self, episodes):
+        self._episodes = list(episodes)
+
+    def collect_episodes(self):
+        return list(self._episodes)
+
+
+class _FakeStore:
+    codebase_root = "/tmp/repo"
+
+    def _embed_text(self, text):
+        return fake_embed(text)
+
+
+def _ep(session, ask, *, errors=None, assistant=None, ts=RECENT):
+    return Episode(
+        session_id=session,
+        anchor_uuid=session + "-a",
+        last_uuid=session + "-b",
+        timestamp=ts,
+        ask=ask,
+        assistant_text=list(assistant or []),
+        errors=list(errors or []),
+    )
+
+
+def _signals(episodes):
+    return [tag_signals(e) for e in episodes]
+
+
+def _embeds(episodes):
+    return [fake_embed(e.ask) for e in episodes]
+
+
+# --------------------------------------------------------------------------
+# tag_signals
+# --------------------------------------------------------------------------
+
+
+def test_tag_signals_detects_tool_error():
+    ep = _ep("s1", "run ruff", errors=["E402 module level import not at top of file"])
+    sig = tag_signals(ep)
+    assert sig.has_tool_error is True
+    assert sig.error_class and "import" in sig.error_class
+    assert sig.asst_asked_clarification is False
+    assert sig.has_friction is True
+
+
+def test_tag_signals_detects_clarification():
+    ep = _ep("s1", "fix the tests", assistant=["Sure — could you clarify which file you mean?"])
+    sig = tag_signals(ep)
+    assert sig.asst_asked_clarification is True
+    assert sig.has_tool_error is False
+    assert sig.has_friction is True
+
+
+def test_tag_signals_no_friction():
+    ep = _ep("s1", "add a function", assistant=["Done."])
+    sig = tag_signals(ep)
+    assert sig.has_friction is False
+
+
+def test_tool_use_error_envelope_is_not_friction():
+    # Claude Code's own tool-protocol guards are harness churn, not project issues.
+    ep = _ep(
+        "s1", "edit file",
+        errors=["<tool_use_error>File has not been read yet. Read it first.</tool_use_error>"],
+    )
+    sig = tag_signals(ep)
+    assert sig.has_tool_error is False
+    assert sig.has_friction is False
+
+
+def test_bare_exit_code_banner_is_not_friction():
+    for banner in ("Exit code 2", "Process exited with code 1", "Command timed out"):
+        sig = tag_signals(_ep("s1", "run it", errors=[banner]))
+        assert sig.has_tool_error is False, banner
+
+
+def test_non_error_command_output_is_not_friction():
+    # A non-zero exit whose captured output is not an error message (a section
+    # header, a diff) must not register as friction.
+    ep = _ep("s1", "show deltas", errors=["=== engine.rs 540-566 (state deltas) ==="])
+    sig = tag_signals(ep)
+    assert sig.has_tool_error is False
+    assert sig.has_friction is False
+
+
+def test_code_identifier_containing_error_is_not_friction():
+    # A Rust type like WorkflowError in a signature is code, not an error.
+    ep = _ep("s1", "edit fn", errors=[") -> Result<StepOutcome, WorkflowError> {"])
+    sig = tag_signals(ep)
+    assert sig.has_tool_error is False
+    assert sig.has_friction is False
+
+
+def test_error_like_line_found_past_output_noise():
+    # Real error buried under non-error output lines is still found.
+    blob = "=== build log ===\nrunning step 3\nfatal: not a git repository"
+    sig = tag_signals(_ep("s1", "build", errors=[blob]))
+    assert sig.has_tool_error is True
+    assert sig.error_class and "git repository" in sig.error_class
+
+
+def test_real_git_merge_error_survives_filtering():
+    # The genuine recurring finding from the cross-project probe must survive.
+    line = "error: Your local changes to the following files would be overwritten by merge:"
+    sig = tag_signals(_ep("s1", "git merge", errors=[line]))
+    assert sig.has_tool_error is True
+    assert sig.error_class and "overwritten by merge" in sig.error_class
+
+
+def test_banner_then_substantive_line_keeps_substantive_class():
+    # Codex-style: banner first line, real error after -> use the real line.
+    ep = _ep("s1", "run", errors=["Process exited with code 1\nModuleNotFoundError: foo"])
+    sig = tag_signals(ep)
+    assert sig.has_tool_error is True
+    assert sig.error_class and "modulenotfounderror" in sig.error_class
+
+
+def test_harness_noise_clusters_produce_no_issues():
+    eps = [
+        _ep("s1", "edit a", errors=["<tool_use_error>File has not been read yet.</tool_use_error>"]),
+        _ep("s2", "edit b", errors=["<tool_use_error>File has not been read yet.</tool_use_error>"]),
+        _ep("s3", "edit c", errors=["<tool_use_error>File has not been read yet.</tool_use_error>"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert issues == []
+
+
+def test_normalize_error_groups_volatile_variants():
+    a = tag_signals(_ep("s1", "x", errors=["File /a/b/c.py line 42: E402 import not at top"]))
+    b = tag_signals(_ep("s2", "x", errors=["File /q/r.py line 9: E402 import not at top"]))
+    assert a.error_class == b.error_class  # paths + line numbers stripped
+
+
+# --------------------------------------------------------------------------
+# detect_issues — gate
+# --------------------------------------------------------------------------
+
+
+def test_gate_rejects_small_cluster():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["could you clarify?"]),
+        _ep("s2", "pytest framework?", assistant=["could you clarify?"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert issues == []
+
+
+def test_gate_requires_two_distinct_sessions():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["could you clarify?"]),
+        _ep("s1", "pytest framework?", assistant=["could you clarify?"]),
+        _ep("s1", "test framework choice?", assistant=["could you clarify?"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert issues == []
+
+
+def test_gate_requires_friction():
+    # Recurring topic across sessions but no errors / no clarification -> not an issue.
+    eps = [
+        _ep("s1", "use pytest", assistant=["Done."]),
+        _ep("s2", "pytest setup", assistant=["Done."]),
+        _ep("s3", "test framework pytest", assistant=["Done."]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert issues == []
+
+
+# --------------------------------------------------------------------------
+# detect_issues — emission + categories
+# --------------------------------------------------------------------------
+
+
+def test_emits_vague_rule_for_clarification_cluster():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["Could you clarify which test framework?"]),
+        _ep("s2", "test framework?", assistant=["I'm not sure — please specify the framework."]),
+        _ep("s3", "pytest or not?", assistant=["Could you clarify the framework you want?"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_VAGUE_RULE
+    assert issues[0].session_count == 3
+    assert issues[0].member_count == 3
+
+
+def test_emits_missing_tool_for_command_not_found():
+    eps = [
+        _ep("s1", "run ruff lint", errors=["ruff: command not found"]),
+        _ep("s2", "ruff check imports", errors=["ruff: command not found"]),
+        _ep("s3", "lint with ruff", errors=["ruff: command not found"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_MISSING_TOOL
+
+
+def test_emits_absent_guardrail_for_recurring_error():
+    eps = [
+        _ep("s1", "fix ruff import", errors=["E402 module level import not at top"]),
+        _ep("s2", "ruff import order", errors=["E402 module level import not at top"]),
+        _ep("s3", "imports failing ruff", errors=["E402 module level import not at top"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_ABSENT_GUARDRAIL
+
+
+def test_no_such_file_is_absent_guardrail_not_missing_tool():
+    # "No such file" is a missing path, not a missing tool -> absent-guardrail.
+    eps = [
+        _ep("s1", "search lib", errors=["ugrep: src/lib.rs: No such file or directory"]),
+        _ep("s2", "search lib", errors=["ugrep: src/lib.rs: No such file or directory"]),
+        _ep("s3", "search lib", errors=["ugrep: src/lib.rs: No such file or directory"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_ABSENT_GUARDRAIL
+
+
+def test_category_precedence_tool_error_beats_clarification():
+    # Mixed cluster: tool error must win over clarification (most structural).
+    eps = [
+        _ep("s1", "run ruff", errors=["ruff: command not found"], assistant=["could you clarify?"]),
+        _ep("s2", "ruff lint", errors=["ruff: command not found"]),
+        _ep("s3", "ruff imports", assistant=["could you clarify?"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_MISSING_TOOL
+
+
+# --------------------------------------------------------------------------
+# evidence + scoring
+# --------------------------------------------------------------------------
+
+
+def test_evidence_spans_are_verbatim():
+    eps = [
+        _ep("s1", "run ruff", errors=["ruff: command not found"]),
+        _ep("s2", "ruff lint", errors=["ruff: command not found"]),
+        _ep("s3", "ruff imports", errors=["ruff: command not found"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert issues
+    for ev in issues[0].evidence:
+        assert isinstance(ev, IssueEvidence)
+        # span must be a verbatim substring of the source error
+        src_ep = next(e for e in eps if e.session_id == ev.session_id)
+        assert ev.span in src_ep.errors[0]
+    assert len(issues[0].evidence) <= 3
+
+
+def test_clarification_evidence_spans_are_verbatim():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["First line.", "Could you clarify the test framework?"]),
+        _ep("s2", "test framework?", assistant=["Please specify which framework to use."]),
+        _ep("s3", "pytest?", assistant=["I'm not sure — could you clarify which one?"]),
+    ]
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 1
+    for ev in issues[0].evidence:
+        src_ep = next(e for e in eps if e.session_id == ev.session_id)
+        # span must be verbatim within a single assistant turn, not a join.
+        assert any(ev.span in turn for turn in src_ep.assistant_text)
+
+
+def test_empty_string_errors_do_not_satisfy_friction_gate():
+    # Three similar asks, but their only "error" is an empty envelope -> no friction.
+    eps = [
+        _ep("s1", "run ruff", errors=[""]),
+        _ep("s2", "ruff lint", errors=["   "]),
+        _ep("s3", "ruff imports", errors=[""]),
+    ]
+    sigs = _signals(eps)
+    assert all(not s.has_friction for s in sigs)
+    assert detect_issues(eps, sigs, _embeds(eps), min_cluster=3, now=NOW) == []
+
+
+def test_confidence_ordering_recent_large_first():
+    big_recent = [
+        _ep(f"s{i}", "ruff import error", errors=["E402 import not at top"], ts=RECENT)
+        for i in range(4)
+    ]
+    small_stale = [
+        _ep("c1", "use pytest?", assistant=["could you clarify?"], ts=STALE),
+        _ep("c2", "pytest framework?", assistant=["could you clarify?"], ts=STALE),
+        _ep("c3", "test framework pytest?", assistant=["could you clarify?"], ts=STALE),
+    ]
+    eps = big_recent + small_stale
+    issues = detect_issues(eps, _signals(eps), _embeds(eps), min_cluster=3, now=NOW)
+    assert len(issues) == 2
+    assert issues[0].confidence >= issues[1].confidence
+    assert issues[0].category == CATEGORY_ABSENT_GUARDRAIL  # the big recent cluster
+
+
+# --------------------------------------------------------------------------
+# find_issues orchestrator
+# --------------------------------------------------------------------------
+
+
+def test_find_issues_end_to_end():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["Could you clarify the test framework?"]),
+        _ep("s2", "test framework?", assistant=["Please specify which framework."]),
+        _ep("s3", "pytest or unittest?", assistant=["Could you clarify which you want?"]),
+    ]
+    issues = find_issues(_FakeStore(), sources=[_StaticSource(eps)], now=NOW)
+    assert len(issues) == 1
+    assert issues[0].category == CATEGORY_VAGUE_RULE
+
+
+def test_find_issues_since_filter_excludes_old():
+    eps = [
+        _ep("s1", "use pytest?", assistant=["could you clarify?"], ts=STALE),
+        _ep("s2", "test framework?", assistant=["could you clarify?"], ts=STALE),
+        _ep("s3", "pytest?", assistant=["could you clarify?"], ts=STALE),
+    ]
+    # 7-day window excludes the 40-day-old episodes -> nothing to cluster.
+    issues = find_issues(
+        _FakeStore(), sources=[_StaticSource(eps)], since_seconds=7 * 86400, now=NOW
+    )
+    assert issues == []
+
+
+def test_find_issues_is_read_only_never_invokes_ingester(monkeypatch):
+    """find_issues must not go through the fact-admission / watermark path."""
+    import neo.memory.transcript as tr
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("find_issues must not construct the TranscriptIngester")
+
+    monkeypatch.setattr(tr, "TranscriptIngester", _boom)
+
+    eps = [
+        _ep("s1", "run ruff", errors=["ruff: command not found"]),
+        _ep("s2", "ruff lint", errors=["ruff: command not found"]),
+        _ep("s3", "ruff imports", errors=["ruff: command not found"]),
+    ]
+    issues = find_issues(_FakeStore(), sources=[_StaticSource(eps)], now=NOW)
+    assert len(issues) == 1  # ran to completion without touching the ingester
+
+
+def test_issue_dataclass_shape():
+    iss = Issue(
+        title="t", category=CATEGORY_VAGUE_RULE, confidence=0.5,
+        evidence=[], session_count=2, member_count=3,
+    )
+    assert iss.suggested_rule is None  # v1: no LM-phrased rule


### PR DESCRIPTION
## Description

Adds `neo memory issues`, a **read-only diagnostic** that mines the existing multi-source transcript episodes (Claude Code / Codex / CAR) for *recurring frictions* and reports them as ranked, evidence-cited issues. It flips the ingester's existing friction signals from silent memory-enrichment into actionable output — the memory-side analog of the continuous-quality flywheel ("diagnose failures by clustering root causes") and an automation of "add a rule every time the agent does something it should not do again."

```
neo memory issues [--since 14d] [--min-cluster 3] [--json] [--cwd PATH]
```

Pipeline (`neo/memory/issues.py`, LM-free in v1): collect episodes → `tag_signals` → cluster ask embeddings (Jina, shared `math_utils.cluster_by_similarity` at 0.85) → gate → categorize + score → ranked list. Categories map to the harness failure taxonomy: `missing-tool`, `absent-guardrail`, `vague-rule`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code cleanup/refactoring (extract `cluster_by_similarity` into `math_utils`)
- [x] Documentation update

## Related Issue

N/A — design originated from the Day-1 SDLC paper review; design note in `docs/solutions/conversation-mined-issues.md`.

## Motivation and Context

The memory ingester already parses transcripts into episodes and computes friction signals (tool errors, assistant clarification) but only ever used them to silently enrich retrieval. This surfaces the friction itself as issues the developer/orchestrator can act on, without any new fact kinds and without mutating memory.

**Hard contract — read-only / no-consume:** `find_issues` never constructs `TranscriptIngester` and never reads or writes the `transcript_watermark_*` files. It is fully decoupled from fact admission and idempotent (guarded by `test_find_issues_is_read_only_never_invokes_ingester`).

## How Has This Been Tested?

- [x] 28 model-free, deterministic unit tests in `tests/test_issues.py` (fake embedder, hand-built episodes): signal tagging, clustering, gate (min-cluster / ≥2 sessions / friction / verbatim evidence), category precedence, confidence ordering, noise filtering, read-only contract.
- [x] Full suite green: **1074 passed, 3 skipped**; `ruff` clean.
- [x] Synthesis/clustering refactor verified behavior-identical (existing synthesis tests pass after re-pointing `store._cluster_by_similarity`).
- [x] **Validated against real transcript history across 8 local projects.** The probe exposed that `Episode.errors` is noisy (Claude Code `<tool_use_error>` guards, bare exit codes, non-error command output, code identifiers like `WorkflowError`). Added a precision filter matching only diagnostic-position error signals. On the busiest repo this turned **7 noise findings into 2 genuine cross-session frictions** (recurring `git merge` blocked by local changes; `ugrep` repeatedly searching non-existent paths); every other project correctly stayed quiet.

**Test Configuration**:
- Python version: 3.14.5
- OS: macOS (darwin)
- Neo version: dev (branch `feat/memory-issues-diagnostic`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code (plus a review by the `neo` agent; findings addressed)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Conservative by design (precision over recall): the gate is strict and the error filter biases toward dropping ambiguous signal, because a wrong issue wastes scarce human attention. Deferred to follow-ups: `--suggest-rules` (gated LM rule phrasing; `Issue.suggested_rule` is the placeholder), dedup against existing FAILURE facts, and artifact-drift detectors (CLAUDE.md vs transcripts).