### PR TITLE
feat: cross-platform observer orphan detection — Windows support (v0.30.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.30.0] - 2026-06-19
+
+### Changed
+
+- **Observer orphan detection is now cross-platform (Windows support).** The 0.29.0 orphan check used `ps` and `ppid == 1`, both POSIX-only. `_find_orphan_observers` now prefers **psutil** (added to the `[car]` extra) for parent-liveness introspection that works on macOS/Linux/Windows, falling back to `ps` on POSIX when psutil is absent. The portable orphan signal is "no live parent": POSIX reparents a dead parent's child to init/launchd (`ppid == 1`), while Windows does not reparent — psutil reports the vanished launching car-server as `parent() is None`. The supervised observer (parented by a live car-server) is never flagged on any OS. Verified live (psutil path doesn't false-positive the real supervised observer) and unit-tested for POSIX-orphan, Windows-orphan, supervised, and non-observer cases. (`memory/observer.py`, `pyproject.toml`)
+
 ## [0.29.0] - 2026-06-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.29.0"
+version = "0.30.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -93,6 +93,11 @@ car = [
     # in-process only; reaching the daemon's a2ui store — which is
     # what renderers subscribe to — requires speaking WS directly.
     "websockets>=12.0",
+    # Cross-platform process introspection for observer orphan detection
+    # (`memory.observer._find_orphan_observers`): `ps`/`ppid==1` are POSIX-only,
+    # so psutil powers parent-liveness checks on Windows too. POSIX without
+    # psutil falls back to `ps`.
+    "psutil>=5.9.0",
 ]
 all = [
     "anthropic>=0.21.0",

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -617,18 +617,64 @@ def kick_observer(codebase_root: Optional[str] = None) -> dict:
             "message": f"restarted as pid {managed.get('pid')}"}
 
 
+def _cmd_is_our_observer(cmd: str, root: str) -> bool:
+    """True if a command line is an observer daemon for this project's root."""
+    if "neo.memory.observer" not in cmd or "--daemon" not in cmd:
+        return False
+    m = re.search(r"--cwd[\s=]+(\S+)", cmd)
+    if not m:
+        return False
+    try:
+        return os.path.realpath(m.group(1).strip('"\'')) == root
+    except OSError:
+        return False
+
+
 def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
-    """Launchd/init-orphaned observer daemons for this project (ppid == 1).
+    """Orphaned observer daemons for this project — cross-platform.
 
     An orphan is an observer process the CAR supervisor no longer parents — left
     behind when a prior car-server died without reaping its child (the pre-0.18.0
-    footgun). It is reparented to init/launchd (ppid 1); the supervised observer
-    is always parented by car-server, so it is never matched. Scoped to this
-    project by the daemon's ``--cwd`` argument (realpath-compared). Best-effort
-    via ``ps`` — returns ``[]`` on any platform/parse/timeout failure so it can
-    never break ``status``.
+    footgun). The supervised observer is always parented by a live car-server, so
+    it is never matched. "No live parent" is the portable signal:
+
+    - POSIX: a dead parent reparents the child to init/launchd (``ppid == 1``).
+    - Windows: there is no reparenting; the parent pid simply no longer maps to a
+      live process, which ``psutil`` reports as ``parent() is None``.
+
+    Prefers ``psutil`` (works on macOS/Linux/Windows); falls back to ``ps`` on
+    POSIX when ``psutil`` is absent. Scoped to this project by the daemon's
+    ``--cwd`` (realpath-compared). Best-effort: returns ``[]`` on any
+    platform/parse/permission failure so it can never break ``status``.
     """
     root = os.path.realpath(codebase_root or os.getcwd())
+
+    try:
+        import psutil
+    except ImportError:
+        return _find_orphan_observers_ps(root)
+
+    orphans: list[int] = []
+    for proc in psutil.process_iter(["pid", "ppid", "cmdline"]):
+        try:
+            cmd = " ".join(proc.info.get("cmdline") or [])
+            if not _cmd_is_our_observer(cmd, root):
+                continue
+            try:
+                parent_alive = proc.parent() is not None
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                parent_alive = False
+            # POSIX orphan: reparented to init (ppid 1). Windows orphan: the
+            # launching car-server is gone, so psutil finds no live parent.
+            if proc.info.get("ppid") == 1 or not parent_alive:
+                orphans.append(int(proc.pid))
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return sorted(orphans)
+
+
+def _find_orphan_observers_ps(root: str) -> list[int]:
+    """POSIX ``ps`` fallback for orphan detection (used when psutil is absent)."""
     try:
         out = subprocess.run(
             ["ps", "-ax", "-o", "pid=,ppid=,command="],
@@ -643,20 +689,15 @@ def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
         if len(fields) < 3:
             continue
         pid_s, ppid_s, cmd = fields
-        if ppid_s != "1":
-            continue  # supervised processes are parented by car-server, not init
-        if "neo.memory.observer" not in cmd or "--daemon" not in cmd:
+        if ppid_s != "1":  # supervised processes are parented by car-server, not init
             continue
-        m = re.search(r"--cwd\s+(\S+)", cmd)
-        if not m:
+        if not _cmd_is_our_observer(cmd, root):
             continue
         try:
-            if os.path.realpath(m.group(1)) != root:
-                continue  # a different project's orphan, not ours
             orphans.append(int(pid_s))
-        except (ValueError, OSError):
+        except ValueError:
             continue
-    return orphans
+    return sorted(orphans)
 
 
 def observer_status(codebase_root: Optional[str] = None) -> dict:

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -90,9 +90,77 @@ class TestCarVersionFloor:
         assert obs._require_car_runtime() is fake_car
 
 
-class TestOrphanDetection:
+class _FakeProc:
+    """Minimal psutil.Process stand-in for orphan-detection tests."""
+
+    def __init__(self, pid, ppid, cmdline, parent_alive=True):
+        self.pid = pid
+        self.info = {"pid": pid, "ppid": ppid, "cmdline": cmdline}
+        self._parent_alive = parent_alive
+
+    def parent(self):
+        return object() if self._parent_alive else None
+
+
+def _install_fake_psutil(monkeypatch, procs):
+    class NoSuchProcess(Exception):
+        pass
+
+    class AccessDenied(Exception):
+        pass
+
+    fake = types.SimpleNamespace(
+        process_iter=lambda attrs=None: list(procs),
+        NoSuchProcess=NoSuchProcess,
+        AccessDenied=AccessDenied,
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+    return fake
+
+
+def _obs_cmd(root):
+    return ["/usr/bin/python", "-m", "neo.memory.observer", "--daemon", "--cwd", root]
+
+
+class TestOrphanDetectionPsutil:
+    """Cross-platform path (psutil): POSIX ppid==1 AND Windows parent-gone."""
+
+    def test_posix_orphan_ppid1(self, monkeypatch, tmp_path):
+        root = str(tmp_path)
+        _install_fake_psutil(monkeypatch, [_FakeProc(100, 1, _obs_cmd(root), parent_alive=True)])
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == [100]
+
+    def test_windows_orphan_parent_gone(self, monkeypatch, tmp_path):
+        # No ppid==1 reparenting on Windows; the launching car-server is just gone.
+        root = str(tmp_path)
+        _install_fake_psutil(monkeypatch, [_FakeProc(200, 4321, _obs_cmd(root), parent_alive=False)])
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == [200]
+
+    def test_supervised_not_flagged(self, monkeypatch, tmp_path):
+        root = str(tmp_path)
+        _install_fake_psutil(monkeypatch, [_FakeProc(300, 20656, _obs_cmd(root), parent_alive=True)])
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == []
+
+    def test_ignores_other_project_and_nonobserver(self, monkeypatch, tmp_path):
+        root = str(tmp_path)
+        procs = [
+            _FakeProc(1, 1, _obs_cmd("/some/other/project"), parent_alive=False),
+            _FakeProc(2, 1, ["/usr/bin/python", "-m", "http.server"], parent_alive=False),
+        ]
+        _install_fake_psutil(monkeypatch, procs)
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers(root) == []
+
+
+class TestOrphanDetectionPs:
+    """POSIX `ps` fallback path (psutil absent)."""
+
     def _fake_ps(self, monkeypatch, text):
         import neo.memory.observer as obs
+        monkeypatch.setitem(sys.modules, "psutil", None)  # force ImportError -> ps fallback
         monkeypatch.setattr(
             obs.subprocess, "run",
             lambda *a, **k: types.SimpleNamespace(stdout=text),
@@ -118,6 +186,7 @@ class TestOrphanDetection:
 
     def test_ps_failure_is_safe(self, monkeypatch, tmp_path):
         import neo.memory.observer as obs
+        monkeypatch.setitem(sys.modules, "psutil", None)
 
         def boom(*a, **k):
             raise OSError("no ps here")
@@ -125,6 +194,8 @@ class TestOrphanDetection:
         monkeypatch.setattr(obs.subprocess, "run", boom)
         assert obs._find_orphan_observers(str(tmp_path)) == []
 
+
+class TestOrphanStatus:
     def test_status_includes_orphans(self, monkeypatch):
         import neo.memory.observer as obs
         monkeypatch.setattr(obs, "_resolve_project_id", lambda root: "abc123def456")


### PR DESCRIPTION
## Description

Makes the observer orphan check (added in 0.29.0) **cross-platform**, so it works on Windows — not just macOS/Linux. Bumps to **v0.30.0**.

0.29.0 detected orphans via `ps` + `ppid == 1`, both POSIX-only. CAR ships Windows builds (`car-server-win32-x64-msvc.exe`, `win_amd64` wheel), so the observer can run there, but the orphan check couldn't.

## Type of Change

- [x] New feature (cross-platform support)
- [x] Documentation update

## How

`_find_orphan_observers` now prefers **psutil** (added to the `[car]` extra) for parent-liveness introspection across macOS/Linux/Windows, and falls back to `ps` on POSIX when psutil is absent. The portable orphan signal is **"no live parent"**:
- **POSIX**: a dead parent reparents the child to init/launchd → `ppid == 1`.
- **Windows**: no reparenting — the vanished launching car-server is reported by psutil as `parent() is None`.

The supervised observer (parented by a live car-server) is never flagged on any OS. Best-effort throughout: any platform/permission/parse failure returns `[]` so it can't break `status`.

## Audit note
The only hard Windows breakage was this orphan check. The rest of the observer path is already OK: `store.py`'s cross-process lock uses `fcntl` but **degrades gracefully** when unavailable; the daemon registers `SIGTERM`/`SIGINT` (both exist on Windows; no `SIGUSR1` in code); and spawn/stop/restart is **CAR's** supervisor, which has Windows builds.

## How Has This Been Tested?

- [x] 4 new psutil-path tests (injected fake psutil): POSIX orphan (`ppid==1`), **Windows orphan (`parent() is None`)**, supervised-not-flagged, other-project/non-observer ignored. Plus the `ps`-fallback tests (forced psutil-absent) retained.
- [x] **Live**: installed psutil 7.2.2, confirmed the psutil path returns `[]` for the real supervised observer (no false positive).
- [x] Full suite green: **1133 passed, 3 skipped**; `ruff` clean.

## Checklist

- [x] Version bumped consistently; CHANGELOG updated; `psutil>=5.9.0` added to `[car]`
- [x] New and existing unit tests pass locally