### PR TITLE
feat: neo memory import — ingest peer-tool memory into neo's store (v0.27.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,11 @@
     [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
     LM-judged conflicts). `neo memory audit [--json] [--no-conflicts]` inspects an AI
     tool's memory files (Claude Code `memory/*.md`) for malformed entries, near-duplicates,
-    conflicts, and MEMORY.md index drift. (`neo/memory/issues.py`,
-    `neo/memory/rulesync.py`, `neo/memory/memaudit.py`)
+    conflicts, and MEMORY.md index drift. `neo memory import [--dry-run]` ingests a peer
+    tool's memory files into neo's store as REVIEW facts on probation (trust-first;
+    `imported:claude-memory` tag, content-hash watermark for idempotency).
+    (`neo/memory/issues.py`, `neo/memory/rulesync.py`, `neo/memory/memaudit.py`,
+    `neo/memory/memimport.py`)
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.27.0] - 2026-06-19
+
+### Added
+
+- **`neo memory import` — ingest a peer tool's memory into neo's store (phase 2 of cross-tool memory).** Reads Claude Code's per-project `memory/*.md` and admits each well-formed entry as a fact in neo's own store, so what one agent learned becomes available to neo's reasoning. **Trust-first admission**: imports enter as **REVIEW** (a decaying kind, never CONSTRAINT/ARCHITECTURE which would bypass decay and read as curated truth), with **INFERRED** provenance and an `imported:claude-memory` tag — so `add_fact` puts them on **probation** (they must earn promotion via access/success like any fluid fact) and gives them the lowest provenance bonus. Dedup/supersession is handled by `add_fact`'s existing cosine ≥ 0.85 machinery; a per-(project, tool) content-hash watermark makes re-runs idempotent (an *edited* memory re-imports and supersedes rather than duplicating). Malformed entries (no frontmatter / no description) are skipped. `--dry-run` previews without mutating; `--confidence` tunes the initial value (default 0.4). `neo memory import [--dry-run] [--confidence 0.4] [--cwd]`. (`memory/memimport.py`, `cli.py`, `subcommands.py`; see `docs/solutions/memory-audit.md`)
+
 ## [0.26.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,11 @@
     [--no-conflicts]` flags drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps +
     LM-judged conflicts). `neo memory audit [--json] [--no-conflicts]` inspects an AI
     tool's memory files (Claude Code `memory/*.md`) for malformed entries, near-duplicates,
-    conflicts, and MEMORY.md index drift. (`neo/memory/issues.py`,
-    `neo/memory/rulesync.py`, `neo/memory/memaudit.py`)
+    conflicts, and MEMORY.md index drift. `neo memory import [--dry-run]` ingests a peer
+    tool's memory files into neo's store as REVIEW facts on probation (trust-first;
+    `imported:claude-memory` tag, content-hash watermark for idempotency).
+    (`neo/memory/issues.py`, `neo/memory/rulesync.py`, `neo/memory/memaudit.py`,
+    `neo/memory/memimport.py`)
     - `issues` reuses the ingester's `TranscriptSource` episodes but never admits facts or
       touches the `transcript_watermark_*` watermark — decoupled from fact admission and
       idempotent (`find_issues`). Gate mirrors synthesis discipline (≥`min_cluster`

--- a/docs/solutions/memory-audit.md
+++ b/docs/solutions/memory-audit.md
@@ -37,11 +37,19 @@ not-yet-written memory is intentional ("marks something worth writing later").
 /projects/<encoded>`) plus `/memory`. So the audit targets the same project's
 Claude Code memory the transcript miner already knows how to locate.
 
+## Phase 2 (shipped v0.27.0): `neo memory import`
+
+`neo memory import [--dry-run] [--confidence 0.4]` (`neo/memory/memimport.py`)
+ingests Claude Code's `memory/*.md` into neo's own store. **Trust-first**: each
+well-formed entry is admitted as a **REVIEW** fact (decaying — never the
+decay-bypassing CONSTRAINT/ARCHITECTURE kinds), with **INFERRED** provenance and
+an `imported:claude-memory` tag, so `add_fact` puts it on **probation** — it must
+earn promotion via access/success like any fluid fact, mitigating the
+import-wrong/stale-facts risk. Dedup/supersession reuses `add_fact`'s cosine
+≥ 0.85 machinery; a per-(project, tool) content-hash watermark makes re-runs
+idempotent (edited memory re-imports and supersedes). `--dry-run` previews.
+
 ## Roadmap
 
-- **Phase 2 (deferred): ingest as a source.** A `MemorySource` adapter that
-  imports peer-tool memory into neo's own store **on probation** with an
-  `imported:<tool>` provenance, under existing hygiene (dedup, supersession,
-  caps). Makes neo the cross-tool memory hub. Gated behind the trust concern
-  that importing another tool's memory can import wrong/stale facts.
-- Other tools' memory formats (Cursor, Copilot) as they stabilize.
+- Other tools' memory formats (Cursor, Copilot) as they stabilize, each as an
+  additional source adapter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.26.0"
+version = "0.27.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -261,6 +261,23 @@ def parse_args():
         )
         audit_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
+        import_p = subparsers.add_parser(
+            'import',
+            help="Import a peer tool's memory files into neo's store (on probation)",
+        )
+        import_p.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be imported without mutating the store',
+        )
+        import_p.add_argument(
+            '--confidence',
+            type=float,
+            default=0.4,
+            help='Initial confidence for imported facts (default: 0.4)',
+        )
+        import_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
+
         args = p.parse_args(sys.argv[2:])
         args.command = 'memory'
         args.memory_action = args.action

--- a/src/neo/memory/memimport.py
+++ b/src/neo/memory/memimport.py
@@ -1,0 +1,151 @@
+"""
+Memory ingestion — import a peer tool's memory files into neo's store.
+
+Phase 2 of cross-tool memory support (phase 1 is the read-only `memaudit`).
+Reads Claude Code's per-project `memory/*.md` and admits each as a fact in
+neo's own store, so what one agent learned becomes available to neo's reasoning.
+
+Trust-first admission. A peer tool's memory can be wrong or stale, so imports:
+
+- enter as **REVIEW** (a decaying kind), never as CONSTRAINT/ARCHITECTURE
+  (which would bypass decay and be treated as curated truth);
+- carry **INFERRED** provenance and an `imported:claude-memory` tag, so
+  `add_fact` puts them on **probation** (they must earn promotion via access /
+  success like any other fluid fact) and they get the lowest provenance bonus;
+- are deduped/superseded by `add_fact`'s existing cosine≥0.85 machinery;
+- are watermarked per (project, tool) by content hash, so re-running is
+  idempotent and an edited memory re-imports (and supersedes) rather than
+  duplicating.
+
+Malformed entries (no frontmatter / no description) are skipped — only
+well-formed memory is imported.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from neo.memory.memaudit import parse_memory_file, resolve_memory_dir
+from neo.memory.models import FactKind, FactScope, Provenance
+
+logger = logging.getLogger(__name__)
+
+SOURCE_NAME = "claude-memory"
+_IMPORT_CONFIDENCE = 0.4  # modest; probation + decay gate it further
+
+
+@dataclass
+class ImportStats:
+    scanned: int = 0
+    imported: int = 0
+    deduped: int = 0
+    skipped_existing: int = 0
+    skipped_malformed: int = 0
+    dry_run: bool = False
+    note: str = ""
+
+
+def _watermark_path(store):
+    from neo.memory.outcomes import SESSIONS_DIR
+
+    pid = getattr(store, "project_id", None) or "global"
+    return SESSIONS_DIR / f"memimport_watermark_{SOURCE_NAME}_{pid}.json"
+
+
+def _load_consumed(store) -> set:
+    path = _watermark_path(store)
+    if not path.exists():
+        return set()
+    try:
+        return set(json.loads(path.read_text(encoding="utf-8")).get("consumed", []))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+
+def _persist_consumed(store, consumed: set) -> None:
+    from neo.memory.io_utils import atomic_write_json
+    from neo.memory.outcomes import SESSIONS_DIR
+
+    path = _watermark_path(store)
+    try:
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(path, {"consumed": sorted(consumed)})
+    except OSError as e:
+        logger.warning("memimport: failed to persist watermark: %s", e)
+
+
+def _is_importable(entry) -> bool:
+    """Skip entries we can't trust to be well-formed memory."""
+    if not entry.description:
+        return False
+    if "missing frontmatter" in entry.malformed or "unparseable frontmatter" in entry.malformed:
+        return False
+    return True
+
+
+def import_memory(
+    store,
+    *,
+    root: Optional[str] = None,
+    confidence: float = _IMPORT_CONFIDENCE,
+    dry_run: bool = False,
+) -> ImportStats:
+    """Import the project's Claude Code memory files into neo's store.
+
+    Idempotent: content-hash watermark skips already-imported, unchanged files.
+    """
+    root = root or getattr(store, "codebase_root", None) or "."
+    mem_dir = resolve_memory_dir(root)
+    if mem_dir is None:
+        return ImportStats(dry_run=dry_run, note="no memory directory found for this project")
+
+    entries = [
+        parse_memory_file(p)
+        for p in sorted(mem_dir.glob("*.md"))
+        if p.name != "MEMORY.md"
+    ]
+    if not entries:
+        return ImportStats(dry_run=dry_run, note="memory directory is empty")
+
+    consumed = _load_consumed(store)
+    new_consumed: set = set()
+    stats = ImportStats(dry_run=dry_run)
+
+    for e in entries:
+        stats.scanned += 1
+        if not _is_importable(e):
+            stats.skipped_malformed += 1
+            continue
+        key = f"{e.filename}:{hashlib.sha256(e.body.encode('utf-8')).hexdigest()[:12]}"
+        if key in consumed:
+            stats.skipped_existing += 1
+            continue
+        if dry_run:
+            stats.imported += 1
+            continue
+
+        before = len(store._facts)
+        store.add_fact(
+            subject=e.description or e.name,
+            body=e.body or e.description,
+            kind=FactKind.REVIEW,
+            scope=FactScope.PROJECT,
+            confidence=confidence,
+            source_file=e.path,
+            tags=["imported", f"imported:{SOURCE_NAME}", f"memtype:{e.mtype or 'unknown'}"],
+            provenance=Provenance.INFERRED,
+        )
+        if len(store._facts) > before:
+            stats.imported += 1
+        else:
+            stats.deduped += 1
+        new_consumed.add(key)
+
+    if not dry_run and new_consumed:
+        _persist_consumed(store, consumed | new_consumed)
+
+    return stats

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -359,6 +359,39 @@ def _parse_since(value: str) -> Optional[float]:
     raise ValueError(f"invalid --since value: {value!r} (use e.g. 14d, 48h, 30m)")
 
 
+def _handle_import(args) -> None:
+    """Import a peer tool's memory files into neo's store (on probation)."""
+    from neo.config import NeoConfig
+    from neo.memory.memimport import import_memory
+    from neo.memory.store import FactStore
+
+    root = getattr(args, "cwd", None) or os.getcwd()
+    config = NeoConfig.load()
+    store = FactStore(codebase_root=root, config=config, eager_init=False)
+
+    stats = import_memory(
+        store,
+        root=root,
+        confidence=getattr(args, "confidence", 0.4),
+        dry_run=getattr(args, "dry_run", False),
+    )
+
+    if stats.note and stats.scanned == 0:
+        print(f"[Neo] memory import: {stats.note}")
+        return
+
+    verb = "would import" if stats.dry_run else "imported"
+    print(
+        f"[Neo] memory import — scanned {stats.scanned}; {verb} {stats.imported}"
+        + (f", deduped {stats.deduped}" if stats.deduped else "")
+        + (f", skipped {stats.skipped_existing} already-imported" if stats.skipped_existing else "")
+        + (f", skipped {stats.skipped_malformed} malformed" if stats.skipped_malformed else "")
+    )
+    if not stats.dry_run and stats.imported:
+        print("  imported as REVIEW facts on probation (decaying, must earn promotion); "
+              "tagged 'imported:claude-memory'")
+
+
 def _handle_audit(args) -> None:
     """Audit an AI tool's memory files for hygiene issues (read-only)."""
     from neo.config import NeoConfig
@@ -595,6 +628,9 @@ def handle_memory(args):
     if action == "audit":
         _handle_audit(args)
         return
+    if action == "import":
+        _handle_import(args)
+        return
     if action == "prune":
         files = _fact_files_for_prune(
             all_files=getattr(args, "all", False),
@@ -632,7 +668,7 @@ def handle_memory(args):
         return
 
     if action != "replay-feedback":
-        print("Usage: neo memory {replay-feedback|prune|observer|issues|rules|audit} ...")
+        print("Usage: neo memory {replay-feedback|prune|observer|issues|rules|audit|import} ...")
         return
 
     from neo.config import NeoConfig

--- a/tests/test_memimport.py
+++ b/tests/test_memimport.py
@@ -1,0 +1,129 @@
+"""Tests for memory ingestion (neo.memory.memimport).
+
+Uses real temp memory files (exercising the real parser) with a fake store and
+a redirected watermark dir, so it stays model-free and deterministic.
+"""
+
+import types
+
+import neo.memory.memimport as mi
+from neo.memory.memimport import import_memory
+from neo.memory.models import FactKind, FactScope, Provenance
+
+
+class _FakeStore:
+    project_id = "testpid"
+    codebase_root = "/x"
+
+    def __init__(self):
+        self._facts = []
+        self.added = []
+
+    def add_fact(self, **kwargs):
+        self.added.append(kwargs)
+        f = types.SimpleNamespace(id=str(len(self._facts)))
+        self._facts.append(f)
+        return f
+
+
+def _write(d, name, *, desc="a useful description", body="the body",
+           mtype="project", frontmatter=True):
+    p = d / f"{name}.md"
+    if frontmatter:
+        fm = f"---\nname: {name}\n"
+        if desc:
+            fm += f"description: {desc}\n"
+        fm += f"metadata:\n  type: {mtype}\n---\n{body}\n"
+        p.write_text(fm, encoding="utf-8")
+    else:
+        p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _setup(tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    monkeypatch.setattr(mi, "resolve_memory_dir", lambda root: mem)
+    monkeypatch.setattr("neo.memory.outcomes.SESSIONS_DIR", sessions)
+    return mem, sessions
+
+
+def test_import_maps_to_review_inferred_probation(tmp_path, monkeypatch):
+    mem, _ = _setup(tmp_path, monkeypatch)
+    _write(mem, "a", mtype="feedback")
+    store = _FakeStore()
+    stats = import_memory(store)
+    assert stats.imported == 1
+    kw = store.added[0]
+    assert kw["kind"] == FactKind.REVIEW            # decaying kind, not CONSTRAINT
+    assert kw["provenance"] == Provenance.INFERRED   # -> probation, lowest trust
+    assert kw["scope"] == FactScope.PROJECT
+    assert "imported" in kw["tags"]
+    assert "imported:claude-memory" in kw["tags"]
+    assert "memtype:feedback" in kw["tags"]
+
+
+def test_import_skips_malformed(tmp_path, monkeypatch):
+    mem, _ = _setup(tmp_path, monkeypatch)
+    _write(mem, "good")
+    _write(mem, "nodesc", desc="")          # missing description
+    _write(mem, "nofm", frontmatter=False)  # missing frontmatter
+    store = _FakeStore()
+    stats = import_memory(store)
+    assert stats.imported == 1
+    assert stats.skipped_malformed == 2
+
+
+def test_memory_md_index_is_not_imported(tmp_path, monkeypatch):
+    mem, _ = _setup(tmp_path, monkeypatch)
+    _write(mem, "a")
+    (mem / "MEMORY.md").write_text("- [A](a.md) — x\n", encoding="utf-8")
+    store = _FakeStore()
+    stats = import_memory(store)
+    assert stats.imported == 1  # MEMORY.md skipped
+
+
+def test_dry_run_does_not_mutate(tmp_path, monkeypatch):
+    mem, sessions = _setup(tmp_path, monkeypatch)
+    _write(mem, "a")
+    _write(mem, "b")
+    store = _FakeStore()
+    stats = import_memory(store, dry_run=True)
+    assert stats.imported == 2
+    assert store.added == []
+    assert not list(sessions.glob("memimport_*"))
+
+
+def test_watermark_makes_reruns_idempotent(tmp_path, monkeypatch):
+    mem, _ = _setup(tmp_path, monkeypatch)
+    _write(mem, "a")
+    _write(mem, "b")
+
+    first = import_memory(_FakeStore())
+    assert first.imported == 2
+
+    store2 = _FakeStore()
+    second = import_memory(store2)
+    assert second.imported == 0
+    assert second.skipped_existing == 2
+    assert store2.added == []
+
+
+def test_edited_memory_reimports(tmp_path, monkeypatch):
+    mem, _ = _setup(tmp_path, monkeypatch)
+    _write(mem, "a", body="version one")
+    import_memory(_FakeStore())
+
+    _write(mem, "a", body="version two edited")  # content changed -> new hash
+    store = _FakeStore()
+    stats = import_memory(store)
+    assert stats.imported == 1
+
+
+def test_no_memory_dir_noop(monkeypatch):
+    monkeypatch.setattr(mi, "resolve_memory_dir", lambda root: None)
+    stats = import_memory(_FakeStore())
+    assert stats.imported == 0
+    assert "no memory directory" in stats.note


### PR DESCRIPTION
## Description

Adds **`neo memory import`** — phase 2 of cross-tool memory. Reads Claude Code's per-project `memory/*.md` and admits each well-formed entry as a fact in neo's own store, so what one agent learned becomes available to neo's reasoning. Bumps to **v0.27.0**.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update

## Trust-first admission (the core design)

A peer tool's memory can be wrong or stale, so imports are admitted conservatively:
- **REVIEW kind** — a *decaying* kind; never CONSTRAINT/ARCHITECTURE (which bypass decay and read as curated truth).
- **INFERRED provenance** + `imported:claude-memory` tag → `add_fact` puts them on **probation** (must earn promotion via access/success like any fluid fact) and gives the lowest provenance bonus.
- **Dedup/supersession** reuses `add_fact`'s existing cosine ≥ 0.85 machinery.
- **Idempotent**: a per-(project, tool) content-hash watermark skips already-imported, unchanged files; an *edited* memory re-imports (and supersedes) rather than duplicating.
- **Malformed entries skipped** (no frontmatter / no description).

`neo memory import [--dry-run] [--confidence 0.4] [--cwd]`

## How Has This Been Tested?

- [x] 7 model-free tests (`tests/test_memimport.py`, real temp memory files + fake store): REVIEW/INFERRED/probation-tag mapping, malformed skipped, MEMORY.md not imported, dry-run no-mutation, watermark idempotency, edited-memory re-import, no-dir noop.
- [x] Full suite green: **1121 passed, 3 skipped**; `ruff` clean.
- [x] Dry-run dogfooded against a real project's memory dir (3 memories, all importable).

## Checklist

- [x] Version bumped consistently; CHANGELOG + design note updated; CLAUDE.md/AGENTS.md mention (kept in sync)
- [x] New and existing unit tests pass locally