### PR TITLE
feat: neo memory observer status flags orphaned observers (v0.29.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.29.0] - 2026-06-19
+
+### Added
+
+- **`neo memory observer status` now flags orphaned observer processes.** A prior car-server that died without reaping its child leaves an observer reparented to init/launchd (the pre-0.18.0 footgun) — running redundant synthesis cycles and invisible to `status`, which only knew about CAR's supervised agent. Status now scans for `neo.memory.observer --daemon` processes scoped to this project (matched by the daemon's `--cwd`, realpath-compared) whose parent is init/launchd (`ppid == 1`) — the supervised observer is always parented by car-server, so it's never falsely flagged — and prints a `WARNING` with the orphan pid(s) and a `kill` hint. Best-effort via `ps`; returns no orphans (never errors) on any platform/parse failure. The status result gains an `orphans` field. Found and reaped a real 4-day-old orphan during validation. (`memory/observer.py:_find_orphan_observers`, `subcommands.py`)
+
 ## [0.28.1] - 2026-06-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,11 @@
   Lifecycle: `neo memory observer {start|stop|status|kick}` — `kick` maps to
   `agents_restart` since CAR has no signal-passthrough primitive. Status surfaces
   CAR's raw state verbatim (`running` | `stopped` | `starting` | `backoff` |
-  `errored`) so restart-loops are diagnosable. Tunables:
+  `errored`) so restart-loops are diagnosable, and also flags **orphaned**
+  observer processes — a `neo.memory.observer --daemon` for this project
+  reparented to init/launchd (`ppid==1`) by a dead prior car-server, which CAR's
+  supervised view can't see (`observer._find_orphan_observers`; the `orphans`
+  field + a `WARNING` with a `kill` hint). Tunables:
   `NEO_OBSERVER_INTERVAL_SECONDS` (default 300), `NEO_OBSERVER_COOLDOWN`
   (default 60, per-process). **Footgun**: the interpreter path (`sys.executable`)
   must not live under a world-writable directory (`/tmp`, `/private/tmp`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.28.1"
+version = "0.29.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.28.1"
+__version__ = "0.29.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -38,6 +38,7 @@ import logging
 import os
 import re
 import signal
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -616,21 +617,66 @@ def kick_observer(codebase_root: Optional[str] = None) -> dict:
             "message": f"restarted as pid {managed.get('pid')}"}
 
 
+def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
+    """Launchd/init-orphaned observer daemons for this project (ppid == 1).
+
+    An orphan is an observer process the CAR supervisor no longer parents — left
+    behind when a prior car-server died without reaping its child (the pre-0.18.0
+    footgun). It is reparented to init/launchd (ppid 1); the supervised observer
+    is always parented by car-server, so it is never matched. Scoped to this
+    project by the daemon's ``--cwd`` argument (realpath-compared). Best-effort
+    via ``ps`` — returns ``[]`` on any platform/parse/timeout failure so it can
+    never break ``status``.
+    """
+    root = os.path.realpath(codebase_root or os.getcwd())
+    try:
+        out = subprocess.run(
+            ["ps", "-ax", "-o", "pid=,ppid=,command="],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+    orphans: list[int] = []
+    for line in out.splitlines():
+        fields = line.split(None, 2)
+        if len(fields) < 3:
+            continue
+        pid_s, ppid_s, cmd = fields
+        if ppid_s != "1":
+            continue  # supervised processes are parented by car-server, not init
+        if "neo.memory.observer" not in cmd or "--daemon" not in cmd:
+            continue
+        m = re.search(r"--cwd\s+(\S+)", cmd)
+        if not m:
+            continue
+        try:
+            if os.path.realpath(m.group(1)) != root:
+                continue  # a different project's orphan, not ours
+            orphans.append(int(pid_s))
+        except (ValueError, OSError):
+            continue
+    return orphans
+
+
 def observer_status(codebase_root: Optional[str] = None) -> dict:
     project_id = _resolve_project_id(codebase_root)
     if not project_id:
         return {"status": "error", "message": "No project_id"}
 
+    orphans = _find_orphan_observers(codebase_root)
+
     try:
         car = _require_car_runtime()
     except RuntimeError as e:
-        return {"status": "error", "project_id": project_id, "message": str(e)}
+        return {"status": "error", "project_id": project_id,
+                "message": str(e), "orphans": orphans}
 
     aid = _agent_id(project_id)
     existing = _find_managed_agent(car, aid)
     if not existing:
         return {"status": "not_running", "project_id": project_id, "agent_id": aid,
-                "message": "no managed agent registered"}
+                "message": "no managed agent registered", "orphans": orphans}
 
     # CAR's `status` field is one of: stopped | starting | running |
     # backoff | errored — we surface it directly so operators can tell
@@ -645,6 +691,7 @@ def observer_status(codebase_root: Optional[str] = None) -> dict:
         "restart_count": existing.get("restart_count", 0),
         "last_exit_code": existing.get("last_exit_code"),
         "log_file": f"~/.car/logs/{aid}.stdout.log",
+        "orphans": orphans,
         "message": (
             f"observer pid {existing.get('pid')} "
             f"(restarts={existing.get('restart_count', 0)})"

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -339,6 +339,17 @@ def _handle_observer(args) -> None:
         parts.append(f"log={result['log_file']}")
     print(" ".join(parts))
 
+    orphans = result.get("orphans") or []
+    if orphans:
+        pidlist = " ".join(str(p) for p in orphans)
+        print(
+            f"[Neo] WARNING: {len(orphans)} orphaned observer process(es) for this "
+            f"project not supervised by CAR (pid {pidlist}) — a leftover from a prior "
+            f"car-server (pre-0.18.0 footgun). It runs redundant synthesis cycles; "
+            f"reap with: kill {pidlist}",
+            file=sys.stderr,
+        )
+
 
 def _parse_since(value: str) -> Optional[float]:
     """Parse a duration like ``14d`` / ``48h`` / ``30m`` / ``3600s`` to seconds.

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -90,6 +90,55 @@ class TestCarVersionFloor:
         assert obs._require_car_runtime() is fake_car
 
 
+class TestOrphanDetection:
+    def _fake_ps(self, monkeypatch, text):
+        import neo.memory.observer as obs
+        monkeypatch.setattr(
+            obs.subprocess, "run",
+            lambda *a, **k: types.SimpleNamespace(stdout=text),
+        )
+
+    def test_finds_launchd_orphan_for_this_root(self, monkeypatch, tmp_path):
+        root = str(tmp_path)
+        text = (
+            f"100     1 /usr/bin/python -m neo.memory.observer --daemon --cwd {root}\n"       # orphan
+            f"200 20656 /usr/bin/python -m neo.memory.observer --daemon --cwd {root}\n"       # supervised
+            f"300     1 /usr/bin/python -m neo.memory.observer --daemon --cwd /other/proj\n"  # other project
+            f"400     1 /usr/bin/python -m http.server\n"                                     # not observer
+        )
+        self._fake_ps(monkeypatch, text)
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == [100]
+
+    def test_no_orphan_when_only_supervised(self, monkeypatch, tmp_path):
+        root = str(tmp_path)
+        self._fake_ps(monkeypatch, f"200 20656 python -m neo.memory.observer --daemon --cwd {root}\n")
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == []
+
+    def test_ps_failure_is_safe(self, monkeypatch, tmp_path):
+        import neo.memory.observer as obs
+
+        def boom(*a, **k):
+            raise OSError("no ps here")
+
+        monkeypatch.setattr(obs.subprocess, "run", boom)
+        assert obs._find_orphan_observers(str(tmp_path)) == []
+
+    def test_status_includes_orphans(self, monkeypatch):
+        import neo.memory.observer as obs
+        monkeypatch.setattr(obs, "_resolve_project_id", lambda root: "abc123def456")
+        monkeypatch.setattr(obs, "_require_car_runtime", lambda: object())
+        monkeypatch.setattr(
+            obs, "_find_managed_agent",
+            lambda car, aid: {"status": "running", "pid": 555, "restart_count": 0},
+        )
+        monkeypatch.setattr(obs, "_find_orphan_observers", lambda root: [777])
+        st = obs.observer_status("/repo")
+        assert st["status"] == "running"
+        assert st["orphans"] == [777]
+
+
 class TestSpecBuilding:
     def test_spec_uses_current_python(self, fake_project_id):
         from neo.memory.observer import _build_spec


### PR DESCRIPTION
## Description

`neo memory observer status` now detects and warns about **orphaned observer processes**. Bumps to **v0.29.0**.

When a prior car-server dies without reaping its child, the observer is reparented to init/launchd (the pre-0.18.0 footgun) — it keeps running redundant synthesis cycles but is **invisible to `status`**, which only knew about CAR's supervised agent. (A real 4-day-old orphan was found and reaped during the observer validation that motivated this.)

## Type of Change

- [x] New feature (non-breaking; additive to `status`)
- [x] Documentation update

## How it works

`_find_orphan_observers` scans `ps` for `neo.memory.observer --daemon` processes scoped to **this project** (matched by the daemon's `--cwd`, realpath-compared) whose **parent is init/launchd (`ppid == 1`)**. The supervised observer is always parented by car-server, so it's never falsely flagged. Best-effort: any platform/parse/timeout failure returns no orphans (never breaks `status`). The status result gains an `orphans` field; the CLI prints a `WARNING` with the orphan pid(s) and a `kill` hint.

## How Has This Been Tested?

- [x] 4 unit tests (mocked `ps`): finds this-project orphan, ignores supervised/other-project/non-observer lines, `ps`-failure-safe, `status` includes `orphans`.
- [x] **Live end-to-end**: spawned a self-expiring orphan decoy (ppid 1) → `status` printed the WARNING with the right pid → reaped it → warning gone, clean status.
- [x] Full suite green: **1129 passed, 3 skipped**; `ruff` clean.

## Checklist

- [x] Version bumped consistently; CHANGELOG + CLAUDE.md observer section updated
- [x] New and existing unit tests pass locally