### PR TITLE
chore: raise [car] floor to car-runtime>=0.27.0,<1.0 (v0.28.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.28.1] - 2026-06-19
+
+### Changed
+
+- **`[car]` extra floor raised to `car-runtime>=0.27.0,<1.0`** (was `>=0.18.0`). The spec already tracked latest *within* the 0.x line — a fresh install / `pipx upgrade` resolves to the newest compatible release, since car-runtime is on the package index — so this raises the floor to the newest version neo is validated against (a fresh install can no longer land on an old 0.x). The `<1.0` cap is kept deliberately: car-runtime is a sealed binary where 0.x minors can carry breaking changes, so a breaking 1.0 rewrite is not adopted silently on upgrade. The observer's *runtime* floor stays a separate, more permissive `0.18.0` (`memory.observer._CAR_MIN_VERSION`) — the functionally footgun-free minimum — so an existing 0.18–0.26 install keeps working while fresh installs ship the latest. (`pyproject.toml`)
+
 ## [0.28.0] - 2026-06-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.28.0"
+version = "0.28.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -61,7 +61,8 @@ ollama = ["requests>=2.31.0"]
 # Requires the car-server daemon (`python -m car_runtime.server`)
 # running locally; see INSTALL.md.
 #
-# Minimum is 0.18.0: 0.16.x has the `agents_*` API but the PyO3
+# Functional minimum is 0.18.0 (the pin floor below is higher — newest
+# validated): 0.16.x has the `agents_*` API but the PyO3
 # binding still tries to acquire the supervisor manifest lock
 # in-process, which collides with a running CarHost.app/car-server
 # (Parslee-ai/car-releases#54). 0.17.0 routes those calls through
@@ -76,13 +77,17 @@ ollama = ["requests>=2.31.0"]
 # for `CarAdapter`-only use, but `neo memory observer start` will
 # reject them with an actionable error.
 car = [
-    # Upper-capped at the next major so `keep current` (a plain
-    # `pipx upgrade`) tracks latest within a compatible major rather
-    # than silently adopting a breaking rewrite of this sealed binary.
-    # NB: car-runtime is pre-1.0, so 0.x minor bumps can still carry
-    # breaking changes (see history above) — validate the observer
-    # after upgrading across a minor.
-    "car-runtime>=0.18.0,<1.0",
+    # Tracks latest within the 0.x line: a fresh install / `pipx upgrade`
+    # resolves to the newest compatible release (car-runtime is on the index).
+    # Upper-capped at the next major so it does NOT silently adopt a breaking
+    # 1.0 rewrite of this sealed binary. Floor raised to 0.27.0 — the latest
+    # version neo is validated against — so a fresh install can't land on an
+    # old 0.x. NB: car-runtime is pre-1.0, so 0.x minor bumps can still carry
+    # breaking changes (see history above) — validate the observer after
+    # upgrading across a minor. (The observer's *runtime* floor is a separate,
+    # more permissive 0.18.0 in `memory.observer._CAR_MIN_VERSION`: the minimum
+    # that is functionally footgun-free, vs. this pin's "ship latest validated".)
+    "car-runtime>=0.27.0,<1.0",
     # JSON-RPC-over-WebSocket client for the A2UI surface
     # (`neo.a2ui`). The Python `car_runtime.a2ui_*` helpers are
     # in-process only; reaching the daemon's a2ui store — which is

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Raises the `[car]` extra floor to `car-runtime>=0.27.0,<1.0` (was `>=0.18.0`). **v0.28.1** (patch — packaging only).

## Type of Change

- [x] Code cleanup/refactoring (dependency metadata)

## Context

While checking why the local observer was running on a stale 0.17.0, I confirmed **car-runtime is on the package index** — so the existing spec *already* tracked latest within the 0.x line (a fresh install / `pipx upgrade` resolves to the newest compatible release). The 0.17.0 was just a never-upgraded local install, not a pin failure.

This raises the **floor to 0.27.0** (the newest version neo is validated against) so a fresh install can't land on an old 0.x, while **keeping the deliberate `<1.0` cap** — car-runtime is a sealed binary where even 0.x minors carry breaking changes, so a breaking 1.0 rewrite must not be adopted silently on upgrade.

The observer's **runtime** floor stays a separate, more permissive `0.18.0` (`memory.observer._CAR_MIN_VERSION`) — the functionally footgun-free minimum — so an existing 0.18–0.26 install keeps working while fresh installs ship the latest validated binding. The two floors are intentionally independent (ship-latest vs. minimum-that-works).

## How Has This Been Tested?

- [x] No code change; CI runs the full suite + ruff.
- [x] `car-runtime` confirmed resolvable on the index (versions through 0.27.0); local binding is 0.27.0 and the observer is `running`.

## Checklist

- [x] Version bumped consistently; CHANGELOG updated; pyproject comment updated to explain both floors