### PR TITLE
feat: single global auto-started observer sweeping all projects (v0.31.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.0] - 2026-06-19
+
+### Changed
+
+- **The memory observer is now a single global, auto-started process instead of one opt-in process per project.** Previously you had to run `neo memory observer start` in each repo, and each got its own supervised daemon — so in practice only one project was ever observed. Now a single CAR agent (`neo-observer`, daemon `--daemon --all`) **sweeps all discovered projects** each cycle (round-robin, `max_projects_per_cycle` default 25; watermark-gated so projects with no new transcripts do near-zero work), running synthesis + transcript mining per project. **No opt-in**: `maybe_autostart_observer()` (called from `cli.main`) auto-registers it whenever `car-server` is reachable — opt out with `NEO_OBSERVER_AUTOSTART=0`; when CAR is absent it prints a one-time hint then stays silent. On bootstrap/start, legacy per-project agents (`neo-observer-<id12>`) are stopped and removed. Lifecycle (`start`/`stop`/`kick`/`status`) and orphan detection now operate on the single global agent; orphan detection flags *any* unsupervised neo observer daemon (global or stranded legacy). Per-project mode (`--daemon --cwd`) and the A2UI inspector remain for direct use. (`memory/observer.py`, `cli.py`)
+
 ## [0.30.0] - 2026-06-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,14 +108,22 @@
   JSON-RPC over its WebSocket. `neo.a2ui.DaemonClient` is that bridge.
   Activation: auto when `127.0.0.1:9100` is reachable; silent no-op
   otherwise. Adds `websockets>=12.0` to the `[car]` extra.
-- Async synthesis observer (`memory.observer`): a per-project background process
-  that runs `synthesize_reviews` on a wall-clock cadence, decoupled from the
-  request path. *Additive* — the inline triple-trigger gate keeps firing too;
-  the observer just makes synthesis more frequent. **Hard dep**: car-runtime
-  ≥ 0.18.0 and a running `car-server` daemon — CAR's supervisor owns the
-  spawn / restart-on-failure / log redirection / clean SIGTERM shutdown.
-  Spec persisted to `~/.car/agents.json` (`auto_start: true` so it comes back
-  on daemon boot); logs land at `~/.car/logs/neo-observer-<id8>.{stdout,stderr}.log`.
+- Async synthesis observer (`memory.observer`): a **single global** background
+  process (CAR agent `neo-observer`, daemon `--daemon --all`) that **sweeps all
+  discovered projects** each cycle — round-robin/budgeted (`max_projects_per_cycle`,
+  default 25; watermark-gated so unchanged projects do near-zero work) — running
+  `synthesize_reviews` + transcript mining per project. *Additive* — the inline
+  triple-trigger gate keeps firing too. **Not opt-in**: `maybe_autostart_observer()`
+  (called from `cli.main`) auto-registers it whenever `car-server` is reachable;
+  opt out with `NEO_OBSERVER_AUTOSTART=0`. No CAR → one-time hint, then silent.
+  Projects are discovered from `~/.claude/projects/*` (decoded roots). On
+  bootstrap/start, legacy **per-project** agents (`neo-observer-<id12>`, the old
+  model) are stopped + `agents_remove`d. **Hard dep**: car-runtime ≥ 0.18.0
+  (pin floor 0.27.0) + a running `car-server` — CAR's supervisor owns
+  spawn / restart-on-failure / clean SIGTERM. Logs at
+  `~/.car/logs/neo-observer.{stdout,stderr}.log`. Lifecycle/`status`/orphan-check
+  all operate on the single global agent. (A2UI per-project inspector is skipped
+  in global mode.)
   Lifecycle: `neo memory observer {start|stop|status|kick}` — `kick` maps to
   `agents_restart` since CAR has no signal-passthrough primitive. Status surfaces
   CAR's raw state verbatim (`running` | `stopped` | `starting` | `backoff` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.30.0"
+version = "0.31.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -454,6 +454,21 @@ def main():
         except Exception as e:
             logger.debug(f"Update check failed: {e}")
 
+    # Auto-start the single global memory observer when CAR is present (no
+    # per-project opt-in). Non-blocking, silent, never raises; opt out with
+    # NEO_OBSERVER_AUTOSTART=0. Skipped for explicit `memory observer` commands
+    # (the handler manages the agent) and version/config short-circuits.
+    if not (
+        (hasattr(args, 'version') and args.version)
+        or (hasattr(args, 'config') and args.config)
+        or (getattr(args, 'memory_action', None) == 'observer')
+    ):
+        try:
+            from neo.memory.observer import maybe_autostart_observer
+            maybe_autostart_observer()
+        except Exception as e:
+            logger.debug(f"Observer autostart failed: {e}")
+
     # Handle global flags first (exist on all parsers, must check before subcommand-specific attributes)
 
     # Handle --version flag

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -113,10 +113,41 @@ def _resolve_project_id(codebase_root: Optional[str]) -> str:
     return project_id
 
 
+# A single, global observer supervises ALL projects (one process, one CAR
+# agent) rather than one per project. Legacy per-project agents use the
+# ``neo-observer-<id12>`` form and are migrated away on bootstrap.
+GLOBAL_AGENT_ID = "neo-observer"
+_LEGACY_AGENT_RE = re.compile(r"^neo-observer-[0-9a-f]{6,}$")
+
+
 def _agent_id(project_id: str) -> str:
     """Filename-safe ID for the supervisor. Short prefix keeps logs
     grep-able when multiple projects are active."""
     return f"neo-observer-{project_id[:12]}"
+
+
+def _discover_project_roots() -> list[str]:
+    """All project roots neo has seen, for the global observer's sweep.
+
+    Source of truth is Claude Code's per-project transcript dirs
+    (``~/.claude/projects/<encoded>``); the encoded name decodes back to an
+    absolute root. Best-effort — returns ``[]`` if the dir is absent/unreadable.
+    """
+    from neo.memory.transcript import CLAUDE_PROJECTS_DIR
+    from neo.prompt.scanner import _decode_project_path
+
+    roots: set[str] = set()
+    try:
+        entries = list(CLAUDE_PROJECTS_DIR.iterdir())
+    except OSError:
+        return []
+    for d in entries:
+        if not d.is_dir():
+            continue
+        root = _decode_project_path(d.name)
+        if root:
+            roots.add(root)
+    return sorted(roots)
 
 
 def _build_spec(project_id: str, codebase_root: str) -> dict:
@@ -172,6 +203,11 @@ class ObserverConfig:
     # the interval so a slow pass doesn't swallow the wake cadence.
     ingest_budget: int = 8
     ingest_deadline_seconds: float = 120.0
+    # Global-mode sweep: cap projects visited per cycle. The sweep round-robins
+    # across cycles, so all projects get covered over a few cycles without one
+    # cycle paying to load every project's FactStore. Projects with no new
+    # transcripts since their watermark do near-zero work (ingest finds nothing).
+    max_projects_per_cycle: int = 25
 
     @classmethod
     def from_env(cls) -> "ObserverConfig":
@@ -200,18 +236,25 @@ class Observer:
     supervisor on stop and exits cleanly.
     """
 
-    def __init__(self, codebase_root: str, config: Optional[ObserverConfig] = None):
+    def __init__(self, codebase_root: Optional[str] = None,
+                 config: Optional[ObserverConfig] = None, global_mode: bool = False):
+        self.global_mode = global_mode
         self.codebase_root = codebase_root
         self.config = config or ObserverConfig.from_env()
-        self.project_id = _resolve_project_id(codebase_root)
-        if not self.project_id:
-            raise RuntimeError(
-                "Cannot run observer without a resolvable project_id "
-                "(no codebase_root and no git repo in cwd)"
-            )
+        if global_mode:
+            # Sweeps all discovered projects; no single project_id.
+            self.project_id = ""
+        else:
+            self.project_id = _resolve_project_id(codebase_root)
+            if not self.project_id:
+                raise RuntimeError(
+                    "Cannot run observer without a resolvable project_id "
+                    "(no codebase_root and no git repo in cwd)"
+                )
         self._stop = False
         self._last_analysis_epoch = 0.0
         self._cycles_total = 0
+        self._sweep_offset = 0  # round-robin cursor for global-mode sweeps
         # Recent cycles for the A2UI Observer tab. List of
         # ``{"timestamp": float, "text": "..."}`` capped client-side at
         # RECENT_CYCLES_MAX.
@@ -241,14 +284,14 @@ class Observer:
         signal.signal(signal.SIGTERM, self._handle_stop)
         signal.signal(signal.SIGINT, self._handle_stop)
 
-        print(
-            f"neo observer started pid={os.getpid()} project={self.project_id[:8]}",
-            flush=True,
-        )
+        scope = "all projects" if self.global_mode else f"project={self.project_id[:8]}"
+        print(f"neo observer started pid={os.getpid()} {scope}", flush=True)
 
-        # Best-effort A2UI surface. Daemon may not be up; if not, we
-        # skip silently and the rest of the loop runs unchanged.
-        await self._init_surface()
+        # Best-effort A2UI surface (per-project inspector). The surface is keyed
+        # to one project_id, so it only applies in per-project mode; the global
+        # sweep skips it.
+        if not self.global_mode:
+            await self._init_surface()
 
         # `get_running_loop()` (not `get_event_loop()`) is the
         # canonical API inside a coroutine — the latter is deprecated
@@ -283,30 +326,34 @@ class Observer:
         return elapsed >= self.config.cooldown_seconds
 
     def _cycle(self) -> None:
-        """One synthesis pass. Errors are caught and logged — never
-        propagate, so a bad cycle doesn't cause the supervisor to
-        restart-loop us into a backoff hell.
+        """One pass. Dispatches to the global sweep or the per-project cycle."""
+        if self.global_mode:
+            self._cycle_global()
+        else:
+            self._cycle_one()
 
-        Also stashes a FactStore snapshot on ``self`` so the post-cycle
-        A2UI push can update the Memory tab without re-loading.
+    def _run_project(self, root: str) -> tuple[int, int, object]:
+        """Synthesize + transcript-mine one project. Returns (synthesized,
+        mined, store). Transcript mining MUST run AFTER synthesis so a durable
+        synthesis can't be aborted by an ingest/LM failure (isolated in its own
+        guard). Do not reorder.
+        """
+        from neo.memory.store import FactStore
+
+        store = FactStore(codebase_root=root, eager_init=False)
+        store.initialize()
+        count = store.synthesize_reviews()
+        mined = self._ingest_transcripts(store, root)
+        return count, mined, store
+
+    def _cycle_one(self) -> None:
+        """Per-project pass (also feeds the A2UI inspector). Errors are caught
+        and logged — never propagate, so a bad cycle can't drive the supervisor
+        into backoff hell.
         """
         try:
-            # Lazy import — FactStore pulls fastembed/numpy/etc.; defer
-            # so a malformed --cwd reports cleanly before paying that
-            # import cost.
-            from neo.memory.store import FactStore
-
             t0 = time.time()
-            store = FactStore(codebase_root=self.codebase_root, eager_init=False)
-            store.initialize()
-            count = store.synthesize_reviews()
-            # Transcript mining MUST run AFTER synthesis: synthesis is then
-            # already durable, so an ingest/LM failure (isolated in its own
-            # guard) can never abort it. Both passes share this executor-run
-            # call (run_in_executor keeps the WS loop draining); tick is logged
-            # so we can tell if it stalls and needs splitting into a separate
-            # cycle. Do not reorder.
-            ingested = self._ingest_transcripts(store)
+            count, ingested, store = self._run_project(self.codebase_root)
             tick = time.time() - t0
             mined = (f"{ingested} mined" if not self._last_ingest_error
                      else f"ingest ERROR {self._last_ingest_error}")
@@ -321,8 +368,6 @@ class Observer:
                     f"{count} synthesized, {mined}"
                 ),
             })
-            # Stash for the post-cycle Memory tab update. Keep the ref
-            # around for ~1 cycle; FactStore is GC'd otherwise.
             self._last_store_snapshot = self._build_store_snapshot(store)
             print(
                 f"neo observer cycle ok: {count} synthesized, {mined} ({tick:.1f}s)",
@@ -341,7 +386,56 @@ class Observer:
                 flush=True,
             )
 
-    def _ingest_transcripts(self, store) -> int:
+    def _cycle_global(self) -> None:
+        """Global sweep: round-robin a budgeted batch of all discovered projects,
+        synthesizing + mining each. Per-project errors are isolated so one bad
+        project never aborts the sweep.
+        """
+        t0 = time.time()
+        roots = _discover_project_roots()
+        if not roots:
+            self._last_analysis_epoch = time.time()
+            self._cycles_total += 1
+            print("neo observer cycle ok: 0 projects discovered", flush=True)
+            return
+
+        budget = max(1, int(self.config.max_projects_per_cycle))
+        start = self._sweep_offset % len(roots)
+        batch = (roots[start:] + roots[:start])[:budget]
+        self._sweep_offset = (start + len(batch)) % len(roots)
+
+        total_synth = total_mined = errors = covered = 0
+        for root in batch:
+            if self._stop:
+                break
+            try:
+                count, mined, _store = self._run_project(root)
+                total_synth += count
+                total_mined += mined
+                covered += 1
+            except Exception as e:
+                errors += 1
+                print(
+                    f"neo observer project error [{root}]: {type(e).__name__}: {e}",
+                    file=sys.stderr, flush=True,
+                )
+
+        tick = time.time() - t0
+        self._last_analysis_epoch = time.time()
+        self._cycles_total += 1
+        self._last_cycle_count = total_synth
+        self._last_cycle_error = None
+        summary = (
+            f"swept {covered}/{len(roots)} projects: {total_synth} synthesized, "
+            f"{total_mined} mined" + (f", {errors} errors" if errors else "")
+        )
+        self._recent_cycles.append({
+            "timestamp": self._last_analysis_epoch,
+            "text": f"{time.strftime('%H:%M:%S', time.localtime(self._last_analysis_epoch))} · {summary}",
+        })
+        print(f"neo observer cycle ok: {summary} ({tick:.1f}s)", flush=True)
+
+    def _ingest_transcripts(self, store, root: str) -> int:
         """Mine Claude Code transcripts for lessons, bounded by the per-cycle
         episode budget AND a wall-clock deadline. Isolated in its own
         try/except so an LM or transcript failure never aborts the synthesis
@@ -360,7 +454,7 @@ class Observer:
             cfg = NeoConfig.load()
             adapter = resolve_adapter(cfg)
             ingester = TranscriptIngester(
-                store=store, lm_adapter=adapter, codebase_root=self.codebase_root
+                store=store, lm_adapter=adapter, codebase_root=root
             )
             stats = ingester.ingest(
                 max_episodes=self.config.ingest_budget,
@@ -501,133 +595,149 @@ def _find_managed_agent(car, agent_id: str) -> Optional[dict]:
     return None
 
 
-def start_observer(codebase_root: Optional[str] = None) -> dict:
-    """Register the spec and start the supervised child.
+def _build_global_spec() -> dict:
+    """Spec for the single global observer that sweeps all projects."""
+    return {
+        "id": GLOBAL_AGENT_ID,
+        "name": "Neo observer (all projects)",
+        "command": sys.executable,
+        "args": ["-m", "neo.memory.observer", "--daemon", "--all"],
+        "cwd": os.path.expanduser("~"),
+        "env": {
+            k: os.environ[k]
+            for k in (
+                "NEO_OBSERVER_INTERVAL_SECONDS",
+                "NEO_OBSERVER_COOLDOWN",
+                "NEO_PROFILE",
+                "NEO_METRICS",
+            )
+            if k in os.environ
+        },
+        "restart": "on_failure",
+        "max_restarts": 10,
+        "backoff_secs": 5,
+        "auto_start": True,
+    }
 
-    Returns: ``{"status": "started"|"already_running"|"error", ...}``.
+
+def _migrate_legacy_per_project_agents(car) -> list[str]:
+    """Stop + remove legacy per-project observer agents (``neo-observer-<id>``).
+
+    The single global observer replaces them. Best-effort; returns removed ids.
     """
-    project_id = _resolve_project_id(codebase_root)
-    if not project_id:
-        return {"status": "error", "project_id": "",
-                "message": "No project_id (run from a git repo or pass --cwd)"}
+    removed: list[str] = []
+    try:
+        managed = json.loads(car.agents_list())
+    except Exception as e:
+        logger.debug("agents_list failed during migration: %s", e)
+        return removed
+    for m in managed:
+        aid = m.get("id", "")
+        if aid == GLOBAL_AGENT_ID or not _LEGACY_AGENT_RE.match(aid):
+            continue
+        try:
+            car.agents_stop(aid)
+        except Exception:
+            pass
+        try:
+            car.agents_remove(aid)
+            removed.append(aid)
+        except Exception as e:
+            logger.debug("agents_remove(%s) failed: %s", aid, e)
+    return removed
 
+
+def start_observer(codebase_root: Optional[str] = None) -> dict:
+    """Register + start the single global observer (migrating legacy agents).
+
+    ``codebase_root`` is accepted for CLI compatibility but ignored — the
+    observer is global, not per-project.
+    """
     try:
         car = _require_car_runtime()
     except RuntimeError as e:
-        return {"status": "error", "project_id": project_id, "message": str(e)}
+        return {"status": "error", "message": str(e)}
 
-    aid = _agent_id(project_id)
-    spec = _build_spec(project_id, codebase_root or os.getcwd())
-
+    migrated = _migrate_legacy_per_project_agents(car)
     try:
-        car.agents_upsert(json.dumps(spec))
+        car.agents_upsert(json.dumps(_build_global_spec()))
     except Exception as e:
-        return {"status": "error", "project_id": project_id,
-                "message": f"agents_upsert failed: {e}"}
+        return {"status": "error", "message": f"agents_upsert failed: {e}"}
 
-    existing = _find_managed_agent(car, aid)
+    existing = _find_managed_agent(car, GLOBAL_AGENT_ID)
     if existing and existing.get("status") == "running":
-        return {"status": "already_running", "project_id": project_id,
-                "agent_id": aid, "pid": existing.get("pid"),
+        return {"status": "already_running", "agent_id": GLOBAL_AGENT_ID,
+                "pid": existing.get("pid"), "migrated": migrated,
                 "message": f"observer pid {existing.get('pid')}"}
 
     try:
-        managed_json = car.agents_start(aid)
-        managed = json.loads(managed_json)
+        managed = json.loads(car.agents_start(GLOBAL_AGENT_ID))
     except Exception as e:
-        return {"status": "error", "project_id": project_id,
-                "message": f"agents_start failed: {e}"}
+        return {"status": "error", "message": f"agents_start failed: {e}"}
 
     return {
         "status": "started",
-        "project_id": project_id,
-        "agent_id": aid,
+        "agent_id": GLOBAL_AGENT_ID,
         "pid": managed.get("pid"),
-        "message": (
-            f"observer pid {managed.get('pid')}, "
-            f"log ~/.car/logs/{aid}.stdout.log"
-        ),
+        "migrated": migrated,
+        "message": f"observer pid {managed.get('pid')}, log ~/.car/logs/{GLOBAL_AGENT_ID}.stdout.log",
     }
 
 
 def stop_observer(codebase_root: Optional[str] = None) -> dict:
-    project_id = _resolve_project_id(codebase_root)
-    if not project_id:
-        return {"status": "error", "message": "No project_id"}
-
     try:
         car = _require_car_runtime()
     except RuntimeError as e:
-        return {"status": "error", "project_id": project_id, "message": str(e)}
+        return {"status": "error", "message": str(e)}
 
-    aid = _agent_id(project_id)
-    existing = _find_managed_agent(car, aid)
+    existing = _find_managed_agent(car, GLOBAL_AGENT_ID)
     if not existing:
-        return {"status": "not_running", "project_id": project_id, "agent_id": aid,
+        return {"status": "not_running", "agent_id": GLOBAL_AGENT_ID,
                 "message": "no managed agent registered"}
     if existing.get("status") != "running":
-        return {"status": "not_running", "project_id": project_id, "agent_id": aid,
+        return {"status": "not_running", "agent_id": GLOBAL_AGENT_ID,
                 "pid": existing.get("pid"),
                 "message": f"agent {existing.get('status', 'unknown')}"}
 
     try:
-        managed_json = car.agents_stop(aid)
-        managed = json.loads(managed_json)
+        managed = json.loads(car.agents_stop(GLOBAL_AGENT_ID))
     except Exception as e:
-        return {"status": "error", "project_id": project_id,
-                "message": f"agents_stop failed: {e}"}
+        return {"status": "error", "message": f"agents_stop failed: {e}"}
 
-    return {"status": "stopped", "project_id": project_id, "agent_id": aid,
+    return {"status": "stopped", "agent_id": GLOBAL_AGENT_ID,
             "pid": managed.get("pid"),
             "message": f"SIGTERM sent to pid {managed.get('pid')}"}
 
 
 def kick_observer(codebase_root: Optional[str] = None) -> dict:
-    """Force an early cycle by restarting the child.
+    """Force an early sweep by restarting the global observer.
 
-    CAR's supervisor has no SIGUSR1 / signal-passthrough primitive, so
-    kick maps to ``agents_restart`` — stop, then start. The new
-    process runs its first cycle immediately (modulo cooldown, which
-    is per-process and so resets on restart).
+    CAR's supervisor has no SIGUSR1 / signal-passthrough primitive, so kick maps
+    to ``agents_restart``. The new process runs its first sweep immediately.
     """
-    project_id = _resolve_project_id(codebase_root)
-    if not project_id:
-        return {"status": "error", "message": "No project_id"}
-
     try:
         car = _require_car_runtime()
     except RuntimeError as e:
-        return {"status": "error", "project_id": project_id, "message": str(e)}
+        return {"status": "error", "message": str(e)}
 
-    aid = _agent_id(project_id)
-    existing = _find_managed_agent(car, aid)
+    existing = _find_managed_agent(car, GLOBAL_AGENT_ID)
     if not existing:
-        return {"status": "not_running", "project_id": project_id, "agent_id": aid,
+        return {"status": "not_running", "agent_id": GLOBAL_AGENT_ID,
                 "message": "no managed agent registered"}
 
     try:
-        managed_json = car.agents_restart(aid)
-        managed = json.loads(managed_json)
+        managed = json.loads(car.agents_restart(GLOBAL_AGENT_ID))
     except Exception as e:
-        return {"status": "error", "project_id": project_id,
-                "message": f"agents_restart failed: {e}"}
+        return {"status": "error", "message": f"agents_restart failed: {e}"}
 
-    return {"status": "kicked", "project_id": project_id, "agent_id": aid,
+    return {"status": "kicked", "agent_id": GLOBAL_AGENT_ID,
             "pid": managed.get("pid"),
             "message": f"restarted as pid {managed.get('pid')}"}
 
 
-def _cmd_is_our_observer(cmd: str, root: str) -> bool:
-    """True if a command line is an observer daemon for this project's root."""
-    if "neo.memory.observer" not in cmd or "--daemon" not in cmd:
-        return False
-    m = re.search(r"--cwd[\s=]+(\S+)", cmd)
-    if not m:
-        return False
-    try:
-        return os.path.realpath(m.group(1).strip('"\'')) == root
-    except OSError:
-        return False
+def _cmd_is_our_observer(cmd: str) -> bool:
+    """True if a command line is a neo observer daemon (global or legacy)."""
+    return "neo.memory.observer" in cmd and "--daemon" in cmd
 
 
 def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
@@ -643,22 +753,22 @@ def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
       live process, which ``psutil`` reports as ``parent() is None``.
 
     Prefers ``psutil`` (works on macOS/Linux/Windows); falls back to ``ps`` on
-    POSIX when ``psutil`` is absent. Scoped to this project by the daemon's
-    ``--cwd`` (realpath-compared). Best-effort: returns ``[]`` on any
-    platform/parse/permission failure so it can never break ``status``.
+    POSIX when ``psutil`` is absent. With the single global observer there is at
+    most one supervised daemon, so any neo observer daemon with no live parent —
+    a stale per-project legacy daemon, or one stranded by a dead car-server — is
+    an orphan. Best-effort: returns ``[]`` on any failure so it never breaks
+    ``status``.
     """
-    root = os.path.realpath(codebase_root or os.getcwd())
-
     try:
         import psutil
     except ImportError:
-        return _find_orphan_observers_ps(root)
+        return _find_orphan_observers_ps()
 
     orphans: list[int] = []
     for proc in psutil.process_iter(["pid", "ppid", "cmdline"]):
         try:
             cmd = " ".join(proc.info.get("cmdline") or [])
-            if not _cmd_is_our_observer(cmd, root):
+            if not _cmd_is_our_observer(cmd):
                 continue
             try:
                 parent_alive = proc.parent() is not None
@@ -673,7 +783,7 @@ def _find_orphan_observers(codebase_root: Optional[str] = None) -> list[int]:
     return sorted(orphans)
 
 
-def _find_orphan_observers_ps(root: str) -> list[int]:
+def _find_orphan_observers_ps() -> list[int]:
     """POSIX ``ps`` fallback for orphan detection (used when psutil is absent)."""
     try:
         out = subprocess.run(
@@ -691,7 +801,7 @@ def _find_orphan_observers_ps(root: str) -> list[int]:
         pid_s, ppid_s, cmd = fields
         if ppid_s != "1":  # supervised processes are parented by car-server, not init
             continue
-        if not _cmd_is_our_observer(cmd, root):
+        if not _cmd_is_our_observer(cmd):
             continue
         try:
             orphans.append(int(pid_s))
@@ -701,22 +811,16 @@ def _find_orphan_observers_ps(root: str) -> list[int]:
 
 
 def observer_status(codebase_root: Optional[str] = None) -> dict:
-    project_id = _resolve_project_id(codebase_root)
-    if not project_id:
-        return {"status": "error", "message": "No project_id"}
-
-    orphans = _find_orphan_observers(codebase_root)
+    orphans = _find_orphan_observers()
 
     try:
         car = _require_car_runtime()
     except RuntimeError as e:
-        return {"status": "error", "project_id": project_id,
-                "message": str(e), "orphans": orphans}
+        return {"status": "error", "message": str(e), "orphans": orphans}
 
-    aid = _agent_id(project_id)
-    existing = _find_managed_agent(car, aid)
+    existing = _find_managed_agent(car, GLOBAL_AGENT_ID)
     if not existing:
-        return {"status": "not_running", "project_id": project_id, "agent_id": aid,
+        return {"status": "not_running", "agent_id": GLOBAL_AGENT_ID,
                 "message": "no managed agent registered", "orphans": orphans}
 
     # CAR's `status` field is one of: stopped | starting | running |
@@ -726,12 +830,11 @@ def observer_status(codebase_root: Optional[str] = None) -> dict:
     is_running = car_status == "running"
     return {
         "status": car_status,
-        "project_id": project_id,
-        "agent_id": aid,
+        "agent_id": GLOBAL_AGENT_ID,
         "pid": existing.get("pid") if is_running else None,
         "restart_count": existing.get("restart_count", 0),
         "last_exit_code": existing.get("last_exit_code"),
-        "log_file": f"~/.car/logs/{aid}.stdout.log",
+        "log_file": f"~/.car/logs/{GLOBAL_AGENT_ID}.stdout.log",
         "orphans": orphans,
         "message": (
             f"observer pid {existing.get('pid')} "
@@ -744,8 +847,70 @@ def observer_status(codebase_root: Optional[str] = None) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Daemon entrypoint — `python -m neo.memory.observer --daemon --cwd <path>`
-# Invoked by CAR's supervisor via the spec from ``_build_spec``.
+# Auto-bootstrap — neo registers the single global observer when CAR is present,
+# so users never opt in per project. Opt out with NEO_OBSERVER_AUTOSTART=0.
+# ---------------------------------------------------------------------------
+
+_CAR_HINT_FLAG = os.path.expanduser("~/.neo/.car_observer_hint_shown")
+
+
+def _car_server_reachable(host: str = "127.0.0.1", port: int = 9100,
+                          timeout: float = 0.3) -> bool:
+    import socket
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _maybe_print_car_hint() -> None:
+    """One-time quiet hint that CAR enables continuous background observation."""
+    try:
+        if os.path.exists(_CAR_HINT_FLAG):
+            return
+        os.makedirs(os.path.dirname(_CAR_HINT_FLAG), exist_ok=True)
+        with open(_CAR_HINT_FLAG, "w", encoding="utf-8") as f:
+            f.write("shown\n")
+    except OSError:
+        return  # can't track -> stay silent rather than nag every run
+    print(
+        "[Neo] tip: install the `car` extra and run car-server to enable "
+        "continuous background memory observation across your projects.",
+        file=sys.stderr,
+    )
+
+
+def maybe_autostart_observer() -> None:
+    """Register + start the single global observer when CAR is present.
+
+    Called once per neo CLI run. No-op (with a one-time hint) when CAR is absent;
+    opt out with ``NEO_OBSERVER_AUTOSTART=0``. Never raises — must not break a
+    neo command for any reason.
+    """
+    try:
+        if os.getenv("NEO_OBSERVER_AUTOSTART", "").strip() == "0":
+            return
+        if not _car_server_reachable():
+            _maybe_print_car_hint()
+            return
+        try:
+            car = _require_car_runtime()
+        except RuntimeError:
+            return
+        if _find_managed_agent(car, GLOBAL_AGENT_ID) is not None:
+            return  # already registered; the supervisor owns its lifecycle
+        _migrate_legacy_per_project_agents(car)
+        car.agents_upsert(json.dumps(_build_global_spec()))
+        car.agents_start(GLOBAL_AGENT_ID)
+        logger.debug("auto-started global observer")
+    except Exception as e:  # never break the CLI
+        logger.debug("observer autostart skipped: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Daemon entrypoint — `python -m neo.memory.observer --daemon --all`
+# (legacy `--cwd <path>` runs a single project). Invoked by CAR's supervisor.
 # ---------------------------------------------------------------------------
 
 
@@ -755,11 +920,18 @@ def _daemon_main(argv: list[str]) -> int:
     p = argparse.ArgumentParser(prog="neo.memory.observer")
     p.add_argument("--daemon", action="store_true", required=True,
                    help="(internal) marks this as the daemon entrypoint")
-    p.add_argument("--cwd", required=True, help="codebase root for project resolution")
+    p.add_argument("--all", action="store_true",
+                   help="sweep all discovered projects (global observer)")
+    p.add_argument("--cwd", help="single-project mode: codebase root")
     args = p.parse_args(argv)
 
+    if not args.all and not args.cwd:
+        print("observer requires --all or --cwd", file=sys.stderr)
+        return 2
+
     try:
-        observer = Observer(codebase_root=args.cwd)
+        observer = (Observer(global_mode=True) if args.all
+                    else Observer(codebase_root=args.cwd))
     except RuntimeError as e:
         print(f"observer init failed: {e}", file=sys.stderr)
         return 1

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -37,6 +37,7 @@ def fake_car(monkeypatch):
         agents_start=MagicMock(),
         agents_stop=MagicMock(),
         agents_restart=MagicMock(),
+        agents_remove=MagicMock(),
         agents_list=MagicMock(return_value="[]"),
         # Sentinel attr that _require_car_runtime checks for to gate
         # the version requirement.
@@ -118,41 +119,48 @@ def _install_fake_psutil(monkeypatch, procs):
     return fake
 
 
-def _obs_cmd(root):
+def _global_cmd():
+    return ["/usr/bin/python", "-m", "neo.memory.observer", "--daemon", "--all"]
+
+
+def _legacy_cmd(root="/some/proj"):
     return ["/usr/bin/python", "-m", "neo.memory.observer", "--daemon", "--cwd", root]
 
 
 class TestOrphanDetectionPsutil:
-    """Cross-platform path (psutil): POSIX ppid==1 AND Windows parent-gone."""
+    """Cross-platform path (psutil): POSIX ppid==1 AND Windows parent-gone.
 
-    def test_posix_orphan_ppid1(self, monkeypatch, tmp_path):
-        root = str(tmp_path)
-        _install_fake_psutil(monkeypatch, [_FakeProc(100, 1, _obs_cmd(root), parent_alive=True)])
+    Global model: any neo observer daemon (global ``--all`` or legacy ``--cwd``)
+    with no live parent is an orphan, regardless of project.
+    """
+
+    def test_posix_orphan_ppid1(self, monkeypatch):
+        _install_fake_psutil(monkeypatch, [_FakeProc(100, 1, _global_cmd(), parent_alive=True)])
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == [100]
+        assert _find_orphan_observers() == [100]
 
-    def test_windows_orphan_parent_gone(self, monkeypatch, tmp_path):
+    def test_windows_orphan_parent_gone(self, monkeypatch):
         # No ppid==1 reparenting on Windows; the launching car-server is just gone.
-        root = str(tmp_path)
-        _install_fake_psutil(monkeypatch, [_FakeProc(200, 4321, _obs_cmd(root), parent_alive=False)])
+        _install_fake_psutil(monkeypatch, [_FakeProc(200, 4321, _global_cmd(), parent_alive=False)])
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == [200]
+        assert _find_orphan_observers() == [200]
 
-    def test_supervised_not_flagged(self, monkeypatch, tmp_path):
-        root = str(tmp_path)
-        _install_fake_psutil(monkeypatch, [_FakeProc(300, 20656, _obs_cmd(root), parent_alive=True)])
+    def test_supervised_not_flagged(self, monkeypatch):
+        _install_fake_psutil(monkeypatch, [_FakeProc(300, 20656, _global_cmd(), parent_alive=True)])
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == []
+        assert _find_orphan_observers() == []
 
-    def test_ignores_other_project_and_nonobserver(self, monkeypatch, tmp_path):
-        root = str(tmp_path)
-        procs = [
-            _FakeProc(1, 1, _obs_cmd("/some/other/project"), parent_alive=False),
-            _FakeProc(2, 1, ["/usr/bin/python", "-m", "http.server"], parent_alive=False),
-        ]
+    def test_legacy_per_project_daemon_is_orphan(self, monkeypatch):
+        # A stranded legacy --cwd daemon (any project) with no live parent counts.
+        _install_fake_psutil(monkeypatch, [_FakeProc(150, 1, _legacy_cmd("/old/proj"), parent_alive=False)])
+        from neo.memory.observer import _find_orphan_observers
+        assert _find_orphan_observers() == [150]
+
+    def test_non_observer_ignored(self, monkeypatch):
+        procs = [_FakeProc(2, 1, ["/usr/bin/python", "-m", "http.server"], parent_alive=False)]
         _install_fake_psutil(monkeypatch, procs)
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == []
+        assert _find_orphan_observers() == []
 
 
 class TestOrphanDetectionPs:
@@ -166,25 +174,23 @@ class TestOrphanDetectionPs:
             lambda *a, **k: types.SimpleNamespace(stdout=text),
         )
 
-    def test_finds_launchd_orphan_for_this_root(self, monkeypatch, tmp_path):
-        root = str(tmp_path)
+    def test_finds_all_unsupervised_observer_daemons(self, monkeypatch):
         text = (
-            f"100     1 /usr/bin/python -m neo.memory.observer --daemon --cwd {root}\n"       # orphan
-            f"200 20656 /usr/bin/python -m neo.memory.observer --daemon --cwd {root}\n"       # supervised
-            f"300     1 /usr/bin/python -m neo.memory.observer --daemon --cwd /other/proj\n"  # other project
-            f"400     1 /usr/bin/python -m http.server\n"                                     # not observer
+            "100     1 /usr/bin/python -m neo.memory.observer --daemon --all\n"               # global orphan
+            "150     1 /usr/bin/python -m neo.memory.observer --daemon --cwd /old/proj\n"      # legacy orphan
+            "200 20656 /usr/bin/python -m neo.memory.observer --daemon --all\n"               # supervised
+            "400     1 /usr/bin/python -m http.server\n"                                       # not observer
         )
         self._fake_ps(monkeypatch, text)
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == [100]
+        assert _find_orphan_observers() == [100, 150]
 
-    def test_no_orphan_when_only_supervised(self, monkeypatch, tmp_path):
-        root = str(tmp_path)
-        self._fake_ps(monkeypatch, f"200 20656 python -m neo.memory.observer --daemon --cwd {root}\n")
+    def test_no_orphan_when_only_supervised(self, monkeypatch):
+        self._fake_ps(monkeypatch, "200 20656 python -m neo.memory.observer --daemon --all\n")
         from neo.memory.observer import _find_orphan_observers
-        assert _find_orphan_observers(root) == []
+        assert _find_orphan_observers() == []
 
-    def test_ps_failure_is_safe(self, monkeypatch, tmp_path):
+    def test_ps_failure_is_safe(self, monkeypatch):
         import neo.memory.observer as obs
         monkeypatch.setitem(sys.modules, "psutil", None)
 
@@ -192,49 +198,43 @@ class TestOrphanDetectionPs:
             raise OSError("no ps here")
 
         monkeypatch.setattr(obs.subprocess, "run", boom)
-        assert obs._find_orphan_observers(str(tmp_path)) == []
+        assert obs._find_orphan_observers() == []
 
 
 class TestOrphanStatus:
     def test_status_includes_orphans(self, monkeypatch):
         import neo.memory.observer as obs
-        monkeypatch.setattr(obs, "_resolve_project_id", lambda root: "abc123def456")
         monkeypatch.setattr(obs, "_require_car_runtime", lambda: object())
         monkeypatch.setattr(
             obs, "_find_managed_agent",
             lambda car, aid: {"status": "running", "pid": 555, "restart_count": 0},
         )
-        monkeypatch.setattr(obs, "_find_orphan_observers", lambda root: [777])
-        st = obs.observer_status("/repo")
+        monkeypatch.setattr(obs, "_find_orphan_observers", lambda *a: [777])
+        st = obs.observer_status()
         assert st["status"] == "running"
+        assert st["agent_id"] == obs.GLOBAL_AGENT_ID
         assert st["orphans"] == [777]
 
 
-class TestSpecBuilding:
-    def test_spec_uses_current_python(self, fake_project_id):
-        from neo.memory.observer import _build_spec
-        spec = _build_spec(fake_project_id, "/repo/root")
+class TestGlobalSpec:
+    def test_spec_is_global_all_projects(self):
+        from neo.memory.observer import GLOBAL_AGENT_ID, _build_global_spec
+        spec = _build_global_spec()
+        assert spec["id"] == GLOBAL_AGENT_ID == "neo-observer"
         assert spec["command"] == sys.executable
-        assert spec["args"] == ["-m", "neo.memory.observer", "--daemon",
-                                "--cwd", "/repo/root"]
-        assert spec["cwd"] == "/repo/root"
+        assert spec["args"] == ["-m", "neo.memory.observer", "--daemon", "--all"]
         assert spec["restart"] == "on_failure"
         assert spec["auto_start"] is True
-
-    def test_spec_id_is_filename_safe(self, fake_project_id):
-        from neo.memory.observer import _agent_id, _build_spec
-        spec = _build_spec(fake_project_id, "/r")
-        # Filename-safe: alphanumerics + hyphens only
-        assert spec["id"] == _agent_id(fake_project_id)
+        # Filename-safe id
         for ch in spec["id"]:
             assert ch.isalnum() or ch in "-_"
 
-    def test_spec_forwards_only_neo_env(self, fake_project_id, monkeypatch):
+    def test_spec_forwards_only_neo_env(self, monkeypatch):
         monkeypatch.setenv("NEO_OBSERVER_INTERVAL_SECONDS", "30")
         monkeypatch.setenv("NEO_PROFILE", "minimal")
         monkeypatch.setenv("USER_SECRET", "hunter2")
-        from neo.memory.observer import _build_spec
-        spec = _build_spec(fake_project_id, "/r")
+        from neo.memory.observer import _build_global_spec
+        spec = _build_global_spec()
         assert spec["env"]["NEO_OBSERVER_INTERVAL_SECONDS"] == "30"
         assert spec["env"]["NEO_PROFILE"] == "minimal"
         assert "USER_SECRET" not in spec["env"]
@@ -268,167 +268,251 @@ class TestObserverConfig:
         assert cfg.interval_seconds == 300.0
         assert cfg.cooldown_seconds == 60.0
 
-    def test_zero_budget_is_defensive_noop(self):
+    def test_zero_budget_is_defensive_noop(self, fake_project_id):
         # Not a feature toggle (budget is a committed constant) — just a guard
         # so a 0 can't waste an adapter build.
         from neo.memory.observer import Observer, ObserverConfig
         obs = Observer(codebase_root="/tmp/x", config=ObserverConfig(ingest_budget=0))
-        assert obs._ingest_transcripts(store=None) == 0
+        assert obs._ingest_transcripts(store=None, root="/tmp/x") == 0
 
-    def test_ingest_transcripts_swallows_errors(self, monkeypatch):
+    def test_ingest_transcripts_swallows_errors(self, monkeypatch, fake_project_id):
         # Force an error inside the ingest path; the cycle must not crash.
         from neo.memory.observer import Observer, ObserverConfig
         monkeypatch.setattr("neo.config.NeoConfig.load",
                             staticmethod(lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))))
         obs = Observer(codebase_root="/tmp/x", config=ObserverConfig(ingest_budget=5))
-        assert obs._ingest_transcripts(store=None) == 0
+        assert obs._ingest_transcripts(store=None, root="/tmp/x") == 0
 
 
 class TestStartObserver:
-    def test_start_with_no_project_id_returns_error(self, fake_car, monkeypatch):
-        monkeypatch.setattr(
-            "neo.memory.observer.detect_org_and_project",
-            lambda _root: ("unknown", ""),
-        )
+    def test_start_no_car_returns_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "car_runtime", None)  # ImportError
         from neo.memory.observer import start_observer
-        result = start_observer("/nowhere")
-        assert result["status"] == "error"
-        # Did NOT touch CAR if project_id resolution failed
-        fake_car.agents_upsert.assert_not_called()
+        assert start_observer()["status"] == "error"
 
-    def test_start_calls_upsert_then_start(self, fake_project_id, fake_car):
+    def test_start_upserts_global_spec_then_starts(self, fake_car):
         fake_car.agents_list.return_value = "[]"
-        fake_car.agents_start.return_value = json.dumps({"id": "x", "pid": 9001})
-
-        from neo.memory.observer import start_observer
-        result = start_observer("/some/path")
-
+        fake_car.agents_start.return_value = json.dumps({"id": "neo-observer", "pid": 9001})
+        from neo.memory.observer import GLOBAL_AGENT_ID, start_observer
+        result = start_observer()
         assert result["status"] == "started"
         assert result["pid"] == 9001
         fake_car.agents_upsert.assert_called_once()
-        fake_car.agents_start.assert_called_once()
-        # The spec passed to agents_upsert must be valid JSON with our fields
-        spec_arg = fake_car.agents_upsert.call_args[0][0]
-        spec = json.loads(spec_arg)
-        assert spec["id"].startswith("neo-observer-")
+        fake_car.agents_start.assert_called_once_with(GLOBAL_AGENT_ID)
+        spec = json.loads(fake_car.agents_upsert.call_args[0][0])
+        assert spec["id"] == GLOBAL_AGENT_ID
+        assert spec["args"][-1] == "--all"
         assert spec["restart"] == "on_failure"
 
-    def test_start_when_already_running(self, fake_project_id, fake_car):
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_start_migrates_legacy_per_project_agents(self, fake_car):
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": 1234, "status": "running"}]
+            [{"id": "neo-observer-abc123def456", "status": "running"}]
         )
-
+        fake_car.agents_start.return_value = json.dumps({"id": "neo-observer", "pid": 1})
         from neo.memory.observer import start_observer
-        result = start_observer("/some/path")
+        result = start_observer()
+        assert "neo-observer-abc123def456" in result["migrated"]
+        fake_car.agents_remove.assert_any_call("neo-observer-abc123def456")
+
+    def test_start_when_already_running(self, fake_car):
+        fake_car.agents_list.return_value = json.dumps(
+            [{"id": "neo-observer", "pid": 1234, "status": "running"}]
+        )
+        from neo.memory.observer import start_observer
+        result = start_observer()
         assert result["status"] == "already_running"
         assert result["pid"] == 1234
-        # Spec gets upserted (idempotent); but start is NOT called when already running
         fake_car.agents_start.assert_not_called()
 
 
 class TestStopObserver:
-    def test_stop_when_not_registered(self, fake_project_id, fake_car):
+    def test_stop_when_not_registered(self, fake_car):
         fake_car.agents_list.return_value = "[]"
         from neo.memory.observer import stop_observer
-        result = stop_observer("/some/path")
-        assert result["status"] == "not_running"
+        assert stop_observer()["status"] == "not_running"
         fake_car.agents_stop.assert_not_called()
 
-    def test_stop_when_running(self, fake_project_id, fake_car):
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_stop_when_running(self, fake_car):
+        from neo.memory.observer import GLOBAL_AGENT_ID, stop_observer
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": 9001, "status": "running"}]
+            [{"id": GLOBAL_AGENT_ID, "pid": 9001, "status": "running"}]
         )
-        fake_car.agents_stop.return_value = json.dumps({"id": aid, "pid": 9001})
-
-        from neo.memory.observer import stop_observer
-        result = stop_observer("/some/path")
+        fake_car.agents_stop.return_value = json.dumps({"id": GLOBAL_AGENT_ID, "pid": 9001})
+        result = stop_observer()
         assert result["status"] == "stopped"
-        fake_car.agents_stop.assert_called_once_with(aid)
+        fake_car.agents_stop.assert_called_once_with(GLOBAL_AGENT_ID)
 
-    def test_stop_when_already_stopped(self, fake_project_id, fake_car):
-        """Spec exists but `status` says stopped — should NOT call agents_stop."""
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_stop_when_already_stopped(self, fake_car):
+        from neo.memory.observer import GLOBAL_AGENT_ID, stop_observer
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": None, "status": "stopped"}]
+            [{"id": GLOBAL_AGENT_ID, "pid": None, "status": "stopped"}]
         )
-        from neo.memory.observer import stop_observer
-        result = stop_observer("/some/path")
-        assert result["status"] == "not_running"
+        assert stop_observer()["status"] == "not_running"
         fake_car.agents_stop.assert_not_called()
 
 
 class TestKickObserver:
-    def test_kick_when_not_registered(self, fake_project_id, fake_car):
+    def test_kick_when_not_registered(self, fake_car):
         fake_car.agents_list.return_value = "[]"
         from neo.memory.observer import kick_observer
-        result = kick_observer("/some/path")
-        assert result["status"] == "not_running"
+        assert kick_observer()["status"] == "not_running"
         fake_car.agents_restart.assert_not_called()
 
-    def test_kick_maps_to_restart(self, fake_project_id, fake_car):
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_kick_maps_to_restart(self, fake_car):
+        from neo.memory.observer import GLOBAL_AGENT_ID, kick_observer
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": 1, "status": "running"}]
+            [{"id": GLOBAL_AGENT_ID, "pid": 1, "status": "running"}]
         )
-        fake_car.agents_restart.return_value = json.dumps({"id": aid, "pid": 2})
-
-        from neo.memory.observer import kick_observer
-        result = kick_observer("/some/path")
+        fake_car.agents_restart.return_value = json.dumps({"id": GLOBAL_AGENT_ID, "pid": 2})
+        result = kick_observer()
         assert result["status"] == "kicked"
         assert result["pid"] == 2
-        fake_car.agents_restart.assert_called_once_with(aid)
+        fake_car.agents_restart.assert_called_once_with(GLOBAL_AGENT_ID)
 
 
 class TestObserverStatus:
-    def test_status_when_not_registered(self, fake_project_id, fake_car):
+    def test_status_when_not_registered(self, fake_car):
         fake_car.agents_list.return_value = "[]"
         from neo.memory.observer import observer_status
-        result = observer_status("/some/path")
-        assert result["status"] == "not_running"
+        assert observer_status()["status"] == "not_running"
 
-    def test_status_when_running(self, fake_project_id, fake_car):
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_status_when_running(self, fake_car):
+        from neo.memory.observer import GLOBAL_AGENT_ID, observer_status
         fake_car.agents_list.return_value = json.dumps([{
-            "id": aid, "pid": 12345, "status": "running", "restart_count": 2,
+            "id": GLOBAL_AGENT_ID, "pid": 12345, "status": "running", "restart_count": 2,
         }])
-        from neo.memory.observer import observer_status
-        result = observer_status("/some/path")
+        result = observer_status()
         assert result["status"] == "running"
         assert result["pid"] == 12345
         assert result["restart_count"] == 2
 
-    def test_status_when_registered_but_stopped(self, fake_project_id, fake_car):
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+    def test_status_when_registered_but_stopped(self, fake_car):
+        from neo.memory.observer import GLOBAL_AGENT_ID, observer_status
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": None, "status": "stopped", "restart_count": 0,
-              "last_exit_code": 0}]
+            [{"id": GLOBAL_AGENT_ID, "pid": None, "status": "stopped",
+              "restart_count": 0, "last_exit_code": 0}]
         )
-        from neo.memory.observer import observer_status
-        result = observer_status("/some/path")
-        # We now surface CAR's raw status verbatim (running|stopped|backoff|...)
+        result = observer_status()
         assert result["status"] == "stopped"
         assert result["pid"] is None
 
-    def test_status_when_in_backoff(self, fake_project_id, fake_car):
+    def test_status_when_in_backoff(self, fake_car):
         """`backoff` is a valid CAR status — restart-loop diagnosis."""
-        from neo.memory.observer import _agent_id
-        aid = _agent_id(fake_project_id)
+        from neo.memory.observer import GLOBAL_AGENT_ID, observer_status
         fake_car.agents_list.return_value = json.dumps(
-            [{"id": aid, "pid": None, "status": "backoff", "restart_count": 7,
-              "last_exit_code": 1}]
+            [{"id": GLOBAL_AGENT_ID, "pid": None, "status": "backoff",
+              "restart_count": 7, "last_exit_code": 1}]
         )
-        from neo.memory.observer import observer_status
-        result = observer_status("/some/path")
+        result = observer_status()
         assert result["status"] == "backoff"
         assert result["restart_count"] == 7
+
+
+class TestMigration:
+    def test_removes_legacy_keeps_global_and_others(self, fake_car):
+        fake_car.agents_list.return_value = json.dumps([
+            {"id": "neo-observer", "status": "running"},             # global, keep
+            {"id": "neo-observer-deadbeef0011", "status": "running"},  # legacy, remove
+            {"id": "proactive-teammate", "status": "running"},       # unrelated, keep
+        ])
+        from neo.memory.observer import _migrate_legacy_per_project_agents
+        removed = _migrate_legacy_per_project_agents(fake_car)
+        assert removed == ["neo-observer-deadbeef0011"]
+        fake_car.agents_remove.assert_called_once_with("neo-observer-deadbeef0011")
+
+
+class TestAutostart:
+    def test_opt_out_env(self, monkeypatch, fake_car):
+        monkeypatch.setenv("NEO_OBSERVER_AUTOSTART", "0")
+        from neo.memory.observer import maybe_autostart_observer
+        maybe_autostart_observer()
+        fake_car.agents_upsert.assert_not_called()
+
+    def test_no_car_writes_hint_once(self, monkeypatch, tmp_path):
+        import neo.memory.observer as obs
+        monkeypatch.setenv("NEO_OBSERVER_AUTOSTART", "")
+        monkeypatch.setattr(obs, "_car_server_reachable", lambda **k: False)
+        monkeypatch.setattr(obs, "_CAR_HINT_FLAG", str(tmp_path / "hint"))
+        obs.maybe_autostart_observer()
+        obs.maybe_autostart_observer()  # idempotent
+        assert (tmp_path / "hint").exists()
+
+    def test_registers_when_car_present_and_unregistered(self, monkeypatch, fake_car):
+        import neo.memory.observer as obs
+        monkeypatch.setenv("NEO_OBSERVER_AUTOSTART", "")
+        monkeypatch.setattr(obs, "_car_server_reachable", lambda **k: True)
+        fake_car.agents_list.return_value = "[]"
+        obs.maybe_autostart_observer()
+        fake_car.agents_upsert.assert_called_once()
+        fake_car.agents_start.assert_called_once_with(obs.GLOBAL_AGENT_ID)
+
+    def test_noop_when_already_registered(self, monkeypatch, fake_car):
+        import neo.memory.observer as obs
+        monkeypatch.setenv("NEO_OBSERVER_AUTOSTART", "")
+        monkeypatch.setattr(obs, "_car_server_reachable", lambda **k: True)
+        fake_car.agents_list.return_value = json.dumps(
+            [{"id": "neo-observer", "status": "running"}]
+        )
+        obs.maybe_autostart_observer()
+        fake_car.agents_upsert.assert_not_called()
+
+
+class TestGlobalSweep:
+    def test_discover_decodes_roots(self, monkeypatch, tmp_path):
+        import neo.memory.observer as obs
+        import neo.memory.transcript as tr
+        import neo.prompt.scanner as scanner
+        proj = tmp_path / "projects"
+        (proj / "-Users-me-git-foo").mkdir(parents=True)
+        (proj / "-Users-me-git-bar").mkdir(parents=True)
+        monkeypatch.setattr(tr, "CLAUDE_PROJECTS_DIR", proj)
+        # Decode deterministically (the real decoder validates on-disk existence,
+        # which a synthetic encoded dir can't satisfy).
+        monkeypatch.setattr(
+            scanner, "_decode_project_path",
+            lambda name: ("/" + name[1:].replace("-", "/")) if name.startswith("-") else None,
+        )
+        roots = obs._discover_project_roots()
+        assert roots == ["/Users/me/git/bar", "/Users/me/git/foo"]
+
+    def test_global_cycle_sweeps_each(self, monkeypatch):
+        import neo.memory.observer as obs
+        from neo.memory.observer import Observer
+        monkeypatch.setattr(obs, "_discover_project_roots", lambda: ["/a", "/b", "/c"])
+        swept = []
+        monkeypatch.setattr(Observer, "_run_project",
+                            lambda self, root: (swept.append(root) or (1, 2, object())))
+        o = Observer(global_mode=True)
+        o._cycle()
+        assert swept == ["/a", "/b", "/c"]
+        assert o._last_cycle_count == 3
+
+    def test_global_cycle_round_robins_budget(self, monkeypatch):
+        import neo.memory.observer as obs
+        from neo.memory.observer import Observer, ObserverConfig
+        monkeypatch.setattr(obs, "_discover_project_roots", lambda: ["/a", "/b", "/c", "/d"])
+        swept = []
+        monkeypatch.setattr(Observer, "_run_project",
+                            lambda self, root: (swept.append(root) or (0, 0, object())))
+        o = Observer(global_mode=True, config=ObserverConfig(max_projects_per_cycle=2))
+        o._cycle()
+        o._cycle()
+        assert set(swept) == {"/a", "/b", "/c", "/d"}
+
+    def test_global_cycle_isolates_project_errors(self, monkeypatch):
+        import neo.memory.observer as obs
+        from neo.memory.observer import Observer
+
+        def rp(self, root):
+            if root == "/boom":
+                raise RuntimeError("bad project")
+            return (1, 0, object())
+
+        monkeypatch.setattr(obs, "_discover_project_roots", lambda: ["/ok1", "/boom", "/ok2"])
+        monkeypatch.setattr(Observer, "_run_project", rp)
+        o = Observer(global_mode=True)
+        o._cycle()  # must not raise
+        assert o._last_cycle_count == 2
 
 
 class TestObserverCycleUnit:


### PR DESCRIPTION
## Description

Replaces the **per-project, opt-in** memory observer with a **single global, auto-started** one that sweeps all projects. Bumps to **v0.31.0**.

Motivation: the per-project model required `neo memory observer start` in each repo and ran one supervised daemon each — so in practice only one project was ever observed (the biggest-history repo had none). This makes continuous observation automatic and complete.

## Type of Change

- [x] New feature / architectural change (non-breaking for users; CLI surface unchanged)
- [x] Documentation update

## What changed

- **One global agent** `neo-observer` (daemon `--daemon --all`) sweeps **all discovered projects** each cycle — round-robin, `max_projects_per_cycle` (default 25), watermark-gated so projects with no new transcripts do near-zero work. Synthesis + transcript mining run per project, errors isolated per project.
- **No opt-in**: `maybe_autostart_observer()` (called from `cli.main`) auto-registers it whenever `car-server` is reachable. Opt out with `NEO_OBSERVER_AUTOSTART=0`. When CAR is absent → one-time quiet hint, then silent.
- **Migration**: on bootstrap/start, legacy per-project agents (`neo-observer-<id12>`) are stopped and `agents_remove`d.
- **Lifecycle + orphan detection** operate on the single global agent; orphan detection now flags *any* unsupervised neo observer daemon (global or a stranded legacy `--cwd` one).
- Project discovery from `~/.claude/projects/*` (decoded roots). Per-project `--daemon --cwd` mode + the A2UI inspector remain for direct use.

## Hard constraint (unchanged)
Still requires CAR (car-runtime + car-server). "No opt-in" = auto-register when CAR is present; without CAR there's simply no observer (one-time hint).

## How Has This Been Tested?

- [x] 49 observer unit tests (global spec, global sweep + round-robin budget + per-project error isolation, discovery wiring, legacy migration, autostart opt-out / no-CAR-hint / register / no-op-when-registered, generalized orphan detection POSIX+Windows).
- [x] Full suite green: **1143 passed, 3 skipped**; `ruff` clean.
- [x] Note: live end-to-end requires the **installed** build to support `--daemon --all`; validated post-release on the upgraded install (the spec/daemon mismatch only appears when running new spec against an old installed daemon).

## Checklist

- [x] Version bumped consistently; CHANGELOG + CLAUDE.md observer section updated
- [x] New and existing unit tests pass locally