### PR TITLE
fix: observer enforces car-runtime ≥0.18.0 floor; revisit CarAdapter #52 hint (v0.28.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.28.0] - 2026-06-19
+
+### Fixed
+
+- **The observer now enforces its documented car-runtime ≥ 0.18.0 floor at runtime.** `_require_car_runtime` previously gated only on `hasattr(car_runtime, "agents_upsert")`, which 0.16.x/0.17.0 also satisfy — so the observer would silently run on an under-spec binding exposed to the pre-0.18.0 supervisor footguns (orphaned child / restart-storm on start-during-backoff / stale `last_exit_code`) that 0.18.0 fixed. It now also checks the installed version (via `importlib.metadata`) and raises an actionable error below 0.18.0. An unparseable/missing version is allowed through (lenient about unknown, strict about known-too-old) so a vendored build isn't falsely rejected. (`memory/observer.py`)
+
+### Changed
+
+- **Revisited the `CarAdapter` `task=code` intent hint now that [car-releases#52](https://github.com/Parslee-ai/car-releases/issues/52) is closed.** The router cost-bias that motivated the hint is fixed upstream (the router now prioritizes quality > speed > cost for `task=code`, plus the 0.25–0.27 capability-honest routing + `exclude_models` reworks), so the `{"task":"code","prefer_quality":True}` default is the *intended* router API rather than a bug workaround — kept, with the rationale in CLAUDE.md updated accordingly. Validated against car-runtime 0.27.0. (docs only; `adapters.py` default unchanged)
+
 ## [0.27.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,15 @@
   fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
   the LM, then exits without making the LLM call. Faster iteration on context-gatherer
   and retrieval changes than waiting for an inference round trip.
-- CarAdapter defaults `intent_hint={"task":"code"}` so CAR's router picks a code-capable
-  model rather than the chat default. This is the local workaround for
+- CarAdapter defaults `intent_hint={"task":"code","prefer_quality":True}` so CAR's router
+  routes neo to the most capable model, not the chat/cost default. This is the *intended*
+  router API, not a hack:
   [Parslee-ai/car-releases#52](https://github.com/Parslee-ai/car-releases/issues/52)
-  (`route_model` is cost-biased for "simple" prompts and ranks `gpt-5.3-codex`/`o3`
-  behind `gpt-4.1-mini`). If that upstream lands, revisit the default.
+  (router cost-bias on `task=code`) is **closed** — the router now prioritizes
+  quality > speed > cost for `task=code`, and the 0.25–0.27 reworks add capability-honest
+  routing + `exclude_models`. We keep `prefer_quality` explicit as belt-and-suspenders
+  (CAR's *default* profile without it is still latency/cost-biased). Rationale lives on
+  `CarAdapter.DEFAULT_INTENT_HINT` in `adapters.py`. Observer floor is car-runtime ≥0.18.0,
+  now enforced at runtime by `_require_car_runtime` (version check, not just the `agents_*`
+  attr); latest validated against car-runtime 0.27.0.
 - When creating a pull request, always use the PR template included in the repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.27.0"
+version = "0.28.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -32,9 +32,11 @@ Tunables (env, read by the daemon child):
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata
 import json
 import logging
 import os
+import re
 import signal
 import sys
 import time
@@ -61,12 +63,33 @@ _CAR_REQUIRED_MSG = (
 )
 
 
-def _require_car_runtime():
-    """Import car_runtime and verify it has the agent-supervisor API.
+_CAR_MIN_VERSION = (0, 18, 0)
 
-    Raises ``RuntimeError`` with an actionable message when missing or
-    too old, instead of a cryptic ImportError/AttributeError at the
-    call site.
+
+def _parse_version(v: Optional[str]) -> Optional[tuple]:
+    """Best-effort parse of a version string to a numeric tuple, or None."""
+    nums = re.findall(r"\d+", v or "")
+    return tuple(int(x) for x in nums[:3]) if nums else None
+
+
+def _installed_car_version() -> Optional[str]:
+    try:
+        return importlib.metadata.version("car-runtime")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _require_car_runtime():
+    """Import car_runtime and verify it satisfies the observer's floor.
+
+    Two gates: the ``agents_*`` supervisor API must be present, AND the
+    installed version must be >= 0.18.0. 0.16.x/0.17.0 expose ``agents_upsert``
+    but carry the supervisor footguns (orphaned child / restart-storm / stale
+    exit code) that 0.18.0 fixed, so the attribute check alone is not enough —
+    we must also enforce the version. Raises ``RuntimeError`` with an actionable
+    message instead of silently running on an under-spec binding. An
+    unparseable / missing version is allowed through (lenient about unknown,
+    strict about known-too-old) so a vendored build is not falsely rejected.
     """
     try:
         import car_runtime
@@ -75,6 +98,11 @@ def _require_car_runtime():
 
     if not hasattr(car_runtime, "agents_upsert"):
         raise RuntimeError(_CAR_REQUIRED_MSG)
+
+    version = _installed_car_version()
+    parsed = _parse_version(version)
+    if parsed is not None and parsed < _CAR_MIN_VERSION:
+        raise RuntimeError(f"car-runtime {version} is too old. " + _CAR_REQUIRED_MSG)
 
     return car_runtime
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -62,6 +62,34 @@ class TestRequireCarRuntime:
             _require_car_runtime()
 
 
+class TestCarVersionFloor:
+    def test_parse_version(self):
+        from neo.memory.observer import _parse_version
+        assert _parse_version("0.27.0") == (0, 27, 0)
+        assert _parse_version("0.18.0rc1") == (0, 18, 0)
+        assert _parse_version("0.16.1") == (0, 16, 1)
+        assert _parse_version(None) is None
+        assert _parse_version("garbage") is None
+
+    def test_old_version_rejected(self, fake_car, monkeypatch):
+        # agents_upsert present (0.16.x/0.17.0) but below the 0.18.0 floor.
+        from neo.memory import observer as obs
+        monkeypatch.setattr(obs, "_installed_car_version", lambda: "0.17.0")
+        with pytest.raises(RuntimeError, match="too old"):
+            obs._require_car_runtime()
+
+    def test_current_version_accepted(self, fake_car, monkeypatch):
+        from neo.memory import observer as obs
+        monkeypatch.setattr(obs, "_installed_car_version", lambda: "0.27.0")
+        assert obs._require_car_runtime() is fake_car
+
+    def test_unknown_version_allowed(self, fake_car, monkeypatch):
+        # Lenient about unknown (vendored build), strict about known-too-old.
+        from neo.memory import observer as obs
+        monkeypatch.setattr(obs, "_installed_car_version", lambda: None)
+        assert obs._require_car_runtime() is fake_car
+
+
 class TestSpecBuilding:
     def test_spec_uses_current_python(self, fake_project_id):
         from neo.memory.observer import _build_spec


### PR DESCRIPTION
## Description

Triggered by noticing the local observer was running on **car-runtime 0.17.0** — *below neo's own documented ≥0.18.0 floor* — while car-releases had moved to **v0.27.0**. Bumps to **v0.28.0**.

## Type of Change

- [x] Bug fix (runtime guard was not enforcing the documented floor)
- [x] Documentation update

## Changes

### Fixed — observer enforces the car-runtime ≥0.18.0 floor at runtime
`_require_car_runtime` gated only on `hasattr(car_runtime, "agents_upsert")`, which 0.16.x/0.17.0 also satisfy — so the observer would **silently run on an under-spec binding** exposed to the pre-0.18.0 supervisor footguns (orphaned child / restart-storm on start-during-backoff / stale `last_exit_code`) that 0.18.0 fixed. It now also checks the installed version (`importlib.metadata`) and raises an actionable error below 0.18.0. Unparseable/missing version is allowed through (lenient about unknown, strict about known-too-old) so a vendored build isn't falsely rejected.

### Changed — CarAdapter `task=code` hint rationale ([#52](https://github.com/Parslee-ai/car-releases/issues/52) closed)
The router cost-bias that motivated the hint is fixed upstream (router now prioritizes quality > speed > cost for `task=code`; 0.25–0.27 add capability-honest routing + `exclude_models`). The `{"task":"code","prefer_quality":True}` default is the *intended* router API, not a workaround — **kept**, with the CLAUDE.md rationale corrected. `adapters.py` default unchanged.

## Operational note (done out-of-band, not in this PR)
Upgraded the local binding **car-runtime 0.17.0 → 0.27.0** and restarted the observer (now `running` healthy on 0.27.0). This PR is the neo-side hardening so the floor can't be silently violated again.

## How Has This Been Tested?

- [x] 4 new observer tests: version parse, old-version rejected, current accepted, unknown allowed (using the existing fake-`car_runtime` fixture, so they run without the `[car]` extra in CI).
- [x] Full suite green: **1125 passed, 3 skipped**; `ruff` clean.
- [x] Live: observer restarted on car-runtime 0.27.0, `neo memory observer status` → `running`.

## Checklist

- [x] Version bumped consistently; CHANGELOG updated; CLAUDE.md rationale corrected
- [x] New and existing unit tests pass locally