### PR TITLE
feat: neo memory issues --suggest-rules (v0.24.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.24.0] - 2026-06-19
+
+### Added
+
+- **`neo memory issues --suggest-rules`** — for each surfaced friction, makes one bounded LM call to draft a preventive `AGENTS.md`/`CLAUDE.md` rule, populating the `Issue.suggested_rule` field (shown in both human and `--json` output). This closes the loop the issue diagnostic opened: v0.23.0 automated *detecting* recurring agent mistakes; this drafts the first version of the rule that would stop them, leaving the developer to review and apply (consistent with neo's read-only, advisory role). The LM-bearing step is confined to this flag — `find_issues` stays deterministic and LM-free — and is cost-bounded (one call per issue, highest-confidence first, capped at `_MAX_SUGGESTED_RULES`). Per-issue LM failure is graceful (leaves `suggested_rule` unset rather than aborting the batch); the adapter is built via `resolve_adapter` only when the flag is set. (`memory/issues.py`, `cli.py`, `subcommands.py`)
+
 ## [0.23.0] - 2026-06-19
 
 ### Added

--- a/docs/solutions/conversation-mined-issues.md
+++ b/docs/solutions/conversation-mined-issues.md
@@ -80,11 +80,17 @@ admission, idempotent, and safe to run repeatedly. Guarded by
   embed_fn, threshold)`; both synthesis and this diagnostic share one
   implementation.
 
+## `--suggest-rules` (shipped v0.24.0)
+
+`neo memory issues --suggest-rules` makes one bounded LM call per surviving
+issue (highest-confidence first, capped at `_MAX_SUGGESTED_RULES`) to draft a
+preventive AGENTS.md rule, populating `Issue.suggested_rule`. The LM-bearing
+step is confined to `suggest_rules` in the CLI path — `find_issues` stays
+deterministic and LM-free. Per-issue LM failure is graceful (leaves the rule
+unset); the adapter is built via `resolve_adapter` only when the flag is set.
+
 ## Deferred (post-v1)
 
-- `--suggest-rules`: one gated LM call per surviving cluster to phrase a
-  proposed AGENTS.md/CLAUDE.md rule (Stage-B style). `Issue.suggested_rule` is
-  the placeholder.
 - Dedup against existing FAILURE facts (annotate "already in memory").
 - Detectors 5–6: artifact drift (CLAUDE.md asserts X, transcripts show not-X)
   and contradiction (CLAUDE.md vs AGENTS.md vs Neo facts) — need an LM judge +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.23.0"
+version = "0.24.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -230,6 +230,11 @@ def parse_args():
             help='Minimum recurring episodes before a friction is reported (default: 3)',
         )
         issues_p.add_argument('--json', action='store_true', help='Emit issues as JSON')
+        issues_p.add_argument(
+            '--suggest-rules',
+            action='store_true',
+            help='For each issue, make one LM call to draft a preventive AGENTS.md rule',
+        )
         issues_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
         args = p.parse_args(sys.argv[2:])

--- a/src/neo/memory/issues.py
+++ b/src/neo/memory/issues.py
@@ -497,3 +497,78 @@ def find_issues(
     return detect_issues(
         episodes, signals, embeddings, min_cluster=min_cluster, now=now
     )
+
+
+# ---------------------------------------------------------------------------
+# --suggest-rules: one gated LM call per issue to phrase a proposed rule.
+# ---------------------------------------------------------------------------
+
+# Bounds LM cost. The gate already keeps the issue list small, but a target
+# repo could in principle surface many; cap to stay cheap and predictable.
+_MAX_SUGGESTED_RULES = 25
+
+_RULE_PROMPT = """You improve a software project's AGENTS.md / CLAUDE.md rules \
+for an AI coding agent.
+
+A recurring friction was mined from the agent's own transcript history:
+
+  Category:  <<CATEGORY>>
+  Summary:   <<TITLE>>
+  Recurred:  <<MEMBERS>> times across <<SESSIONS>> sessions
+  Evidence (verbatim from transcripts):
+<<EVIDENCE>>
+
+Write ONE concise, imperative rule (1-2 sentences) that, added to AGENTS.md, \
+would prevent this friction from recurring. Be specific and actionable; do not \
+merely restate the problem. If no useful preventive rule applies, return an \
+empty string.
+
+Respond with JSON only: {"rule": "<the rule, or empty string>"}"""
+
+
+def _suggest_one(iss: Issue, lm_adapter) -> Optional[str]:
+    """One LM call to phrase a preventive rule for an issue, or None."""
+    from neo.memory.transcript import _parse_json
+
+    evidence = "\n".join(f"    - {ev.span}" for ev in iss.evidence) or "    (none)"
+    prompt = (
+        _RULE_PROMPT
+        .replace("<<CATEGORY>>", iss.category)
+        .replace("<<TITLE>>", iss.title)
+        .replace("<<MEMBERS>>", str(iss.member_count))
+        .replace("<<SESSIONS>>", str(iss.session_count))
+        .replace("<<EVIDENCE>>", evidence)
+    )
+    try:
+        out = lm_adapter.generate(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200,
+            temperature=0.2,
+        )
+    except Exception as e:
+        logger.warning("memory issues: rule-suggestion LM call failed: %s", e)
+        return None
+    data = _parse_json(out)
+    if not isinstance(data, dict):
+        return None
+    rule = str(data.get("rule") or "").strip()
+    return rule or None
+
+
+def suggest_rules(
+    issues: list[Issue], lm_adapter, *, max_rules: int = _MAX_SUGGESTED_RULES
+) -> list[Issue]:
+    """Populate ``Issue.suggested_rule`` with an LM-phrased preventive rule.
+
+    Mutates issues in place (and returns them). One bounded LM call per issue,
+    highest-confidence first, up to ``max_rules``. A no-op when ``lm_adapter``
+    is None; any per-issue LM failure leaves that issue's ``suggested_rule`` as
+    None rather than aborting the batch.
+    """
+    if lm_adapter is None:
+        return issues
+    for iss in issues[:max_rules]:
+        rule = _suggest_one(iss, lm_adapter)
+        if rule:
+            iss.suggested_rule = rule
+    return issues

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -377,6 +377,21 @@ def _handle_issues(args) -> None:
     store = FactStore(codebase_root=root, config=config, eager_init=False)
     issues = find_issues(store, since_seconds=since_seconds, min_cluster=min_cluster)
 
+    if getattr(args, "suggest_rules", False) and issues:
+        try:
+            from neo.adapters import resolve_adapter
+            from neo.memory.issues import suggest_rules
+
+            adapter = resolve_adapter(config)
+        except Exception as e:
+            print(
+                f"[Neo] --suggest-rules: could not build an LM adapter ({e}); "
+                "reporting issues without suggested rules.",
+                file=sys.stderr,
+            )
+        else:
+            suggest_rules(issues, adapter)
+
     if getattr(args, "json", False):
         payload = [
             {
@@ -407,6 +422,8 @@ def _handle_issues(args) -> None:
         print(f"  {iss.member_count} episodes across {iss.session_count} sessions")
         for ev in iss.evidence:
             print(f"    {ev.timestamp or '?'}  {ev.span}")
+        if iss.suggested_rule:
+            print(f"  suggested rule: {iss.suggested_rule}")
         print()
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -14,6 +14,7 @@ from neo.memory.issues import (
     IssueEvidence,
     detect_issues,
     find_issues,
+    suggest_rules,
     tag_signals,
 )
 from neo.memory.models import FactScope
@@ -386,6 +387,82 @@ def test_find_issues_is_read_only_never_invokes_ingester(monkeypatch):
     ]
     issues = find_issues(_FakeStore(), sources=[_StaticSource(eps)], now=NOW)
     assert len(issues) == 1  # ran to completion without touching the ingester
+
+
+# --------------------------------------------------------------------------
+# suggest_rules (--suggest-rules)
+# --------------------------------------------------------------------------
+
+
+class _FakeLM:
+    """Records prompts; returns a canned reply (str or Exception to raise)."""
+
+    def __init__(self, reply):
+        self._reply = reply
+        self.prompts = []
+
+    def generate(self, messages, max_tokens=None, temperature=None):
+        self.prompts.append(messages[0]["content"])
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return self._reply
+
+
+def _issue(title="t", category=CATEGORY_ABSENT_GUARDRAIL, conf=0.9):
+    return Issue(
+        title=title, category=category, confidence=conf,
+        evidence=[IssueEvidence("s1", "1000", "error: boom")],
+        session_count=2, member_count=3,
+    )
+
+
+def test_suggest_rules_populates_from_json():
+    lm = _FakeLM('{"rule": "Always stash before merging."}')
+    issues = [_issue()]
+    suggest_rules(issues, lm)
+    assert issues[0].suggested_rule == "Always stash before merging."
+
+
+def test_suggest_rules_prompt_includes_evidence():
+    lm = _FakeLM('{"rule": "x"}')
+    suggest_rules([_issue(title="git merge friction")], lm)
+    assert "error: boom" in lm.prompts[0]
+    assert "git merge friction" in lm.prompts[0]
+
+
+def test_suggest_rules_none_adapter_is_noop():
+    issues = [_issue()]
+    suggest_rules(issues, None)
+    assert issues[0].suggested_rule is None
+
+
+def test_suggest_rules_lm_failure_is_graceful():
+    lm = _FakeLM(RuntimeError("api down"))
+    issues = [_issue()]
+    suggest_rules(issues, lm)
+    assert issues[0].suggested_rule is None  # batch not aborted, just left unset
+
+
+def test_suggest_rules_empty_rule_stays_none():
+    lm = _FakeLM('{"rule": ""}')
+    issues = [_issue()]
+    suggest_rules(issues, lm)
+    assert issues[0].suggested_rule is None
+
+
+def test_suggest_rules_unparseable_response_stays_none():
+    lm = _FakeLM("Sure! Here is a great rule for you.")  # no JSON object
+    issues = [_issue()]
+    suggest_rules(issues, lm)
+    assert issues[0].suggested_rule is None
+
+
+def test_suggest_rules_respects_max_rules_cap():
+    lm = _FakeLM('{"rule": "r"}')
+    issues = [_issue(title=f"i{i}") for i in range(5)]
+    suggest_rules(issues, lm, max_rules=2)
+    assert len(lm.prompts) == 2
+    assert [bool(i.suggested_rule) for i in issues] == [True, True, False, False, False]
 
 
 def test_issue_dataclass_shape():


### PR DESCRIPTION
## Description

Adds the deferred **`--suggest-rules`** flag to `neo memory issues` and bumps to **v0.24.0**. For each surfaced friction, neo makes one bounded LM call to draft a preventive `AGENTS.md`/`CLAUDE.md` rule, populating `Issue.suggested_rule` (shown in human and `--json` output).

This closes the loop the diagnostic opened: v0.23.0 automated *detecting* recurring agent mistakes; this drafts the rule that would stop them — leaving the developer to review and apply (read-only, advisory).

## Type of Change

- [x] New feature (non-breaking; opt-in flag)
- [x] Documentation update

## Design

- **LM step is confined to `suggest_rules`** in the CLI path — `find_issues` stays deterministic and LM-free.
- **Cost-bounded**: one call per issue, highest-confidence first, capped at `_MAX_SUGGESTED_RULES` (25).
- **Graceful**: per-issue LM failure leaves `suggested_rule` unset rather than aborting the batch; the adapter is built via `resolve_adapter` only when the flag is set; adapter-build failure degrades to reporting issues without rules.
- Parses a strict `{"rule": "..."}` contract via the existing tolerant `_parse_json`; empty/unparseable → `None`.

## How Has This Been Tested?

- [x] 7 new tests (fake LM adapter): JSON population, prompt includes evidence, None-adapter no-op, LM-exception graceful, empty-rule → None, unparseable → None, `max_rules` cap.
- [x] Full suite green: **1081 passed, 3 skipped**; `ruff` clean.

## Checklist

- [x] Version bumped consistently (pyproject.toml, src/neo/__init__.py, .claude-plugin/plugin.json)
- [x] CHANGELOG.md updated (0.24.0); design note updated
- [x] New and existing unit tests pass locally