### PR TITLE
feat: neo memory audit — hygiene inspection of AI-tool memory files (v0.26.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,10 @@
     (`missing-tool` / `absent-guardrail` / `vague-rule`); `--suggest-rules` adds a bounded
     LM call per issue to draft a preventive rule. `neo memory rules [--json]
     [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
-    LM-judged conflicts). (`neo/memory/issues.py`, `neo/memory/rulesync.py`)
+    LM-judged conflicts). `neo memory audit [--json] [--no-conflicts]` inspects an AI
+    tool's memory files (Claude Code `memory/*.md`) for malformed entries, near-duplicates,
+    conflicts, and MEMORY.md index drift. (`neo/memory/issues.py`,
+    `neo/memory/rulesync.py`, `neo/memory/memaudit.py`)
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.26.0] - 2026-06-19
+
+### Added
+
+- **`neo memory audit` — read-only hygiene inspection of an AI tool's memory files.** Distinct from `neo memory rules` (which compares human-authored rule files), this inspects a tool's *accumulated, learned* memory. v1 targets Claude Code's per-project `~/.claude/projects/<proj>/memory/` dir (a `MEMORY.md` index plus fact files with YAML frontmatter). It reports four hygiene problems: **malformed** (missing frontmatter/description, invalid `type`), **near-duplicate** memories (embedding cosine ≥ 0.93 via the shared clusterer), **conflicts** (same-topic-but-divergent pairs, LM-judged; `--no-conflicts` to skip), and **index** drift (a memory file absent from `MEMORY.md`, or `MEMORY.md` pointing at a missing file). Dangling `[[links]]` are intentional per the memory spec and are not flagged. Read-only — never edits memory. Dogfooded across local projects (correctly flagged a memory file missing from its `MEMORY.md` index). `neo memory audit [--json] [--no-conflicts] [--cwd]`. (`memory/memaudit.py`, `cli.py`, `subcommands.py`; see `docs/solutions/memory-audit.md`) This is phase 1 of cross-tool memory support; phase 2 (ingesting peer memory into neo's store as a `MemorySource`, on probation) is deferred.
+
 ## [0.25.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@
     (`missing-tool` / `absent-guardrail` / `vague-rule`); `--suggest-rules` adds a bounded
     LM call per issue to draft a preventive rule. `neo memory rules [--json]
     [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
-    LM-judged conflicts). (`neo/memory/issues.py`, `neo/memory/rulesync.py`)
+    LM-judged conflicts). `neo memory audit [--json] [--no-conflicts]` inspects an AI
+    tool's memory files (Claude Code `memory/*.md`) for malformed entries, near-duplicates,
+    conflicts, and MEMORY.md index drift. (`neo/memory/issues.py`,
+    `neo/memory/rulesync.py`, `neo/memory/memaudit.py`)
     - `issues` reuses the ingester's `TranscriptSource` episodes but never admits facts or
       touches the `transcript_watermark_*` watermark — decoupled from fact admission and
       idempotent (`find_issues`). Gate mirrors synthesis discipline (≥`min_cluster`

--- a/docs/solutions/memory-audit.md
+++ b/docs/solutions/memory-audit.md
@@ -1,0 +1,47 @@
+# Memory-file audit — `neo memory audit`
+
+**Status:** v1 (2026-06-19). Read-only hygiene inspection of an AI tool's
+*accumulated* memory files. Phase 1 of cross-tool memory support.
+
+## Why
+
+Tools accumulate learned memory on disk, separate from their human-authored
+rule files. Claude Code writes per-project `~/.claude/projects/<proj>/memory/`:
+a `MEMORY.md` index plus individual fact files with YAML frontmatter (`name`,
+`description`, `metadata.type ∈ {user, feedback, project, reference}`) and a
+prose body. Over time this store accretes duplicates, contradictions, malformed
+entries, and index drift — and nothing inspects it. `neo memory rules` compares
+*config*; this audits *memory*.
+
+## What it checks
+
+`neo memory audit [--json] [--no-conflicts] [--cwd PATH]`
+(`neo/memory/memaudit.py`). Read-only — never edits memory.
+
+1. **malformed** — missing/unparseable frontmatter, missing `description`, or a
+   `type` outside the valid set.
+2. **near-duplicate** — bodies whose embeddings cluster at cosine ≥
+   `DUP_THRESHOLD` (0.93), via the shared `math_utils.cluster_by_similarity`.
+3. **conflict** — pairs that align (≥ `ALIGN_THRESHOLD` 0.80) but aren't
+   duplicates, judged contradictory by a bounded, graceful LM judge
+   (`resolve_adapter` + `_parse_json`; opt out with `--no-conflicts`).
+4. **index** — a memory file absent from `MEMORY.md`, or `MEMORY.md` pointing at
+   a file that doesn't exist.
+
+**Dangling `[[links]]` are NOT flagged**: the memory spec says a link to a
+not-yet-written memory is intentional ("marks something worth writing later").
+
+## Discovery
+
+`resolve_memory_dir` reuses `transcript.resolve_transcript_dir` (path→`~/.claude
+/projects/<encoded>`) plus `/memory`. So the audit targets the same project's
+Claude Code memory the transcript miner already knows how to locate.
+
+## Roadmap
+
+- **Phase 2 (deferred): ingest as a source.** A `MemorySource` adapter that
+  imports peer-tool memory into neo's own store **on probation** with an
+  `imported:<tool>` provenance, under existing hygiene (dedup, supersession,
+  caps). Makes neo the cross-tool memory hub. Gated behind the trust concern
+  that importing another tool's memory can import wrong/stale facts.
+- Other tools' memory formats (Cursor, Copilot) as they stabilize.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.25.0"
+version = "0.26.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -249,6 +249,18 @@ def parse_args():
         )
         rules_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
+        audit_p = subparsers.add_parser(
+            'audit',
+            help="Audit an AI tool's memory files for hygiene issues (read-only)",
+        )
+        audit_p.add_argument('--json', action='store_true', help='Emit the audit report as JSON')
+        audit_p.add_argument(
+            '--no-conflicts',
+            action='store_true',
+            help='Skip the LM contradiction check; report other findings only',
+        )
+        audit_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
+
         args = p.parse_args(sys.argv[2:])
         args.command = 'memory'
         args.memory_action = args.action

--- a/src/neo/memory/memaudit.py
+++ b/src/neo/memory/memaudit.py
@@ -1,0 +1,289 @@
+"""
+Memory-file audit — read-only hygiene inspection of an AI tool's memory store.
+
+Distinct from `rulesync` (which compares human-authored rule files): this
+inspects a tool's *accumulated, learned* memory. v1 targets Claude Code's
+per-project `~/.claude/projects/<encoded>/memory/` dir — a `MEMORY.md` index
+plus individual fact files with YAML frontmatter (`name`, `description`,
+`metadata.type`) and a body.
+
+It reports four hygiene problems, all read-only (never edits memory):
+
+- **malformed**: missing frontmatter / description, or an invalid `type`.
+- **duplicate**: two memories with near-identical bodies (redundant).
+- **conflict**: two memories on the same topic that contradict (LM-judged; opt-out).
+- **index**: a memory file absent from MEMORY.md, or MEMORY.md pointing at a
+  missing file.
+
+Dangling `[[links]]` are intentional per the memory spec ("marks something worth
+writing later"), so they are NOT flagged.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+import yaml
+
+from neo.math_utils import batched_cosine, cluster_by_similarity
+
+logger = logging.getLogger(__name__)
+
+VALID_TYPES = {"user", "feedback", "project", "reference"}
+
+# Near-identical bodies -> redundant duplicate.
+DUP_THRESHOLD = 0.93
+# Same-topic-but-not-duplicate -> candidate contradiction (LM-judged).
+ALIGN_THRESHOLD = 0.80
+_MAX_CONFLICT_CHECKS = 40
+
+_INDEX_LINK_RE = re.compile(r"\]\(([^)]+\.md)\)")
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+@dataclass
+class MemoryEntry:
+    path: str
+    filename: str
+    name: str
+    description: str
+    mtype: str
+    body: str
+    links: list[str] = field(default_factory=list)
+    malformed: list[str] = field(default_factory=list)
+    embedding: object = None
+
+
+@dataclass
+class Duplicate:
+    names: list[str]
+
+
+@dataclass
+class Conflict:
+    name_a: str
+    name_b: str
+    explanation: str = ""
+
+
+@dataclass
+class AuditReport:
+    memory_dir: str = ""
+    entry_count: int = 0
+    malformed: list[tuple] = field(default_factory=list)   # (filename, issue)
+    duplicates: list[Duplicate] = field(default_factory=list)
+    conflicts: list[Conflict] = field(default_factory=list)
+    index_issues: list[str] = field(default_factory=list)
+    note: str = ""
+
+    @property
+    def clean(self) -> bool:
+        return not (self.malformed or self.duplicates or self.conflicts or self.index_issues)
+
+
+def resolve_memory_dir(root: str) -> Optional[Path]:
+    """The Claude Code memory dir for a codebase root, or None."""
+    from neo.memory.transcript import resolve_transcript_dir
+
+    tdir = resolve_transcript_dir(root)
+    if tdir is None:
+        return None
+    mem = tdir / "memory"
+    return mem if mem.is_dir() else None
+
+
+def parse_memory_file(path: Path) -> MemoryEntry:
+    """Parse a memory `.md` file into a MemoryEntry, recording malformations."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return MemoryEntry(str(path), path.name, path.stem, "", "", "", malformed=["unreadable"])
+
+    fm: dict = {}
+    body = raw
+    malformed: list[str] = []
+    if raw.lstrip().startswith("---"):
+        parts = raw.split("---", 2)
+        if len(parts) >= 3:
+            try:
+                loaded = yaml.safe_load(parts[1])
+                fm = loaded if isinstance(loaded, dict) else {}
+            except yaml.YAMLError:
+                malformed.append("unparseable frontmatter")
+            body = parts[2].strip()
+    if not fm and "unparseable frontmatter" not in malformed:
+        malformed.append("missing frontmatter")
+
+    name = str(fm.get("name") or path.stem)
+    description = str(fm.get("description") or "")
+    meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+    mtype = str((meta or {}).get("type") or "")
+
+    if not description:
+        malformed.append("missing description")
+    if mtype and mtype not in VALID_TYPES:
+        malformed.append(f"invalid type {mtype!r}")
+    elif not mtype:
+        malformed.append("missing type")
+
+    links = _WIKILINK_RE.findall(body)
+    return MemoryEntry(
+        path=str(path), filename=path.name, name=name, description=description,
+        mtype=mtype, body=body, links=links, malformed=malformed,
+    )
+
+
+def _index_targets(memory_dir: Path) -> Optional[set[str]]:
+    idx = memory_dir / "MEMORY.md"
+    if not idx.is_file():
+        return None
+    try:
+        raw = idx.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return set(_INDEX_LINK_RE.findall(raw))
+
+
+def audit_memories(
+    entries: list[MemoryEntry],
+    *,
+    index_targets: Optional[set[str]] = None,
+    existing_filenames: Optional[set[str]] = None,
+    lm_adapter=None,
+) -> AuditReport:
+    """Compute hygiene findings over parsed memory entries."""
+    report = AuditReport(entry_count=len(entries))
+
+    for e in entries:
+        for issue in e.malformed:
+            report.malformed.append((e.filename, issue))
+
+    # --- Index consistency vs MEMORY.md ------------------------------------
+    if index_targets is not None:
+        listed = index_targets
+        present = existing_filenames or {e.filename for e in entries}
+        for e in entries:
+            if e.filename not in listed:
+                report.index_issues.append(f"{e.filename} is not listed in MEMORY.md")
+        for target in sorted(listed):
+            if target not in present:
+                report.index_issues.append(f"MEMORY.md references missing file {target}")
+
+    # --- Duplicates & conflicts (embedding-based) --------------------------
+    embedded = [e for e in entries if e.embedding is not None]
+    if len(embedded) >= 2:
+        clusters = cluster_by_similarity(
+            embedded, embed_fn=lambda e: e.embedding, threshold=DUP_THRESHOLD
+        )
+        for cluster in clusters:
+            if len(cluster) >= 2:
+                report.duplicates.append(Duplicate(names=[e.name for e in cluster]))
+
+        if lm_adapter is not None:
+            report.conflicts = _detect_conflicts(embedded, lm_adapter)
+
+    return report
+
+
+def _detect_conflicts(embedded: list[MemoryEntry], lm_adapter) -> list[Conflict]:
+    conflicts: list[Conflict] = []
+    seen: set[tuple] = set()
+    checks = 0
+    for i, ea in enumerate(embedded):
+        for eb in embedded[i + 1:]:
+            if checks >= _MAX_CONFLICT_CHECKS:
+                return conflicts
+            sim = batched_cosine([eb.embedding], ea.embedding, default=0.0)[0]
+            if ALIGN_THRESHOLD <= sim < DUP_THRESHOLD:
+                sig = tuple(sorted((ea.name, eb.name)))
+                if sig in seen:
+                    continue
+                seen.add(sig)
+                checks += 1
+                verdict = _judge_conflict(ea, eb, lm_adapter)
+                if verdict and verdict.get("conflict"):
+                    conflicts.append(
+                        Conflict(
+                            name_a=ea.name, name_b=eb.name,
+                            explanation=str(verdict.get("explanation") or "").strip(),
+                        )
+                    )
+    return conflicts
+
+
+_CONFLICT_PROMPT = """Two persisted memory notes about the same project may \
+contradict. Decide whether they state INCOMPATIBLE facts/guidance, or are \
+compatible / about different things.
+
+Note A (<<NA>>): <<A>>
+Note B (<<NB>>): <<B>>
+
+Respond with JSON only: {"conflict": true|false, "explanation": "<one sentence>"}"""
+
+
+def _judge_conflict(ea: MemoryEntry, eb: MemoryEntry, lm_adapter) -> Optional[dict]:
+    from neo.memory.transcript import _parse_json
+
+    prompt = (
+        _CONFLICT_PROMPT
+        .replace("<<NA>>", ea.name).replace("<<A>>", (ea.description or ea.body)[:400])
+        .replace("<<NB>>", eb.name).replace("<<B>>", (eb.description or eb.body)[:400])
+    )
+    try:
+        out = lm_adapter.generate(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200, temperature=0.1,
+        )
+    except Exception as e:
+        logger.warning("memaudit: conflict-judge LM call failed: %s", e)
+        return None
+    data = _parse_json(out)
+    return data if isinstance(data, dict) else None
+
+
+def find_memory_audit(
+    store,
+    *,
+    root: Optional[str] = None,
+    check_conflicts: bool = True,
+    lm_adapter=None,
+) -> AuditReport:
+    """Discover and audit the project's memory dir. Read-only."""
+    root = root or getattr(store, "codebase_root", None) or "."
+    mem_dir = resolve_memory_dir(root)
+    if mem_dir is None:
+        return AuditReport(note="no memory directory found for this project")
+
+    entries: list[MemoryEntry] = []
+    for path in sorted(mem_dir.glob("*.md")):
+        if path.name == "MEMORY.md":
+            continue
+        entries.append(parse_memory_file(path))
+
+    if not entries:
+        return AuditReport(memory_dir=str(mem_dir), note="memory directory is empty")
+
+    embed: Optional[Callable] = getattr(store, "_embed_text", None)
+    if embed is not None:
+        for e in entries:
+            e.embedding = _safe_embed(embed, f"{e.description}\n{e.body}")
+
+    report = audit_memories(
+        entries,
+        index_targets=_index_targets(mem_dir),
+        existing_filenames={e.filename for e in entries},
+        lm_adapter=lm_adapter if check_conflicts else None,
+    )
+    report.memory_dir = str(mem_dir)
+    return report
+
+
+def _safe_embed(embed: Callable, text: str):
+    try:
+        return embed(text)
+    except Exception:
+        return None

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -359,6 +359,78 @@ def _parse_since(value: str) -> Optional[float]:
     raise ValueError(f"invalid --since value: {value!r} (use e.g. 14d, 48h, 30m)")
 
 
+def _handle_audit(args) -> None:
+    """Audit an AI tool's memory files for hygiene issues (read-only)."""
+    from neo.config import NeoConfig
+    from neo.memory.memaudit import find_memory_audit
+    from neo.memory.store import FactStore
+
+    root = getattr(args, "cwd", None) or os.getcwd()
+    config = NeoConfig.load()
+    store = FactStore(codebase_root=root, config=config, eager_init=False)
+
+    check_conflicts = not getattr(args, "no_conflicts", False)
+    lm = None
+    if check_conflicts:
+        try:
+            from neo.adapters import resolve_adapter
+
+            lm = resolve_adapter(config)
+        except Exception as e:
+            print(
+                f"[Neo] audit: no LM adapter for the conflict check ({e}); "
+                "reporting other findings only.",
+                file=sys.stderr,
+            )
+
+    report = find_memory_audit(
+        store, root=root, check_conflicts=check_conflicts, lm_adapter=lm
+    )
+
+    if getattr(args, "json", False):
+        payload = {
+            "memory_dir": report.memory_dir,
+            "entry_count": report.entry_count,
+            "clean": report.clean,
+            "note": report.note,
+            "malformed": [{"file": f, "issue": i} for f, i in report.malformed],
+            "duplicates": [{"names": d.names} for d in report.duplicates],
+            "conflicts": [
+                {"name_a": c.name_a, "name_b": c.name_b, "explanation": c.explanation}
+                for c in report.conflicts
+            ],
+            "index_issues": report.index_issues,
+        }
+        print(json.dumps(payload, indent=2))
+        return
+
+    if report.note and report.entry_count == 0:
+        print(f"[Neo] memory audit: {report.note}")
+        return
+
+    print(f"[Neo] memory audit — {report.entry_count} memories in {report.memory_dir}")
+    if report.clean:
+        print("  ✓ no hygiene issues found")
+        return
+    if report.malformed:
+        print(f"\n  Malformed ({len(report.malformed)}):")
+        for fname, issue in report.malformed:
+            print(f"    • {fname}: {issue}")
+    if report.duplicates:
+        print(f"\n  Near-duplicates ({len(report.duplicates)}):")
+        for d in report.duplicates:
+            print(f"    • {', '.join(d.names)}")
+    if report.conflicts:
+        print(f"\n  Conflicts ({len(report.conflicts)}):")
+        for c in report.conflicts:
+            print(f"    • {c.name_a} ↔ {c.name_b}: {c.explanation}")
+    if report.index_issues:
+        print(f"\n  MEMORY.md index ({len(report.index_issues)}):")
+        for issue in report.index_issues:
+            print(f"    • {issue}")
+    print()
+
+
 def _handle_rules(args) -> None:
     """Flag drift between AGENTS.md / CLAUDE.md / GEMINI.md (read-only)."""
     from neo.config import NeoConfig
@@ -520,6 +592,9 @@ def handle_memory(args):
     if action == "rules":
         _handle_rules(args)
         return
+    if action == "audit":
+        _handle_audit(args)
+        return
     if action == "prune":
         files = _fact_files_for_prune(
             all_files=getattr(args, "all", False),
@@ -557,7 +632,7 @@ def handle_memory(args):
         return
 
     if action != "replay-feedback":
-        print("Usage: neo memory {replay-feedback|prune|observer|issues|rules} ...")
+        print("Usage: neo memory {replay-feedback|prune|observer|issues|rules|audit} ...")
         return
 
     from neo.config import NeoConfig

--- a/tests/test_memaudit.py
+++ b/tests/test_memaudit.py
@@ -1,0 +1,178 @@
+"""Tests for the memory-file audit (neo.memory.memaudit). Model-free."""
+
+import numpy as np
+
+from neo.memory.memaudit import (
+    MemoryEntry,
+    audit_memories,
+    parse_memory_file,
+)
+
+V_A = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+V_B = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+V_TABS = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+# ~0.85 cosine with V_TABS: aligned (>=0.80) but below DUP (0.93) -> conflict candidate.
+V_SPACES = np.array([0.0, np.sqrt(1 - 0.85**2), 0.85], dtype=np.float32)
+
+
+class _FakeLM:
+    def __init__(self, reply):
+        self.reply = reply
+
+    def generate(self, messages, max_tokens=None, temperature=None):
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+
+def _entry(name, *, emb=None, mtype="project", desc="desc", body="body", malformed=None):
+    return MemoryEntry(
+        path=f"/{name}.md", filename=f"{name}.md", name=name, description=desc,
+        mtype=mtype, body=body, links=[], malformed=list(malformed or []), embedding=emb,
+    )
+
+
+# --------------------------------------------------------------------------
+# parse_memory_file
+# --------------------------------------------------------------------------
+
+
+def test_parse_valid(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("---\nname: x\ndescription: a desc\nmetadata:\n  type: feedback\n---\nbody here\n")
+    e = parse_memory_file(p)
+    assert e.name == "x"
+    assert e.mtype == "feedback"
+    assert e.description == "a desc"
+    assert e.body == "body here"
+    assert e.malformed == []
+
+
+def test_parse_missing_frontmatter(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("just a body, no frontmatter")
+    e = parse_memory_file(p)
+    assert "missing frontmatter" in e.malformed
+
+
+def test_parse_invalid_type(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("---\nname: x\ndescription: d\nmetadata:\n  type: bogus\n---\nb")
+    e = parse_memory_file(p)
+    assert any("invalid type" in m for m in e.malformed)
+
+
+def test_parse_missing_description(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("---\nname: x\nmetadata:\n  type: project\n---\nb")
+    e = parse_memory_file(p)
+    assert "missing description" in e.malformed
+
+
+def test_parse_wikilinks(tmp_path):
+    p = tmp_path / "x.md"
+    p.write_text("---\nname: x\ndescription: d\nmetadata:\n  type: project\n---\nsee [[other]] and [[third]]")
+    e = parse_memory_file(p)
+    assert e.links == ["other", "third"]
+
+
+# --------------------------------------------------------------------------
+# audit_memories
+# --------------------------------------------------------------------------
+
+
+def test_audit_reports_malformed():
+    rep = audit_memories([_entry("bad", malformed=["missing description"])])
+    assert ("bad.md", "missing description") in rep.malformed
+
+
+def test_audit_detects_duplicates():
+    rep = audit_memories([_entry("a", emb=V_A), _entry("b", emb=V_A)])
+    assert len(rep.duplicates) == 1
+    assert set(rep.duplicates[0].names) == {"a", "b"}
+
+
+def test_audit_distinct_memories_no_duplicate():
+    rep = audit_memories([_entry("a", emb=V_A), _entry("b", emb=V_B)])
+    assert rep.duplicates == []
+
+
+def test_audit_detects_conflict_with_lm():
+    lm = _FakeLM('{"conflict": true, "explanation": "tabs vs spaces"}')
+    rep = audit_memories([_entry("tabs", emb=V_TABS), _entry("spaces", emb=V_SPACES)], lm_adapter=lm)
+    assert len(rep.conflicts) == 1
+    assert rep.conflicts[0].explanation == "tabs vs spaces"
+    assert rep.duplicates == []  # 0.85 < DUP threshold
+
+
+def test_audit_no_lm_no_conflicts():
+    rep = audit_memories([_entry("tabs", emb=V_TABS), _entry("spaces", emb=V_SPACES)], lm_adapter=None)
+    assert rep.conflicts == []
+
+
+def test_audit_conflict_lm_failure_graceful():
+    rep = audit_memories(
+        [_entry("tabs", emb=V_TABS), _entry("spaces", emb=V_SPACES)],
+        lm_adapter=_FakeLM(RuntimeError("down")),
+    )
+    assert rep.conflicts == []
+
+
+def test_audit_index_issues():
+    rep = audit_memories(
+        [_entry("a")], index_targets={"b.md"}, existing_filenames={"a.md"}
+    )
+    assert any("a.md is not listed" in s for s in rep.index_issues)
+    assert any("missing file b.md" in s for s in rep.index_issues)
+
+
+def test_audit_clean_when_no_issues():
+    rep = audit_memories([_entry("a", emb=V_A)])
+    assert rep.clean
+
+
+def test_dangling_wikilinks_not_flagged():
+    e = _entry("a", emb=V_A)
+    e.links = ["does-not-exist"]  # intentional per memory spec
+    rep = audit_memories([e])
+    assert rep.clean
+
+
+# --------------------------------------------------------------------------
+# find_memory_audit (orchestration)
+# --------------------------------------------------------------------------
+
+
+def test_find_memory_audit_end_to_end(tmp_path, monkeypatch):
+    import neo.memory.memaudit as ma
+
+    fm = "---\nname: {n}\ndescription: use pytest\nmetadata:\n  type: project\n---\nuse pytest always\n"
+    (tmp_path / "a.md").write_text(fm.format(n="a"))
+    (tmp_path / "b.md").write_text(fm.format(n="b"))  # duplicate of a
+    (tmp_path / "MEMORY.md").write_text("- [A](a.md) — x\n")  # b.md not listed
+
+    monkeypatch.setattr(ma, "resolve_memory_dir", lambda root: tmp_path)
+
+    class _Store:
+        codebase_root = "/x"
+
+        def _embed_text(self, text):
+            return V_A  # everything identical -> duplicate
+
+    rep = ma.find_memory_audit(_Store(), check_conflicts=False)
+    assert rep.entry_count == 2
+    assert len(rep.duplicates) == 1
+    assert any("b.md is not listed" in s for s in rep.index_issues)
+
+
+def test_find_memory_audit_no_dir(monkeypatch):
+    import neo.memory.memaudit as ma
+
+    monkeypatch.setattr(ma, "resolve_memory_dir", lambda root: None)
+
+    class _Store:
+        codebase_root = "/x"
+
+    rep = ma.find_memory_audit(_Store())
+    assert "no memory directory" in rep.note
+    assert rep.clean


### PR DESCRIPTION
## Description

Adds **`neo memory audit`**, a read-only hygiene inspection of an AI tool's *accumulated* memory files (phase 1 of cross-tool memory support). Bumps to **v0.26.0**.

Distinct from `neo memory rules` (human-authored config): this inspects learned memory. v1 targets Claude Code's per-project `~/.claude/projects/<proj>/memory/` (a `MEMORY.md` index + fact files with YAML frontmatter).

Reports four hygiene problems, all read-only (never edits memory):
- **malformed** — missing/unparseable frontmatter, missing `description`, invalid `type`
- **near-duplicate** — bodies cluster at cosine ≥ 0.93 (shared `cluster_by_similarity`)
- **conflict** — same-topic-but-divergent pairs, LM-judged (`--no-conflicts` to skip)
- **index** — a memory file absent from `MEMORY.md`, or `MEMORY.md` pointing at a missing file

Dangling `[[links]]` are intentional per the memory spec and are **not** flagged.

`neo memory audit [--json] [--no-conflicts] [--cwd]`

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update

## How Has This Been Tested?

- [x] 16 model-free tests (`tests/test_memaudit.py`): frontmatter parsing (valid/missing/invalid-type/missing-desc/wikilinks), malformed/duplicate/conflict/index detection, no-LM and graceful-LM-failure, dangling-links-not-flagged, end-to-end + no-dir.
- [x] Full suite green: **1113 passed, 3 skipped**; `ruff` clean.
- [x] **Dogfooded** across local Claude Code memory dirs — correctly flagged a real memory file (`user_owns_quip_and_car.md`) missing from its `MEMORY.md` index.

## Additional Notes

Phase 2 (deferred): a `MemorySource` adapter that *ingests* peer-tool memory into neo's store on probation with an `imported:<tool>` provenance — gated behind the trust concern that imported memory can be wrong/stale.

## Checklist

- [x] Version bumped consistently; CHANGELOG + `docs/solutions/memory-audit.md`
- [x] New and existing unit tests pass locally