### PR TITLE
feat: neo memory rules — flag drift between AGENTS.md / CLAUDE.md / GEMINI.md (v0.25.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,13 @@
     cold start (`store.py:190-192`). For on-demand compaction of tombstone bloat in a
     specific project's fact file, use `neo memory prune [--all] [--dry-run]`
     (`subcommands.py:_compact_fact_file`).
+  - Diagnostics (read-only, flag-and-propose): `neo memory issues [--since 14d]
+    [--min-cluster 3] [--suggest-rules] [--json]` surfaces recurring frictions mined from
+    transcript history (Claude Code / Codex / CAR) as ranked, evidence-cited issues
+    (`missing-tool` / `absent-guardrail` / `vague-rule`); `--suggest-rules` adds a bounded
+    LM call per issue to draft a preventive rule. `neo memory rules [--json]
+    [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
+    LM-judged conflicts). (`neo/memory/issues.py`, `neo/memory/rulesync.py`)
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.25.0] - 2026-06-19
+
+### Added
+
+- **`neo memory rules` — flag drift between `AGENTS.md` / `CLAUDE.md` / `GEMINI.md`.** A repo worked by multiple coding agents has multiple rule files, and teams update one while forgetting the others; no single tool notices because each reads only its own. This static cross-file diagnostic discovers the rule files at the repo root, parses each into rule units (bullets with wrapped continuations folded in; headings/fences/prose dropped), embeds them (Jina, shared infra), and reports two divergence kinds: **gaps** (a rule present in one file with no aligned equivalent in another, at cosine < 0.78) and **conflicts** (aligned-but-divergent pairs judged contradictory by a bounded, graceful LM judge — opt out with `--no-conflicts`). Read-only / flag-and-propose: it prints proposed reconciling edits (`Add to AGENTS.md: …` / `Reconcile: …`) but never writes files. Byte-identical files (e.g. a symlinked single source) and single-file repos report "in sync." Dogfooded on this repo, where it correctly surfaced one real gap (a diagnostics section added to CLAUDE.md but not AGENTS.md). `neo memory rules [--json] [--no-conflicts] [--cwd]`. (`memory/rulesync.py`, `cli.py`, `subcommands.py`; see `docs/solutions/rule-file-sync.md`)
+
 ## [0.24.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,17 +36,19 @@
     specific project's fact file, use `neo memory prune [--all] [--dry-run]`
     (`neo/subcommands.py:_compact_fact_file` — at the package root, not
     under `memory/`).
-  - Diagnostics: `neo memory issues [--since 14d] [--min-cluster 3] [--json]`
-    surfaces recurring frictions mined from transcript history (Claude Code /
-    Codex / CAR) as ranked, evidence-cited issues (categories: `missing-tool`,
-    `absent-guardrail`, `vague-rule`). **Read-only**: it reuses the ingester's
-    `TranscriptSource` episodes but never admits facts or touches the
-    `transcript_watermark_*` watermark — decoupled from fact admission and
-    idempotent (`neo/memory/issues.py:find_issues`). Gate mirrors synthesis
-    discipline (≥`min_cluster` members, ≥2 sessions, ≥2 frictional, verbatim
-    evidence). LM-free in v1; clusters at `SYNTHESIS_SIMILARITY` via the shared
-    `math_utils.cluster_by_similarity`. See
-    `docs/solutions/conversation-mined-issues.md`.
+  - Diagnostics (read-only, flag-and-propose): `neo memory issues [--since 14d]
+    [--min-cluster 3] [--suggest-rules] [--json]` surfaces recurring frictions mined from
+    transcript history (Claude Code / Codex / CAR) as ranked, evidence-cited issues
+    (`missing-tool` / `absent-guardrail` / `vague-rule`); `--suggest-rules` adds a bounded
+    LM call per issue to draft a preventive rule. `neo memory rules [--json]
+    [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
+    LM-judged conflicts). (`neo/memory/issues.py`, `neo/memory/rulesync.py`)
+    - `issues` reuses the ingester's `TranscriptSource` episodes but never admits facts or
+      touches the `transcript_watermark_*` watermark — decoupled from fact admission and
+      idempotent (`find_issues`). Gate mirrors synthesis discipline (≥`min_cluster`
+      members, ≥2 sessions, ≥2 frictional, verbatim evidence); clusters at
+      `SYNTHESIS_SIMILARITY` via the shared `math_utils.cluster_by_similarity`. See
+      `docs/solutions/conversation-mined-issues.md` and `docs/solutions/rule-file-sync.md`.
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/docs/solutions/rule-file-sync.md
+++ b/docs/solutions/rule-file-sync.md
@@ -1,0 +1,68 @@
+# Rule-file sync diagnostic — `neo memory rules`
+
+**Status:** v1 (2026-06-19). Static cross-file analysis of `AGENTS.md` /
+`CLAUDE.md` / `GEMINI.md`. Read-only (flag + propose; never writes files).
+
+## Why
+
+A repo worked by more than one coding agent has more than one rule file —
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`. Teams update one and forget the others,
+so the agents drift apart: one is told "use pytest", another never hears it;
+one says "tabs", another "spaces". Nothing in any single tool notices, because
+each reads only its own file. This is the complement to `neo memory issues`:
+issues *suggests* rules from observed friction; this keeps the rules you've
+already written consistent across every agent's config — the paper's "treat
+AGENTS.md/CLAUDE.md as versioned code" applied across tools.
+
+## What it is
+
+```
+neo memory rules [--json] [--no-conflicts] [--cwd PATH]
+```
+
+A pull command (`neo/memory/rulesync.py`). Pipeline:
+
+1. **Discover** rule files at the repo root (case-insensitive `AGENTS.md` /
+   `CLAUDE.md` / `GEMINI.md`). If <2 exist, or all are byte-identical (e.g. a
+   symlinked single source), report "in sync" and stop.
+2. **Parse** each into rule *units* — bullet items with wrapped/sub-detail
+   continuation lines folded in; headings, code fences, and top-level prose
+   dropped (these files encode rules as bullets; treating prose as rules is
+   noise — learned from running it on this repo, where naive line-splitting
+   produced 12 fragment "gaps" vs. 1 real one after folding).
+3. **Embed** each unit (Jina via `store._embed_text` — same vectors as the rest
+   of memory, no new infra).
+4. **Gaps**: a unit in one file whose best cosine against another file is below
+   `ALIGN_THRESHOLD` (0.78) → "present in X, missing from Y", deduped, with a
+   proposed `Add to <files>: <rule>` edit.
+5. **Conflicts** (LM-judged, opt-out via `--no-conflicts`): a pair that aligns
+   (≥0.78) but isn't near-identical (<`IDENTICAL_THRESHOLD` 0.97) is a candidate
+   contradiction; a bounded, graceful LM judge (`resolve_adapter` + `_parse_json`,
+   same pattern as `issues --suggest-rules`, capped at `_MAX_CONFLICT_CHECKS`)
+   decides `{"conflict": bool, "explanation": str}`.
+
+## Read-only / flag + propose
+
+Never writes files. Gaps yield a proposed `Add to AGENTS.md: …` line; conflicts
+yield a `Reconcile: X says …; Y says …` line. The developer applies the edit —
+consistent with neo's advisory role. (An opt-in `--write` was considered and
+deliberately deferred.)
+
+## Output
+
+```
+[Neo] memory rules — files: AGENTS.md (32 rules), CLAUDE.md (33 rules)
+
+  Gaps (1):
+    • present in claude; missing from agents
+      <the rule text>
+      → Add to AGENTS.md: <the rule text>
+```
+
+`--json` emits `{files, in_sync, note, gaps[], conflicts[]}`.
+
+## Deferred
+
+- `--write` to apply proposed additions (with backup + diff).
+- Nested rule files (sub-directory `AGENTS.md`), and other tools' conventions.
+- Inspecting tools' *memory* artifacts (distinct from static rule files).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.24.0"
+version = "0.25.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -237,6 +237,18 @@ def parse_args():
         )
         issues_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
+        rules_p = subparsers.add_parser(
+            'rules',
+            help='Flag drift between AGENTS.md / CLAUDE.md / GEMINI.md (read-only)',
+        )
+        rules_p.add_argument('--json', action='store_true', help='Emit the sync report as JSON')
+        rules_p.add_argument(
+            '--no-conflicts',
+            action='store_true',
+            help='Skip the LM contradiction check; report gaps only (offline)',
+        )
+        rules_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
+
         args = p.parse_args(sys.argv[2:])
         args.command = 'memory'
         args.memory_action = args.action

--- a/src/neo/memory/rulesync.py
+++ b/src/neo/memory/rulesync.py
@@ -1,0 +1,329 @@
+"""
+Rule-file sync diagnostic — flag drift between AGENTS.md / CLAUDE.md / GEMINI.md.
+
+When a repo is worked by more than one coding agent, each tool reads its own
+rule file (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`). Teams routinely update one
+and forget the others, so the agents drift out of sync — one is told "use
+pytest", another never hears it; one says "tabs", another "spaces". This is a
+static cross-file analysis (no transcripts) that reports two divergence kinds:
+
+- **gap**: a rule present in one file with no equivalent in another.
+- **conflict**: two files whose rules on the same topic contradict (LM-judged).
+
+Flag + propose only — never writes files (neo stays read-only). Reuses the same
+embedding infra as the rest of memory; the LM conflict judge mirrors the
+`issues.suggest_rules` pattern (resolve_adapter + _parse_json), is bounded, and
+degrades gracefully (skipped, not fatal) when no adapter is available.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from neo.math_utils import batched_cosine
+
+logger = logging.getLogger(__name__)
+
+# Canonical tool name per rule-file basename.
+_RULE_FILENAMES = {
+    "AGENTS.md": "agents",
+    "CLAUDE.md": "claude",
+    "GEMINI.md": "gemini",
+}
+
+# Two units "say the same thing" above this cosine — used for gap alignment.
+ALIGN_THRESHOLD = 0.78
+# Above this, the two units are near-identical wording: in sync, never a conflict.
+IDENTICAL_THRESHOLD = 0.97
+# Cap LM conflict-judge calls per run (bounded cost; degrades to fewer checks).
+_MAX_CONFLICT_CHECKS = 40
+
+# Lines that are structure/prose, not rules. Headings, fences, blanks, links-only.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
+_BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.*)$")
+_FENCE_RE = re.compile(r"^\s*```")
+
+
+@dataclass
+class RuleFile:
+    tool: str            # "agents" | "claude" | "gemini"
+    path: str
+    units: list[str] = field(default_factory=list)
+    embeddings: list = field(default_factory=list)  # aligned to units
+
+
+@dataclass
+class RuleGap:
+    rule: str
+    present_in: list[str]
+    missing_from: list[str]
+
+    @property
+    def suggestion(self) -> str:
+        files = ", ".join(f"{t.upper()}.md" for t in self.missing_from)
+        return f"Add to {files}: {self.rule}"
+
+
+@dataclass
+class RuleConflict:
+    tool_a: str
+    text_a: str
+    tool_b: str
+    text_b: str
+    explanation: str = ""
+
+    @property
+    def suggestion(self) -> str:
+        return (
+            f"Reconcile: {self.tool_a.upper()}.md says {self.text_a!r}; "
+            f"{self.tool_b.upper()}.md says {self.text_b!r}. Pick one and update the other."
+        )
+
+
+@dataclass
+class SyncReport:
+    files: list[RuleFile] = field(default_factory=list)
+    gaps: list[RuleGap] = field(default_factory=list)
+    conflicts: list[RuleConflict] = field(default_factory=list)
+    note: str = ""  # e.g. "single source", "all files identical"
+
+    @property
+    def in_sync(self) -> bool:
+        return not self.gaps and not self.conflicts
+
+
+def discover_rule_files(root: str) -> list[tuple[str, Path]]:
+    """Find rule files at the repo root, case-insensitively. (tool, path) pairs."""
+    base = Path(root)
+    if not base.is_dir():
+        return []
+    by_lower = {fn.lower(): (fn, tool) for fn, tool in _RULE_FILENAMES.items()}
+    found: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    try:
+        entries = sorted(base.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.is_file():
+            continue
+        match = by_lower.get(entry.name.lower())
+        if match and match[1] not in seen:
+            found.append((match[1], entry))
+            seen.add(match[1])
+    return found
+
+
+def parse_units(text: str) -> list[str]:
+    """Split a rule-file's markdown into normalized rule units.
+
+    A unit is a bullet item plus any following *more-indented, non-bullet*
+    continuation lines (wrapped text or sub-detail) folded in — so a wrapped
+    bullet does not fragment into meaningless standalone lines. Headings, code
+    fences (and their contents), blank lines, and top-level non-bullet prose are
+    dropped: these files encode rules as bullets, and treating prose as rules is
+    pure noise. Blank lines and headings flush the current unit.
+    """
+    units: list[str] = []
+    in_fence = False
+    current: Optional[str] = None
+    current_indent = 0
+
+    def flush() -> None:
+        nonlocal current
+        if current is not None:
+            u = _normalize_unit(current)
+            if len(u) >= 8:  # skip trivial fragments
+                units.append(u)
+        current = None
+
+    for raw in (text or "").splitlines():
+        if _FENCE_RE.match(raw):
+            in_fence = not in_fence
+            flush()
+            continue
+        if in_fence:
+            continue
+        if not raw.strip() or _HEADING_RE.match(raw):
+            flush()
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        m = _BULLET_RE.match(raw)
+        if m:
+            flush()
+            current = m.group(1).strip()
+            current_indent = indent
+        elif current is not None and indent > current_indent:
+            current += " " + raw.strip()  # wrapped continuation of the bullet
+        else:
+            flush()  # top-level non-bullet prose: not a rule
+    flush()
+    return units
+
+
+def _normalize_unit(s: str) -> str:
+    s = re.sub(r"`([^`]*)`", r"\1", s)         # strip inline code backticks
+    s = re.sub(r"\*\*([^*]*)\*\*", r"\1", s)   # strip bold
+    s = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", s)  # link -> text
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _best_sim(vec, others: list) -> float:
+    """Best cosine of vec against a list of vectors (0.0 if none usable)."""
+    if vec is None or not others:
+        return 0.0
+    sims = batched_cosine(others, vec, default=0.0)
+    return max(sims) if sims else 0.0
+
+
+def analyze_rule_sync(
+    files: list[RuleFile],
+    *,
+    lm_adapter=None,
+) -> SyncReport:
+    """Compute gaps and (optionally LM-judged) conflicts across rule files."""
+    report = SyncReport(files=files)
+    present = [f for f in files if f.units]
+    if len(present) < 2:
+        report.note = "single rule file — nothing to cross-check" if present else "no rule files"
+        return report
+
+    # --- Gaps: a unit in one file with no aligned match in another file. ------
+    # Dedup so the same rule (which may appear in several files) is reported once.
+    seen_gap: set[str] = set()
+    conflict_candidates: list[tuple[RuleFile, str, object, RuleFile, str, object]] = []
+    for fa in present:
+        for ui, unit in enumerate(fa.units):
+            vec = fa.embeddings[ui] if ui < len(fa.embeddings) else None
+            missing_from: list[str] = []
+            for fb in present:
+                if fb.tool == fa.tool:
+                    continue
+                best = _best_sim(vec, fb.embeddings)
+                if best < ALIGN_THRESHOLD:
+                    missing_from.append(fb.tool)
+                elif best < IDENTICAL_THRESHOLD:
+                    # aligned but not identical -> candidate contradiction
+                    bj = _argmax_sim(vec, fb.embeddings)
+                    if bj is not None and fa.tool < fb.tool:  # one direction only
+                        conflict_candidates.append(
+                            (fa, unit, vec, fb, fb.units[bj], fb.embeddings[bj])
+                        )
+            if missing_from:
+                key = unit.lower()
+                if key not in seen_gap:
+                    seen_gap.add(key)
+                    present_in = [fa.tool] + [
+                        fb.tool for fb in present
+                        if fb.tool != fa.tool and _best_sim(vec, fb.embeddings) >= ALIGN_THRESHOLD
+                    ]
+                    report.gaps.append(
+                        RuleGap(rule=unit, present_in=present_in, missing_from=missing_from)
+                    )
+
+    # --- Conflicts: LM-judge the aligned-but-divergent candidate pairs. -------
+    if lm_adapter is not None and conflict_candidates:
+        seen_conf: set[tuple[str, str]] = set()
+        for fa, ta, _va, fb, tb, _vb in conflict_candidates[:_MAX_CONFLICT_CHECKS]:
+            sig = tuple(sorted((ta.lower(), tb.lower())))
+            if sig in seen_conf:
+                continue
+            seen_conf.add(sig)
+            verdict = _judge_conflict(ta, tb, lm_adapter)
+            if verdict and verdict.get("conflict"):
+                report.conflicts.append(
+                    RuleConflict(
+                        tool_a=fa.tool, text_a=ta,
+                        tool_b=fb.tool, text_b=tb,
+                        explanation=str(verdict.get("explanation") or "").strip(),
+                    )
+                )
+    return report
+
+
+def _argmax_sim(vec, others: list) -> Optional[int]:
+    if vec is None or not others:
+        return None
+    sims = batched_cosine(others, vec, default=0.0)
+    if not sims:
+        return None
+    best_i = max(range(len(sims)), key=lambda i: sims[i])
+    return best_i
+
+
+_CONFLICT_PROMPT = """Two rule files for the same codebase each state a rule on \
+what appears to be the same topic. Decide whether they CONTRADICT (prescribe \
+incompatible things) or are merely worded differently / compatible.
+
+Rule A: <<A>>
+Rule B: <<B>>
+
+Respond with JSON only: {"conflict": true|false, "explanation": "<one sentence>"}"""
+
+
+def _judge_conflict(text_a: str, text_b: str, lm_adapter) -> Optional[dict]:
+    from neo.memory.transcript import _parse_json
+
+    prompt = _CONFLICT_PROMPT.replace("<<A>>", text_a).replace("<<B>>", text_b)
+    try:
+        out = lm_adapter.generate(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200,
+            temperature=0.1,
+        )
+    except Exception as e:
+        logger.warning("rulesync: conflict-judge LM call failed: %s", e)
+        return None
+    data = _parse_json(out)
+    return data if isinstance(data, dict) else None
+
+
+def find_rule_sync(
+    store,
+    *,
+    root: Optional[str] = None,
+    check_conflicts: bool = True,
+    lm_adapter=None,
+) -> SyncReport:
+    """Discover rule files under ``root``, embed their units, and analyze sync.
+
+    Read-only. ``lm_adapter`` (for conflict judging) is used only when
+    ``check_conflicts`` is True; absent it, gaps are still reported.
+    """
+    root = root or getattr(store, "codebase_root", None) or "."
+    discovered = discover_rule_files(root)
+
+    files: list[RuleFile] = []
+    contents: dict[str, str] = {}
+    for tool, path in discovered:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        contents[tool] = text
+        files.append(RuleFile(tool=tool, path=str(path), units=parse_units(text)))
+
+    # Identical content (e.g. a symlinked single source) -> explicitly in sync.
+    if len(contents) >= 2 and len(set(contents.values())) == 1:
+        rep = SyncReport(files=files, note="all rule files are identical — in sync")
+        return rep
+
+    embed: Optional[Callable] = getattr(store, "_embed_text", None)
+    if embed is not None:
+        for f in files:
+            f.embeddings = [_safe_embed(embed, u) for u in f.units]
+
+    return analyze_rule_sync(
+        files, lm_adapter=lm_adapter if check_conflicts else None
+    )
+
+
+def _safe_embed(embed: Callable, text: str):
+    try:
+        return embed(text)
+    except Exception:
+        return None

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -359,6 +359,87 @@ def _parse_since(value: str) -> Optional[float]:
     raise ValueError(f"invalid --since value: {value!r} (use e.g. 14d, 48h, 30m)")
 
 
+def _handle_rules(args) -> None:
+    """Flag drift between AGENTS.md / CLAUDE.md / GEMINI.md (read-only)."""
+    from neo.config import NeoConfig
+    from neo.memory.rulesync import find_rule_sync
+    from neo.memory.store import FactStore
+
+    root = getattr(args, "cwd", None) or os.getcwd()
+    config = NeoConfig.load()
+    store = FactStore(codebase_root=root, config=config, eager_init=False)
+
+    check_conflicts = not getattr(args, "no_conflicts", False)
+    lm = None
+    if check_conflicts:
+        try:
+            from neo.adapters import resolve_adapter
+
+            lm = resolve_adapter(config)
+        except Exception as e:
+            print(
+                f"[Neo] rules: no LM adapter for the conflict check ({e}); "
+                "reporting gaps only.",
+                file=sys.stderr,
+            )
+
+    report = find_rule_sync(
+        store, root=root, check_conflicts=check_conflicts, lm_adapter=lm
+    )
+
+    if getattr(args, "json", False):
+        payload = {
+            "files": [
+                {"tool": f.tool, "path": f.path, "rule_count": len(f.units)}
+                for f in report.files
+            ],
+            "in_sync": report.in_sync,
+            "note": report.note,
+            "gaps": [
+                {
+                    "rule": g.rule,
+                    "present_in": g.present_in,
+                    "missing_from": g.missing_from,
+                    "suggestion": g.suggestion,
+                }
+                for g in report.gaps
+            ],
+            "conflicts": [
+                {
+                    "tool_a": c.tool_a, "text_a": c.text_a,
+                    "tool_b": c.tool_b, "text_b": c.text_b,
+                    "explanation": c.explanation,
+                    "suggestion": c.suggestion,
+                }
+                for c in report.conflicts
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+        return
+
+    files_desc = ", ".join(f"{f.tool.upper()}.md ({len(f.units)} rules)" for f in report.files) or "none"
+    print(f"[Neo] memory rules — files: {files_desc}")
+    if report.note:
+        print(f"  {report.note}")
+    if report.in_sync:
+        if not report.note:
+            print("  ✓ rule files are in sync (no gaps or conflicts)")
+        return
+
+    if report.gaps:
+        print(f"\n  Gaps ({len(report.gaps)}):")
+        for g in report.gaps:
+            print(f"    • present in {', '.join(g.present_in)}; missing from {', '.join(g.missing_from)}")
+            print(f"      {g.rule}")
+            print(f"      → {g.suggestion}")
+    if report.conflicts:
+        print(f"\n  Conflicts ({len(report.conflicts)}):")
+        for c in report.conflicts:
+            print(f"    • {c.tool_a.upper()}.md vs {c.tool_b.upper()}.md: {c.explanation}")
+            print(f"      → {c.suggestion}")
+    print()
+
+
 def _handle_issues(args) -> None:
     """Surface recurring frictions mined from transcript history (read-only)."""
     from neo.config import NeoConfig
@@ -436,6 +517,9 @@ def handle_memory(args):
     if action == "issues":
         _handle_issues(args)
         return
+    if action == "rules":
+        _handle_rules(args)
+        return
     if action == "prune":
         files = _fact_files_for_prune(
             all_files=getattr(args, "all", False),
@@ -473,7 +557,7 @@ def handle_memory(args):
         return
 
     if action != "replay-feedback":
-        print("Usage: neo memory {replay-feedback|prune|observer|issues} ...")
+        print("Usage: neo memory {replay-feedback|prune|observer|issues|rules} ...")
         return
 
     from neo.config import NeoConfig

--- a/tests/test_rulesync.py
+++ b/tests/test_rulesync.py
@@ -1,0 +1,200 @@
+"""Tests for the rule-file sync diagnostic (neo.memory.rulesync).
+
+Model-free: fixed embedding vectors and a fake LM, hand-built rule files.
+"""
+
+import math
+
+import numpy as np
+
+from neo.memory.rulesync import (
+    RuleFile,
+    analyze_rule_sync,
+    discover_rule_files,
+    find_rule_sync,
+    parse_units,
+)
+
+V_PYTEST = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+V_RUFF = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+V_TABS = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+# ~0.9 cosine with V_TABS: aligned (>=0.78) but not identical (<0.97) -> conflict candidate.
+V_SPACES = np.array([0.0, math.sqrt(1 - 0.81), 0.9], dtype=np.float32)
+
+
+class _FakeLM:
+    def __init__(self, reply):
+        self.reply = reply
+        self.calls = 0
+
+    def generate(self, messages, max_tokens=None, temperature=None):
+        self.calls += 1
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+
+class _NoEmbedStore:
+    codebase_root = "/tmp/x"
+
+    def _embed_text(self, text):
+        return None
+
+
+class _EmbStore:
+    codebase_root = "/tmp/x"
+
+    def _embed_text(self, text):
+        t = text.lower()
+        if "pytest" in t:
+            return V_PYTEST
+        if "ruff" in t:
+            return V_RUFF
+        return V_TABS
+
+
+# --------------------------------------------------------------------------
+# parse_units
+# --------------------------------------------------------------------------
+
+
+def test_parse_units_folds_continuations_drops_prose_and_fences():
+    text = (
+        "# Heading\n"
+        "- Use pytest, never unittest\n"
+        "  under tests/ only\n"
+        "- Run ruff before every commit\n"
+        "\n"
+        "This is top-level prose, not a rule.\n"
+        "```\n"
+        "code block contents\n"
+        "```\n"
+    )
+    units = parse_units(text)
+    assert any("Use pytest" in u and "under tests" in u for u in units)  # continuation folded
+    assert any("Run ruff before every commit" in u for u in units)
+    assert all("top-level prose" not in u for u in units)
+    assert all("code block" not in u for u in units)
+
+
+def test_parse_units_skips_trivial_fragments():
+    assert parse_units("- ok\n- short") == []  # both < 8 chars
+
+
+# --------------------------------------------------------------------------
+# discover_rule_files
+# --------------------------------------------------------------------------
+
+
+def test_discover_rule_files_case_insensitive(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("- a rule here")
+    (tmp_path / "claude.md").write_text("- another rule")  # lowercase
+    (tmp_path / "README.md").write_text("nope")
+    found = dict((t, p) for t, p in discover_rule_files(str(tmp_path)))
+    assert sorted(found) == ["agents", "claude"]
+
+
+def test_discover_rule_files_missing_dir():
+    assert discover_rule_files("/no/such/dir/xyz") == []
+
+
+# --------------------------------------------------------------------------
+# analyze_rule_sync — gaps
+# --------------------------------------------------------------------------
+
+
+def test_analyze_detects_gap():
+    agents = RuleFile("agents", "A", ["use pytest for tests"], [V_PYTEST])
+    claude = RuleFile(
+        "claude", "C",
+        ["use pytest for tests", "run ruff before commit"],
+        [V_PYTEST, V_RUFF],
+    )
+    rep = analyze_rule_sync([agents, claude])
+    assert len(rep.gaps) == 1
+    assert "ruff" in rep.gaps[0].rule
+    assert rep.gaps[0].missing_from == ["agents"]
+    assert "claude" in rep.gaps[0].present_in
+    assert "AGENTS.md" in rep.gaps[0].suggestion
+
+
+def test_analyze_no_gap_when_aligned():
+    agents = RuleFile("agents", "A", ["use pytest for tests"], [V_PYTEST])
+    claude = RuleFile("claude", "C", ["use pytest for tests"], [V_PYTEST])
+    rep = analyze_rule_sync([agents, claude])
+    assert rep.gaps == []
+    assert rep.in_sync
+
+
+def test_analyze_single_file_noop():
+    rep = analyze_rule_sync([RuleFile("agents", "A", ["use pytest for tests"], [V_PYTEST])])
+    assert rep.in_sync
+    assert "single" in rep.note
+
+
+# --------------------------------------------------------------------------
+# analyze_rule_sync — conflicts (LM-judged)
+# --------------------------------------------------------------------------
+
+
+def test_analyze_detects_conflict_with_lm():
+    agents = RuleFile("agents", "A", ["use tabs for indentation"], [V_TABS])
+    claude = RuleFile("claude", "C", ["use spaces for indentation"], [V_SPACES])
+    lm = _FakeLM('{"conflict": true, "explanation": "tabs vs spaces"}')
+    rep = analyze_rule_sync([agents, claude], lm_adapter=lm)
+    assert len(rep.conflicts) == 1
+    assert rep.conflicts[0].explanation == "tabs vs spaces"
+    assert rep.gaps == []  # aligned pair is not a gap
+    assert "Reconcile" in rep.conflicts[0].suggestion
+
+
+def test_analyze_lm_says_no_conflict():
+    agents = RuleFile("agents", "A", ["use tabs for indentation"], [V_TABS])
+    claude = RuleFile("claude", "C", ["use spaces for indentation"], [V_SPACES])
+    rep = analyze_rule_sync([agents, claude], lm_adapter=_FakeLM('{"conflict": false}'))
+    assert rep.conflicts == []
+
+
+def test_analyze_no_lm_no_conflicts():
+    agents = RuleFile("agents", "A", ["use tabs for indentation"], [V_TABS])
+    claude = RuleFile("claude", "C", ["use spaces for indentation"], [V_SPACES])
+    rep = analyze_rule_sync([agents, claude], lm_adapter=None)
+    assert rep.conflicts == []
+
+
+def test_analyze_conflict_lm_failure_graceful():
+    agents = RuleFile("agents", "A", ["use tabs for indentation"], [V_TABS])
+    claude = RuleFile("claude", "C", ["use spaces for indentation"], [V_SPACES])
+    rep = analyze_rule_sync([agents, claude], lm_adapter=_FakeLM(RuntimeError("down")))
+    assert rep.conflicts == []  # not fatal
+
+
+# --------------------------------------------------------------------------
+# find_rule_sync — orchestration
+# --------------------------------------------------------------------------
+
+
+def test_find_identical_files_in_sync(tmp_path):
+    same = "- Use pytest for tests\n- Run ruff before commit\n"
+    (tmp_path / "AGENTS.md").write_text(same)
+    (tmp_path / "CLAUDE.md").write_text(same)
+    rep = find_rule_sync(_NoEmbedStore(), root=str(tmp_path))
+    assert rep.in_sync
+    assert "identical" in rep.note
+
+
+def test_find_single_file_in_sync(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("- Use pytest for tests\n")
+    rep = find_rule_sync(_NoEmbedStore(), root=str(tmp_path))
+    assert rep.in_sync
+    assert "single" in rep.note
+
+
+def test_find_rule_sync_gap_end_to_end(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("- Use pytest for tests\n")
+    (tmp_path / "CLAUDE.md").write_text("- Use pytest for tests\n- Run ruff before commit\n")
+    rep = find_rule_sync(_EmbStore(), root=str(tmp_path), check_conflicts=False)
+    assert not rep.in_sync
+    assert len(rep.gaps) == 1
+    assert "ruff" in rep.gaps[0].rule
+    assert rep.gaps[0].missing_from == ["agents"]


### PR DESCRIPTION
## Description

Adds **`neo memory rules`**, a static cross-file diagnostic for repos worked by multiple coding agents whose rule files (`AGENTS.md` / `CLAUDE.md` / `GEMINI.md`) drift out of sync. Bumps to **v0.25.0**.

No single tool notices the drift because each reads only its own file. This discovers the rule files at the repo root, parses each into rule units (bullets with wrapped continuations folded in; headings/fences/prose dropped), embeds them (shared Jina infra), and reports:
- **gaps** — a rule present in one file with no aligned equivalent (cosine < 0.78) in another
- **conflicts** — aligned-but-divergent pairs judged contradictory by a bounded, graceful LM judge (`--no-conflicts` to skip)

Read-only / **flag-and-propose**: prints proposed reconciling edits (`Add to AGENTS.md: …` / `Reconcile: …`) but never writes files. Byte-identical files (symlinked single source) and single-file repos report "in sync."

`neo memory rules [--json] [--no-conflicts] [--cwd]`

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update

## How Has This Been Tested?

- [x] 14 model-free tests (`tests/test_rulesync.py`): parse/continuation-folding, discovery (case-insensitive, missing dir), gap detection, LM conflict detection (+ no-LM, LM-says-no, graceful failure), identical/single-file in-sync, end-to-end.
- [x] Full suite green: **1096 passed, 3 skipped**; `ruff` clean.
- [x] **Dogfooded on this repo**: first run produced 12 noisy fragment-gaps → added continuation-folding to the parser → reduced to **1 real gap** (a diagnostics section added to CLAUDE.md but not AGENTS.md). Synced the two new diagnostics into AGENTS.md; the only remaining flag is one intentionally CLAUDE.md-only detail sub-bullet — exactly the "review and decide" case the tool is for.

## Checklist

- [x] Version bumped consistently (pyproject.toml, src/neo/__init__.py, .claude-plugin/plugin.json)
- [x] CHANGELOG.md updated (0.25.0); design note `docs/solutions/rule-file-sync.md`
- [x] New and existing unit tests pass locally