### PR TITLE
feat: learn from merged GitHub PRs + review threads (0.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.33.0] - 2026-06-26
+
+### Added
+
+- **neo now learns from merged GitHub PRs and their review threads, not just AI-tool transcripts.** A fourth transcript source, `GitHubPRSource`, mines each repo's merged PRs via the `gh` CLI (one GraphQL call/repo) — review summaries, conversation comments, and inline line-comments — and turns the review discussion into memory facts. owner/repo is auto-derived from the git remote, so PR facts co-scope with that repo's transcript facts under the same `project_id`. Facts enter as **REVIEW on probation** (`imported:github-pr` tag) — trust-first, since PR reviews are other people's opinions, not neo's validated outcomes; they are not promoted by recurrence. The source filters bot authors, skips PRs with no human discussion, mines each PR once (bounded watermark keyed on PR number), and is throttled to one fetch per repo per hour so the all-projects observer sweep keeps near-zero work on unchanged repos. It self-disables (no env flag) when the remote isn't github.com or `gh` is absent. Known limits: merged-only, discussion text only (no PR diff), no historical backfill beyond the 25 most-recently-updated PRs, GitHub Enterprise and fork-origin remotes not yet handled. A new optional `fact_kind`/`extra_tags` on the `TranscriptSource` Protocol carries the trust posture into the ingester's `admit` (backward-compatible; existing sources unchanged). (`memory/transcript.py`)
+
 ## [0.32.0] - 2026-06-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,27 @@
       members, ≥2 sessions, ≥2 frictional, verbatim evidence); clusters at
       `SYNTHESIS_SIMILARITY` via the shared `math_utils.cluster_by_similarity`. See
       `docs/solutions/conversation-mined-issues.md` and `docs/solutions/rule-file-sync.md`.
+- Transcript sources (`memory.transcript`, the `TranscriptSource` Protocol): the
+  `TranscriptIngester` mines lessons from four sources by default —
+  `ClaudeCodeSource` (`~/.claude/projects/**/*.jsonl`), `CodexSource`
+  (`~/.codex/sessions/**/rollout-*.jsonl`), `CarSource` (`~/.car/sessions/*.json`),
+  and `GitHubPRSource` (merged PRs + review threads via the `gh` CLI). A source may
+  declare optional `fact_kind` / `extra_tags` trust overrides that the ingester's
+  `admit` reads (default = today's PATTERN/FAILURE + `transcript-derived` tag).
+  `GitHubPRSource`: PROJECT-scoped (owner/repo derived from the git remote, so PR
+  facts co-scope with that repo's transcript facts under the same `project_id`);
+  enters facts as **REVIEW on probation** (`imported:github-pr` tag) — trust-first,
+  and NOT promoted by recurrence (synthesis keys it `"other"` → stays REVIEW; only an
+  independent git-verified acceptance ever mints PATTERN). Mine-once (watermark keyed
+  on PR number, bounded); maps title+body→`ask`, reviews/comments/inline-thread
+  comments→`assistant_text`, `CHANGES_REQUESTED`→`errors`; filters bot authors;
+  skips PRs with no human discussion. Throttled to one `gh` fetch per repo per
+  `_GH_PR_FETCH_INTERVAL` (3600s) so the all-projects sweep keeps near-zero work on
+  unchanged repos. Self-disables (returns `[]`) when the remote isn't github.com or
+  `gh` is absent — no env flag. Known limits (deferred): merged-only, no PR-diff
+  ingestion (discussion text only), no historical backfill beyond the
+  `_GH_PR_PAGE`(=25)-most-recently-updated window, GitHub Enterprise hosts and
+  fork-origin upstreams not handled.
 - Domain tags (`Fact.domain`, `memory.models.SUGGESTED_DOMAINS`): optional free-form
   area tag orthogonal to `FactKind` — `code-style`, `testing`, `git`, `debugging`,
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.32.0"
+version = "0.33.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -26,6 +26,8 @@ import datetime
 import json
 import logging
 import re
+import shutil
+import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -35,6 +37,7 @@ from neo.math_utils import cosine_similarity
 from neo.memory.io_utils import atomic_write_json
 from neo.memory.metrics import record as metrics_record
 from neo.memory.models import FactKind, FactScope, Provenance
+from neo.memory.scope import _get_git_remote_url, _normalize_remote_url
 from neo.memory.outcomes import (
     MAX_MINED_OUTCOMES_PER_CYCLE,
     OUTCOME_CORRELATION_SIMILARITY,
@@ -343,10 +346,21 @@ class TranscriptSource(Protocol):
     ``name`` namespaces the watermark; ``scope`` is the FactScope for facts
     derived from this source (PROJECT for repo-bound tools, GLOBAL for
     cross-agent tools that aren't tied to one repo).
+
+    Optional trust overrides (a source may define neither, either, or both):
+    ``fact_kind`` forces the FactKind for derived facts (e.g. REVIEW for
+    lower-trust, decaying material that synthesis later promotes) instead of
+    the default PATTERN/FAILURE inferred per-lesson; ``extra_tags`` are appended
+    to the standard transcript tag so the source is identifiable and dedup-able.
+    When unset, ``admit`` keeps today's behavior. See ``GitHubPRSource``.
     """
 
     name: str
     scope: FactScope
+    # Optional; read via getattr in the ingester so existing sources that don't
+    # define them keep the default PATTERN/FAILURE + transcript-tag behavior.
+    fact_kind: Optional["FactKind"]
+    extra_tags: Optional[list[str]]
 
     def collect_episodes(self) -> list[Episode]:
         ...
@@ -595,6 +609,281 @@ class CodexSource:
         return episodes
 
 
+# ---------------------------------------------------------------------------
+# GitHub PR source helpers (task #2): derive owner/repo from the repo's git
+# remote and fetch merged PRs + their review threads via the `gh` CLI. Every
+# failure path returns empty/None so a missing/unauthenticated gh, a non-GitHub
+# remote, an offline box, or a rate-limit never raises into the ingest loop.
+# ---------------------------------------------------------------------------
+
+# One GraphQL call pulls this many most-recently-updated merged PRs. This is a
+# fixed window, NOT paginated: PRs older than the window at first run are not
+# backfilled. Forward coverage still holds — a newly-merged PR surfaces at the
+# top (merge bumps updatedAt) and is mined before it falls out, as long as the
+# fetch cadence outpaces the merge rate.
+_GH_PR_PAGE = 25
+_GH_API_TIMEOUT = 20  # seconds for a single gh invocation
+# PRs change far slower than transcripts. Fetch at most once per this interval
+# per repo so the observer's all-projects sweep keeps its "unchanged projects do
+# near-zero work" property instead of firing a gh subprocess every cycle.
+_GH_PR_FETCH_INTERVAL = 3600  # seconds
+
+# One GraphQL query gets each merged PR with its review summaries, conversation
+# comments, and inline review-thread comments — bounded fan-out (1 call/repo)
+# instead of REST's 1 + 3N.
+_GH_PR_QUERY = """
+query($owner:String!, $repo:String!, $n:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequests(states:MERGED, first:$n, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number title body mergedAt updatedAt
+        author { login }
+        reviews(first:50) { nodes { body state author { login } } }
+        comments(first:50) { nodes { body author { login } } }
+        reviewThreads(first:50) { nodes {
+          isResolved
+          comments(first:20) { nodes { body path author { login } } }
+        } }
+      }
+    }
+  }
+}
+"""
+
+
+def _owner_repo_from_remote(codebase_root: Optional[str]) -> Optional[tuple[str, str]]:
+    """``(owner, repo)`` for a github.com remote, or None.
+
+    Reuses ``scope._normalize_remote_url`` (the same normalization that derives
+    ``project_id``), so PR facts co-scope with that repo's transcript facts.
+    GitHub Enterprise hosts (``github.<company>.com``) are intentionally not
+    matched yet — only public github.com.
+    """
+    norm = _normalize_remote_url(_get_git_remote_url(codebase_root))
+    m = re.match(r"github\.com/([^/]+)/([^/]+)$", norm)
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def _gh_available() -> bool:
+    """True if the ``gh`` CLI is on PATH. Auth/network failures are handled at
+    call time (a fetch just returns []), so we don't pay a `gh auth status`
+    subprocess on every cycle."""
+    return shutil.which("gh") is not None
+
+
+def _gh_graphql(query: str, str_vars: Optional[dict] = None,
+                int_vars: Optional[dict] = None) -> Optional[dict]:
+    """Run a ``gh api graphql`` query, returning parsed ``data`` or None.
+
+    None on any failure — gh absent, not authenticated, offline, rate-limited,
+    timeout, or malformed JSON — so callers degrade to an empty source.
+
+    ``str_vars`` go via ``-f`` (raw string); ``int_vars`` via ``-F`` (typed).
+    The split matters: ``-F`` coerces values (a bare integer becomes an Int, a
+    leading ``@`` reads a file), so a String! variable like a repo literally
+    named ``2048`` MUST use ``-f`` or it fails the schema and silently mines
+    nothing.
+    """
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for k, v in (str_vars or {}).items():
+        cmd += ["-f", f"{k}={v}"]
+    for k, v in (int_vars or {}).items():
+        cmd += ["-F", f"{k}={v}"]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_GH_API_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug("github-pr: gh graphql failed: %s", e)
+        return None
+    if result.returncode != 0:
+        logger.debug("github-pr: gh graphql rc=%s: %s",
+                     result.returncode, (result.stderr or "")[:200])
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    data = payload.get("data") if isinstance(payload, dict) else None
+    return data if isinstance(data, dict) else None
+
+
+def _fetch_merged_prs(owner: str, repo: str, limit: int = _GH_PR_PAGE) -> list[dict]:
+    """The ``limit`` most-recently-updated merged PRs for ``owner/repo`` with
+    their reviews and comments, or [] on any failure."""
+    data = _gh_graphql(_GH_PR_QUERY,
+                       str_vars={"owner": owner, "repo": repo},
+                       int_vars={"n": limit})
+    if not data:
+        return []
+    try:
+        nodes = data["repository"]["pullRequests"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [n for n in nodes if isinstance(n, dict)]
+
+
+# Authored-by-automation noise: GitHub App accounts end in "[bot]"; the rest are
+# common review/CI bots posting under plain logins. Their comments are high
+# volume, low lesson density.
+_PR_BOT_LOGINS = {"dependabot", "renovate", "github-actions", "codecov",
+                  "coderabbitai", "sonarcloud", "netlify", "vercel"}
+
+
+def _is_bot(login: str) -> bool:
+    low = (login or "").lower()
+    return low.endswith("[bot]") or low in _PR_BOT_LOGINS
+
+
+def _node_list(obj: dict, key: str) -> list[dict]:
+    """Safely pull ``obj[key]['nodes']`` as a list of dicts ([] if absent)."""
+    try:
+        nodes = obj[key]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [n for n in nodes if isinstance(n, dict)]
+
+
+def _author_login(obj: dict) -> str:
+    a = obj.get("author") if isinstance(obj, dict) else None
+    return a.get("login", "") if isinstance(a, dict) else ""
+
+
+class GitHubPRSource:
+    """Merged GitHub PRs + their review threads for one repo, via the ``gh`` CLI.
+
+    Repo-bound, so derived facts are PROJECT-scoped and co-scope with that
+    repo's transcript facts (same git-remote ``project_id``). Facts enter as
+    REVIEW on probation (trust-first): PR reviews are other people's opinions on
+    code, topic-correlated and not neo's own validated outcomes, so they're
+    low-trust, decaying material. They are NOT promoted by recurrence — synthesis
+    consolidates them into another REVIEW, and only an independent git-verified
+    acceptance of a suggestion neo itself surfaced ever mints a PATTERN. That is
+    deliberate: promoting other people's opinions by repetition is exactly the
+    false-accept vector neo guards against. ``fact_kind``/``extra_tags`` carry
+    this posture to the ingester's ``admit`` (task #1).
+
+    Each merged PR is mined once (watermark keyed on PR number); post-merge
+    thread growth is not re-mined — merged-PR discussion is effectively final,
+    and mine-once keeps the watermark bounded (one entry/PR, like the other
+    sources) instead of accreting one per edit.
+    """
+
+    name = "github-pr"
+    scope = FactScope.PROJECT
+    fact_kind = FactKind.REVIEW
+    extra_tags = ["imported:github-pr"]
+
+    def __init__(self, codebase_root: Optional[str]):
+        self.codebase_root = codebase_root
+
+    def collect_episodes(self) -> list[Episode]:
+        repo = _owner_repo_from_remote(self.codebase_root)
+        if repo is None or not _gh_available():
+            return []  # non-GitHub remote / no gh on PATH → silent no-op
+        owner, name = repo
+        if not self._fetch_due(owner, name):
+            return []  # throttled: a gh subprocess at most once per interval/repo
+        episodes: list[Episode] = []
+        for pr in _fetch_merged_prs(owner, name):
+            ep = self._pr_to_episode(pr)
+            if ep is not None:
+                episodes.append(ep)
+        # Advance the throttle only after a real fetch — if the budget skipped us
+        # this cycle (collect never ran), we retry next cycle rather than waiting
+        # a full interval, so a busy repo isn't starved on first mining.
+        self._mark_fetched(owner, name)
+        return episodes
+
+    @staticmethod
+    def _fetch_stamp_path(owner: str, repo: str) -> "Path":
+        # Sanitize: owner/repo are GitHub handles (no "/"), but be defensive.
+        slug = f"{owner}_{repo}".replace("/", "_")
+        return SESSIONS_DIR / f"github_pr_fetch_{slug}.stamp"
+
+    def _fetch_due(self, owner: str, repo: str) -> bool:
+        try:
+            age = time.time() - self._fetch_stamp_path(owner, repo).stat().st_mtime
+        except OSError:
+            return True  # no stamp yet → due
+        return age >= _GH_PR_FETCH_INTERVAL
+
+    def _mark_fetched(self, owner: str, repo: str) -> None:
+        try:
+            SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+            self._fetch_stamp_path(owner, repo).write_text(str(time.time()))
+        except OSError as e:
+            logger.debug("github-pr: could not write fetch stamp: %s", e)
+
+    @staticmethod
+    def _pr_to_episode(pr: dict) -> Optional[Episode]:
+        try:
+            number = int(pr["number"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        title = str(pr.get("title") or "").strip()
+        if not title:
+            return None
+        body = str(pr.get("body") or "").strip()
+        ask = f"PR #{number}: {title}"
+        if body:
+            ask = f"{ask}\n\n{body}"
+        ask = ask[:_MAX_ASK_CHARS]
+
+        texts: list[str] = []
+        errors: list[str] = []
+        # Review summaries, carrying the verdict state.
+        for r in _node_list(pr, "reviews"):
+            login = _author_login(r)
+            if _is_bot(login):
+                continue
+            rb = str(r.get("body") or "").strip()
+            state = str(r.get("state") or "").strip()
+            if state == "CHANGES_REQUESTED":
+                errors.append(f"changes requested by {login}: {rb}"[:300])
+            if rb:
+                texts.append(f"[review {state} by {login}] {rb}")
+        # Conversation (issue-style) comments.
+        for c in _node_list(pr, "comments"):
+            login = _author_login(c)
+            cb = str(c.get("body") or "").strip()
+            if _is_bot(login) or not cb:
+                continue
+            texts.append(f"[comment by {login}] {cb}")
+        # Inline review-thread comments (line-level discussion).
+        for th in _node_list(pr, "reviewThreads"):
+            for c in _node_list(th, "comments"):
+                login = _author_login(c)
+                cb = str(c.get("body") or "").strip()
+                if _is_bot(login) or not cb:
+                    continue
+                path = str(c.get("path") or "").strip()
+                loc = f" {path}" if path else ""
+                texts.append(f"[inline{loc} by {login}] {cb}")
+
+        # A merged PR with no human review discussion has nothing to teach — the
+        # lesson lives in the review, not the description. Skip it (and leave it
+        # un-watermarked so it ingests later if review activity appears).
+        if not texts:
+            return None
+
+        # Mine-once: anchor on the PR number alone, so re-fetching a
+        # already-consumed PR is a no-op and the watermark stays bounded at one
+        # entry per PR (no per-edit accretion).
+        anchor = f"pr-{number}"
+        return Episode(
+            session_id=f"pr-{number}",
+            anchor_uuid=anchor,
+            last_uuid=anchor,
+            timestamp=str(pr.get("mergedAt") or ""),
+            ask=ask,
+            assistant_text=texts,
+            errors=errors,
+        )
+
+
 class TranscriptIngester:
     """Extract verified, generalizable lessons from transcript episodes and
     admit them directly as PATTERN/FAILURE facts.
@@ -610,11 +899,15 @@ class TranscriptIngester:
         self._store = store
         self._lm = lm_adapter
         self.codebase_root = codebase_root or getattr(store, "codebase_root", None)
-        # Default source set; add new tool adapters here as they land.
+        # Default source set; add new tool adapters here as they land. No env
+        # toggles: GitHubPRSource self-disables (returns []) when the repo has no
+        # github.com remote or `gh` isn't on PATH, so it costs nothing where it
+        # doesn't apply rather than needing an opt-out flag.
         self.sources = sources if sources is not None else [
             ClaudeCodeSource(self.codebase_root),
             CodexSource(self.codebase_root),
             CarSource(),
+            GitHubPRSource(self.codebase_root),
         ]
 
     # -- Stage B ---------------------------------------------------------
@@ -652,8 +945,16 @@ class TranscriptIngester:
         return bool(data and data.get("keep") is True)
 
     # -- admission -------------------------------------------------------
-    def admit(self, lesson: dict, ep: Episode, scope: FactScope = FactScope.PROJECT):
-        kind = FactKind.FAILURE if lesson.get("kind") == "failure" else FactKind.PATTERN
+    def admit(self, lesson: dict, ep: Episode, scope: FactScope = FactScope.PROJECT,
+              fact_kind: Optional[FactKind] = None,
+              extra_tags: Optional[list[str]] = None):
+        # ``fact_kind`` (when a source declares one) overrides the per-lesson
+        # PATTERN/FAILURE split — e.g. a PR source enters everything as REVIEW
+        # (low-trust, decaying) and lets synthesis promote clusters later.
+        if fact_kind is not None:
+            kind = fact_kind
+        else:
+            kind = FactKind.FAILURE if lesson.get("kind") == "failure" else FactKind.PATTERN
         try:
             raw_conf = float(lesson.get("confidence", 0.5) or 0.5)
         except (TypeError, ValueError):
@@ -669,12 +970,14 @@ class TranscriptIngester:
             scope=scope,
             confidence=confidence,
             source_prompt=ep.ask[:200],
-            tags=[_TRANSCRIPT_TAG],
+            tags=[_TRANSCRIPT_TAG, *(extra_tags or [])],
             provenance=Provenance.INFERRED,  # LM generalization, no bonus over corroborated facts
             domain=domain,  # first-class field so retrieve_relevant(domain=...) matches
         )
 
-    def ingest_episode(self, ep: Episode, scope: FactScope = FactScope.PROJECT) -> int:
+    def ingest_episode(self, ep: Episode, scope: FactScope = FactScope.PROJECT,
+                       fact_kind: Optional[FactKind] = None,
+                       extra_tags: Optional[list[str]] = None) -> int:
         """Full per-episode pipeline; returns number of facts admitted.
 
         ``store.add_fact`` saves to disk on each call, so an episode's facts
@@ -685,7 +988,7 @@ class TranscriptIngester:
         admitted = 0
         for lesson in self.extract_lessons(ep):
             if self.verify(lesson, ep):
-                self.admit(lesson, ep, scope)
+                self.admit(lesson, ep, scope, fact_kind=fact_kind, extra_tags=extra_tags)
                 admitted += 1
         return admitted
 
@@ -735,10 +1038,14 @@ class TranscriptIngester:
             new = [e for e in episodes if e.anchor_uuid not in consumed]
             stats["episodes_total"] += len(episodes)
             stats["episodes_new"] += len(new)
+            # Optional per-source trust overrides (default None → today's behavior).
+            src_kind = getattr(source, "fact_kind", None)
+            src_tags = getattr(source, "extra_tags", None)
             for ep in new:
                 if stop_now():
                     break
-                stats["facts_admitted"] += self.ingest_episode(ep, source.scope)
+                stats["facts_admitted"] += self.ingest_episode(
+                    ep, source.scope, fact_kind=src_kind, extra_tags=src_tags)
                 consumed.add(ep.anchor_uuid)
                 self._persist_consumed(source, consumed)  # advance only after durable
                 stats["episodes_processed"] += 1

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -2,6 +2,7 @@
 
 import json
 import time as _time
+import types
 from dataclasses import dataclass as _dataclass
 
 import numpy as _np
@@ -13,7 +14,11 @@ from neo.memory.transcript import (
     CarSource,
     CodexSource,
     Episode,
+    GitHubPRSource,
     TranscriptIngester,
+    _fetch_merged_prs,
+    _gh_graphql,
+    _owner_repo_from_remote,
     _parse_json,
     build_episodes,
     collect_episodes,
@@ -717,3 +722,256 @@ def test_mine_gives_up_after_window(mining_store):
     assert ing.mine_suggestion_outcomes([]) == 0
     assert st._outcome_tracker.load_suggestion_ledger() == []  # expired, dropped
     assert fact.metadata.success_count == 0
+
+
+# ===========================================================================
+# GitHubPRSource — merged PRs + review threads as a transcript source.
+# All network is faked; no test touches the real `gh` CLI or GitHub.
+# ===========================================================================
+
+
+def _pr(number=1, title="t", body="", updated="u1", merged="m1",
+        reviews=None, comments=None, threads=None):
+    """A GraphQL PR node shaped like _fetch_merged_prs returns."""
+    return {
+        "number": number, "title": title, "body": body,
+        "updatedAt": updated, "mergedAt": merged,
+        "author": {"login": "author"},
+        "reviews": {"nodes": reviews or []},
+        "comments": {"nodes": comments or []},
+        "reviewThreads": {"nodes": threads or []},
+    }
+
+
+class TestOwnerRepoParsing:
+    @pytest.mark.parametrize("url,expected", [
+        ("git@github.com:Parslee-ai/neo.git", ("Parslee-ai", "neo")),
+        ("https://github.com/Parslee-ai/neo", ("Parslee-ai", "neo")),
+        ("https://x-token@github.com/Parslee-ai/neo.git", ("Parslee-ai", "neo")),
+        ("ssh://git@github.com/Parslee-ai/neo.git", ("Parslee-ai", "neo")),
+        ("git@gitlab.com:foo/bar.git", None),   # non-GitHub remote
+        ("", None),                              # no remote
+    ])
+    def test_parses(self, monkeypatch, url, expected):
+        monkeypatch.setattr("neo.memory.transcript._get_git_remote_url",
+                            lambda root: url)
+        assert _owner_repo_from_remote("/x") == expected
+
+
+class TestPRToEpisode:
+    def test_maps_reviews_comments_inline_and_errors(self):
+        pr = _pr(
+            number=42, title="Add cache", body="why", updated="2026-06-02",
+            merged="2026-06-01",
+            reviews=[
+                {"body": "LGTM", "state": "APPROVED", "author": {"login": "bob"}},
+                {"body": "key collides", "state": "CHANGES_REQUESTED",
+                 "author": {"login": "carol"}},
+            ],
+            comments=[
+                {"body": "bump", "author": {"login": "dependabot[bot]"}},  # bot
+                {"body": "nice", "author": {"login": "dave"}},
+            ],
+            threads=[{"isResolved": True, "comments": {"nodes": [
+                {"body": "use LRU", "path": "cache.py", "author": {"login": "carol"}},
+            ]}}],
+        )
+        ep = GitHubPRSource._pr_to_episode(pr)
+        joined = " ".join(ep.assistant_text)
+        assert ep.ask.startswith("PR #42: Add cache")
+        assert "review APPROVED by bob" in joined
+        assert "review CHANGES_REQUESTED by carol" in joined
+        assert "comment by dave" in joined
+        assert "inline cache.py by carol" in joined
+        assert "dependabot" not in joined            # bot filtered out
+        assert ep.errors and "changes requested by carol" in ep.errors[0]
+        assert ep.anchor_uuid == "pr-42"             # mine-once: keyed on number
+        assert ep.timestamp == "2026-06-01"
+        assert ep.is_substantive
+
+    def test_no_discussion_returns_none(self):
+        assert GitHubPRSource._pr_to_episode(_pr(number=7, title="typo")) is None
+
+    def test_all_bot_discussion_returns_none(self):
+        pr = _pr(comments=[{"body": "bump", "author": {"login": "renovate"}}])
+        assert GitHubPRSource._pr_to_episode(pr) is None
+
+    def test_missing_title_returns_none(self):
+        assert GitHubPRSource._pr_to_episode(_pr(title="")) is None
+
+    def test_handles_null_author_and_null_nodes(self):
+        """GraphQL returns author:null for deleted accounts and may null whole
+        connections — none of it should raise."""
+        pr = {
+            "number": 3, "title": "x", "body": "", "updatedAt": "u", "mergedAt": "m",
+            "author": None,                       # deleted account
+            "reviews": None,                      # whole connection null
+            "comments": {"nodes": [None, {"body": "real point", "author": None}]},
+            "reviewThreads": {"nodes": [None]},   # null node in list
+        }
+        ep = GitHubPRSource._pr_to_episode(pr)
+        assert ep is not None
+        assert any("real point" in t for t in ep.assistant_text)
+        assert ep.anchor_uuid == "pr-3"
+
+
+class TestGhFetchFailureModes:
+    def _run(self, monkeypatch, *, rc=0, stdout="", raises=None):
+        def fake_run(*a, **k):
+            if raises:
+                raise raises
+            return types.SimpleNamespace(returncode=rc, stdout=stdout, stderr="e")
+        monkeypatch.setattr("neo.memory.transcript.subprocess.run", fake_run)
+
+    def test_none_on_nonzero(self, monkeypatch):
+        self._run(monkeypatch, rc=1)
+        assert _gh_graphql("q") is None
+
+    def test_none_on_exception(self, monkeypatch):
+        self._run(monkeypatch, raises=OSError("no gh"))
+        assert _gh_graphql("q") is None
+
+    def test_none_on_timeout(self, monkeypatch):
+        import subprocess
+        self._run(monkeypatch, raises=subprocess.TimeoutExpired("gh", 20))
+        assert _gh_graphql("q") is None
+
+    def test_none_on_bad_json(self, monkeypatch):
+        self._run(monkeypatch, rc=0, stdout="not json")
+        assert _gh_graphql("q") is None
+
+    def test_string_vars_use_lowercase_f_int_vars_use_uppercase_F(self, monkeypatch):
+        """Regression: a repo named "2048" must go via -f (String!), not -F,
+        which would coerce it to an Int and silently fail the query."""
+        captured = {}
+
+        def fake_run(cmd, **k):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout='{"data":{}}', stderr="")
+        monkeypatch.setattr("neo.memory.transcript.subprocess.run", fake_run)
+        _gh_graphql("Q", str_vars={"owner": "2048", "repo": "2048"}, int_vars={"n": 25})
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("owner=2048") - 1] == "-f"   # String! via -f
+        assert cmd[cmd.index("repo=2048") - 1] == "-f"
+        assert cmd[cmd.index("n=25") - 1] == "-F"         # Int! via -F
+
+    def test_fetch_empty_when_graphql_none(self, monkeypatch):
+        monkeypatch.setattr("neo.memory.transcript._gh_graphql", lambda *a, **k: None)
+        assert _fetch_merged_prs("o", "r") == []
+
+    def test_fetch_empty_on_malformed_payload(self, monkeypatch):
+        monkeypatch.setattr("neo.memory.transcript._gh_graphql",
+                            lambda *a, **k: {"repository": None})
+        assert _fetch_merged_prs("o", "r") == []
+
+
+class TestCollectEpisodesGuards:
+    def test_empty_when_no_gh(self, monkeypatch):
+        monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: False)
+        monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                            lambda root: ("o", "r"))
+        assert GitHubPRSource("/x").collect_episodes() == []
+
+    def test_empty_when_non_github_remote(self, monkeypatch):
+        monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: True)
+        monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                            lambda root: None)
+        assert GitHubPRSource("/x").collect_episodes() == []
+
+    def test_maps_fetched_prs(self, tmp_path, monkeypatch):
+        # SESSIONS_DIR → tmp so the throttle stamp never touches real state.
+        monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "s")
+        monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: True)
+        monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                            lambda root: ("o", "r"))
+        monkeypatch.setattr(
+            "neo.memory.transcript._fetch_merged_prs",
+            lambda o, r: [_pr(number=1, title="x",
+                              comments=[{"body": "good", "author": {"login": "u"}}])])
+        eps = GitHubPRSource("/x").collect_episodes()
+        assert len(eps) == 1 and eps[0].session_id == "pr-1"
+
+    def test_fetch_is_throttled_per_repo(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "s")
+        monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: True)
+        monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                            lambda root: ("o", "r"))
+        calls = []
+        monkeypatch.setattr(
+            "neo.memory.transcript._fetch_merged_prs",
+            lambda o, r: calls.append(1) or [
+                _pr(number=1, comments=[{"body": "x", "author": {"login": "u"}}])])
+        src = GitHubPRSource("/x")
+        src.collect_episodes()          # no stamp → fetches
+        src.collect_episodes()          # within interval → throttled, no fetch
+        assert len(calls) == 1
+        monkeypatch.setattr("neo.memory.transcript._GH_PR_FETCH_INTERVAL", 0)
+        src.collect_episodes()          # interval elapsed → fetches again
+        assert len(calls) == 2
+
+
+def test_pr_facts_enter_as_review_on_probation(temp_store, tmp_path, monkeypatch):
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: True)
+    monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                        lambda root: ("o", "r"))
+    pr = _pr(number=5, title="Add cache",
+             reviews=[{"body": "key collides under load", "state": "CHANGES_REQUESTED",
+                       "author": {"login": "carol"}}])
+    monkeypatch.setattr("neo.memory.transcript._fetch_merged_prs", lambda o, r: [pr])
+    ad = _StubAdapter([{"kind": "pattern", "subject": "cache key design",
+                        "body": "Cache keys must include all inputs to avoid collisions.",
+                        "evidence_span": "key collides under load"}], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[GitHubPRSource("/x")])
+    stats = ing.ingest()
+    assert stats["facts_admitted"] == 1
+    facts = [f for f in temp_store._facts if f.is_valid]
+    assert len(facts) == 1
+    f = facts[0]
+    assert f.kind == FactKind.REVIEW                  # trust-first, not PATTERN
+    assert "imported:github-pr" in f.tags
+    assert "transcript-derived" in f.tags
+    assert "probation" in f.tags                      # enters on probation
+
+
+def test_pr_ingest_is_mine_once(temp_store, tmp_path, monkeypatch):
+    """A merged PR is mined exactly once (watermark keyed on PR number), even if
+    its thread grows after merge — keeps the watermark bounded and avoids re-
+    paying extraction. Throttle disabled so this exercises the watermark itself."""
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    monkeypatch.setattr("neo.memory.transcript._GH_PR_FETCH_INTERVAL", 0)  # no throttle
+    monkeypatch.setattr("neo.memory.transcript._gh_available", lambda: True)
+    monkeypatch.setattr("neo.memory.transcript._owner_repo_from_remote",
+                        lambda root: ("o", "r"))
+    lesson = [{"kind": "pattern", "subject": "bounded cache",
+               "body": "Use a bounded LRU to cap cache memory.",
+               "evidence_span": "use a bounded LRU here"}]
+    ad = _StubAdapter(lesson, keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[GitHubPRSource("/x")])
+
+    v1 = [_pr(number=9, title="x", updated="2026-01-01",
+              comments=[{"body": "use a bounded LRU here", "author": {"login": "carol"}}])]
+    monkeypatch.setattr("neo.memory.transcript._fetch_merged_prs", lambda o, r: v1)
+    assert ing.ingest()["episodes_new"] == 1
+    assert ing.ingest()["episodes_new"] == 0          # already mined
+
+    # Thread grew (new updatedAt) — but mine-once keys on number, so still 0 new.
+    v2 = [_pr(number=9, title="x", updated="2026-02-02",
+              comments=[{"body": "use a bounded LRU here", "author": {"login": "carol"}},
+                        {"body": "and add a metric", "author": {"login": "dave"}}])]
+    monkeypatch.setattr("neo.memory.transcript._fetch_merged_prs", lambda o, r: v2)
+    assert ing.ingest()["episodes_new"] == 0          # not re-mined
+
+
+def test_source_without_fact_kind_defaults_to_pattern(temp_store, tmp_path, monkeypatch):
+    """Backward-compat: a source that declares no fact_kind still yields PATTERN."""
+    monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+    src = _StaticSource([_episode()])  # no fact_kind / extra_tags attributes
+    ad = _StubAdapter([{"kind": "pattern", "subject": "s",
+                        "body": "Check the venv before blaming the code.",
+                        "evidence_span": "venv was missing pytest-asyncio"}], keep=True)
+    ing = TranscriptIngester(store=temp_store, lm_adapter=ad, sources=[src])
+    ing.ingest()
+    facts = [f for f in temp_store._facts if f.is_valid]
+    assert facts and facts[0].kind == FactKind.PATTERN
+    assert "imported:github-pr" not in facts[0].tags


### PR DESCRIPTION
## Description

Adds `GitHubPRSource`, a fourth `TranscriptSource`, so neo learns from **code-review discussion** (merged PRs + review threads) and not just AI-tool session transcripts.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

neo mines lessons from AI-tool transcripts (Claude Code, Codex, CAR). PR review threads are high-signal — *why* a change was requested/approved, conventions surfaced in review — and were invisible to it. This pulls them in.

## What changed

- **`GitHubPRSource`** — one `gh api graphql` call per repo fetches merged PRs with review summaries, conversation comments, and inline line-comments; maps each PR → an `Episode` (title+body→ask, discussion→assistant_text, `CHANGES_REQUESTED`→errors).
- **Auto-derived owner/repo** from the git remote (reuses `scope._normalize_remote_url`), so PR facts co-scope with that repo's transcript facts under the same `project_id`.
- **Trust-first**: facts enter as **REVIEW on probation** (`imported:github-pr`), not promoted by recurrence — PR reviews are others' opinions, not neo's validated outcomes. A new optional `fact_kind`/`extra_tags` on the `TranscriptSource` Protocol carries this into `admit` (backward-compatible; existing sources unchanged).
- **Bounded & cheap**: mine-once (watermark keyed on PR number), bot-author filter, skips no-discussion PRs, throttled to one fetch/repo/hour so the all-projects observer sweep stays near-zero-work on unchanged repos. Self-disables (no env flag) when the remote isn't github.com or `gh` is absent.

## Review

Reviewed by the `neo` (architecture) and `Linus` (kernel-quality) agents. Blocking findings folded in:
- **`gh -f` vs `-F` typing** (Linus, critical): a repo literally named `2048` was sent via `-F` → coerced to Int → failed the GraphQL `String!` → silently mined nothing. Fixed + regression test on the constructed argv.
- **Fetch throttle** (neo): the gh subprocess fired every cycle; now ≤once/hour/repo.
- **Corrected docstrings** (both): removed a false "synthesis promotes REVIEW→PATTERN by recurrence" claim and a false "watermark backfills older PRs" claim.
- **Mine-once watermark** (both): was accreting one entry per PR-edit; now one per PR.

## How Has This Been Tested?

- [x] 24 new tests with a faked `gh` (no network): owner/repo parsing across remote forms, PR→Episode mapping, bot filtering, all failure modes (no gh, no auth, timeout, bad JSON, malformed/null payloads), argv-typing regression, throttle, mine-once idempotency, REVIEW-on-probation trust model, backward-compat of the Protocol change.
- [x] Live read-only smoke test of the GraphQL fetch against this repo.
- [x] Full suite: **1188 passed, 3 skipped**.

**Test Configuration**:
- Python version: 3.13 (local) / 3.10–3.13 (CI)
- OS: macOS
- Neo version: 0.33.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CLAUDE.md, CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Deferred as documented follow-ups: merged-only (no closed-unmerged), no PR-diff ingestion (discussion text only), no historical backfill beyond the 25-most-recently-updated window, GitHub Enterprise hosts and fork-origin upstreams not handled, description-only admission for solo-maintainer repos.