### PR TITLE
feat: per-project progress heartbeat in global observer sweep (v0.31.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.1] - 2026-06-19
+
+### Changed
+
+- **The global observer sweep now logs per-project progress.** Previously a sweep logged only a `swept N/M …` summary at the *end*, so a long first sweep (catching up the transcript backlog of every previously-unobserved project) had no heartbeat and looked hung. The sweep now prints a `sweep start: N of M project(s)` line, then a `sweep [i/N] <project>: X synthesized, Y mined (Zs)` line as each project completes (errors per project logged to stderr). Subsequent watermark-fast sweeps stay quiet. (`memory/observer.py`)
+
 ## [0.31.0] - 2026-06-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.31.0"
+version = "0.31.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -404,19 +404,36 @@ class Observer:
         batch = (roots[start:] + roots[:start])[:budget]
         self._sweep_offset = (start + len(batch)) % len(roots)
 
+        n = len(batch)
+        print(
+            f"neo observer sweep start: {n} of {len(roots)} project(s) this cycle",
+            flush=True,
+        )
+
         total_synth = total_mined = errors = covered = 0
-        for root in batch:
+        for i, root in enumerate(batch, 1):
             if self._stop:
                 break
+            label = os.path.basename(root.rstrip("/")) or root
+            p0 = time.time()
             try:
                 count, mined, _store = self._run_project(root)
                 total_synth += count
                 total_mined += mined
                 covered += 1
+                # Per-project heartbeat so a long first sweep is legible (it logs
+                # only at batch end otherwise — invisible during a multi-minute
+                # backlog catch-up).
+                print(
+                    f"neo observer sweep [{i}/{n}] {label}: "
+                    f"{count} synthesized, {mined} mined ({time.time() - p0:.1f}s)",
+                    flush=True,
+                )
             except Exception as e:
                 errors += 1
                 print(
-                    f"neo observer project error [{root}]: {type(e).__name__}: {e}",
+                    f"neo observer sweep [{i}/{n}] {label}: ERROR "
+                    f"{type(e).__name__}: {e}",
                     file=sys.stderr, flush=True,
                 )
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -487,6 +487,19 @@ class TestGlobalSweep:
         assert swept == ["/a", "/b", "/c"]
         assert o._last_cycle_count == 3
 
+    def test_global_cycle_logs_per_project_progress(self, monkeypatch, capsys):
+        import neo.memory.observer as obs
+        from neo.memory.observer import Observer
+        monkeypatch.setattr(obs, "_discover_project_roots", lambda: ["/a/foo", "/b/bar"])
+        monkeypatch.setattr(Observer, "_run_project", lambda self, root: (1, 0, object()))
+        o = Observer(global_mode=True)
+        o._cycle()
+        out = capsys.readouterr().out
+        assert "sweep start: 2 of 2 project(s)" in out
+        assert "[1/2] foo:" in out
+        assert "[2/2] bar:" in out
+        assert "cycle ok: swept 2/2" in out
+
     def test_global_cycle_round_robins_budget(self, monkeypatch):
         import neo.memory.observer as obs
         from neo.memory.observer import Observer, ObserverConfig


### PR DESCRIPTION
## Description

Adds a per-project progress heartbeat to the global observer sweep so a long first sweep is legible. **v0.31.1** (patch — observability).

A sweep previously logged only a `swept N/M …` summary at the *end*, so the first sweep — which catches up the transcript backlog of every previously-unobserved project (multi-minute) — had no heartbeat and looked hung.

## Type of Change

- [x] Code cleanup / observability

## Change

The sweep now prints:
- `sweep start: N of M project(s) this cycle` before the loop
- `sweep [i/N] <project>: X synthesized, Y mined (Zs)` as each project completes (per-project errors → stderr)

Subsequent watermark-fast sweeps stay quiet (each project finishes in ~0s).

## How Has This Been Tested?

- [x] New test asserts the sweep-start + per-project lines + final summary are emitted (capsys).
- [x] Full suite green: **1144 passed, 3 skipped**; `ruff` clean.

## Checklist

- [x] Version bumped consistently; CHANGELOG updated
- [x] New and existing unit tests pass locally