### PR TITLE
fix: harden neo inference (stdin hang + CAR call deadline + large-context FFI timeout)

### DIFF
--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -924,6 +925,28 @@ def create_adapter(
 #: from a transient CAR outage instead of pinning to the fallback forever.
 _CAR_RETRY_COOLDOWN_S = 300.0
 
+#: Default per-call wall-clock deadline (seconds) for a single CAR inference
+#: call in auto mode. ``car_runtime.infer_tracked`` is a blocking FFI call; if
+#: the daemon is restarted mid-call (its PID churns on every CarHost relaunch)
+#: the client's socket read can block with no deadline — observed once as a
+#: 5-day hang of the whole neo process. Bounding the call turns that into a
+#: clean failover to the static provider. Healthy CAR calls finish in seconds,
+#: so this is generous. Override with ``NEO_CAR_TIMEOUT_SECONDS``.
+_CAR_CALL_TIMEOUT_S = 180.0
+
+
+def _car_call_timeout() -> float:
+    """Per-call CAR deadline, overridable via ``NEO_CAR_TIMEOUT_SECONDS``."""
+    raw = os.environ.get("NEO_CAR_TIMEOUT_SECONDS")
+    if raw:
+        try:
+            v = float(raw)
+            if v > 0:
+                return v
+        except ValueError:
+            pass
+    return _CAR_CALL_TIMEOUT_S
+
 
 class AutoAdapter(LMAdapter):
     """CAR-first adapter: route through CAR's dynamic router, fall back to a
@@ -947,11 +970,13 @@ class AutoAdapter(LMAdapter):
     """
 
     def __init__(self, car: LMAdapter, fallback_factory,
-                 retry_cooldown: float = _CAR_RETRY_COOLDOWN_S):
+                 retry_cooldown: float = _CAR_RETRY_COOLDOWN_S,
+                 car_timeout: Optional[float] = None):
         self._car = car
         self._make_fallback = fallback_factory
         self._fallback: Optional[LMAdapter] = None
         self._retry_cooldown = retry_cooldown
+        self._car_timeout = car_timeout if car_timeout is not None else _car_call_timeout()
         self._disabled_until = 0.0  # monotonic deadline; <= now => CAR eligible
 
     def _fallback_adapter(self) -> LMAdapter:
@@ -959,13 +984,47 @@ class AutoAdapter(LMAdapter):
             self._fallback = self._make_fallback()
         return self._fallback
 
+    def _car_generate_bounded(self, messages, stop, max_tokens,
+                              temperature, reasoning_effort) -> str:
+        """Run the CAR call under a wall-clock deadline.
+
+        ``infer_tracked`` is a blocking FFI call with no caller-visible
+        timeout, so an error-only breaker can't catch a *hang* (a dead/
+        restarted daemon leaving the socket read blocked forever). We run it
+        in a daemon worker thread and abandon it on timeout, raising so the
+        breaker opens and the next call routes to the fallback. The orphaned
+        worker can't be force-killed, but it's a daemon (won't block process
+        exit) and timeouts are rare + cooldown-bounded, so leaked threads
+        can't accumulate unbounded.
+        """
+        box: dict = {}
+
+        def _worker():
+            try:
+                box["value"] = self._car.generate(
+                    messages, stop=stop, max_tokens=max_tokens,
+                    temperature=temperature, reasoning_effort=reasoning_effort,
+                )
+            except BaseException as exc:  # noqa: BLE001 — relay to caller thread
+                box["error"] = exc
+
+        worker = threading.Thread(target=_worker, name="neo-car-call", daemon=True)
+        worker.start()
+        worker.join(self._car_timeout)
+        if worker.is_alive():
+            raise TimeoutError(
+                f"CAR inference exceeded {self._car_timeout:.0f}s deadline"
+            )
+        if "error" in box:
+            raise box["error"]
+        return box.get("value", "")
+
     def generate(self, messages, stop=None, max_tokens: int = 4096,
                  temperature: float = 0.7, reasoning_effort: Optional[str] = None) -> str:
         if time.monotonic() >= self._disabled_until:
             try:
-                return self._car.generate(
-                    messages, stop=stop, max_tokens=max_tokens,
-                    temperature=temperature, reasoning_effort=reasoning_effort,
+                return self._car_generate_bounded(
+                    messages, stop, max_tokens, temperature, reasoning_effort,
                 )
             except Exception as e:
                 self._disabled_until = time.monotonic() + self._retry_cooldown

--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -720,6 +720,23 @@ class ClaudeCodeAdapter(LMAdapter):
 # ============================================================================
 
 
+#: Default for CAR's per-call FFI read timeout (``CAR_DAEMON_TIMEOUT``, seconds).
+#: CAR ships a 30s default, but a quality remote serving neo's large multi-file
+#: code context legitimately takes longer — measured ~140s for a 143 KB prompt
+#: via parslee. At 30s those calls are cut off mid-inference and neo falls back
+#: every time, so we raise the floor. Only applied when the operator hasn't set
+#: ``CAR_DAEMON_TIMEOUT`` themselves. Kept strictly below the AutoAdapter
+#: watchdog (``_CAR_CALL_TIMEOUT_S``) so CAR's own clean timeout fires first and
+#: the watchdog only catches a true hang where even that doesn't return.
+_CAR_DAEMON_TIMEOUT_DEFAULT_S = 180
+
+
+def _apply_car_daemon_timeout_default() -> None:
+    """Raise CAR's FFI read-timeout floor for neo's long-inference workload,
+    unless the operator already set ``CAR_DAEMON_TIMEOUT``."""
+    os.environ.setdefault("CAR_DAEMON_TIMEOUT", str(_CAR_DAEMON_TIMEOUT_DEFAULT_S))
+
+
 class CarAdapter(LMAdapter):
     """Route Neo's outbound inference through CAR's unified inference layer.
 
@@ -764,8 +781,11 @@ class CarAdapter(LMAdapter):
         runtime: Optional[object] = None,
     ):
         self.model = model
-        # Caller-supplied intent wins; otherwise default to coding workload.
+        # Caller-supplied intent wins; otherwise default to the coding workload.
         self.intent_hint = dict(intent_hint) if intent_hint else dict(self.DEFAULT_INTENT_HINT)
+        # Give large-context inference room to finish before CAR's FFI read
+        # timeout cuts it off (a quality remote can take ~140s on neo's context).
+        _apply_car_daemon_timeout_default()
         if runtime is None:
             from neo.car_inference import get_runtime
             runtime = get_runtime()
@@ -930,9 +950,11 @@ _CAR_RETRY_COOLDOWN_S = 300.0
 #: the daemon is restarted mid-call (its PID churns on every CarHost relaunch)
 #: the client's socket read can block with no deadline — observed once as a
 #: 5-day hang of the whole neo process. Bounding the call turns that into a
-#: clean failover to the static provider. Healthy CAR calls finish in seconds,
-#: so this is generous. Override with ``NEO_CAR_TIMEOUT_SECONDS``.
-_CAR_CALL_TIMEOUT_S = 180.0
+#: clean failover to the static provider. Kept ABOVE the CAR FFI read timeout
+#: (``_CAR_DAEMON_TIMEOUT_DEFAULT_S``) so CAR's own clean timeout normally fires
+#: first (→ breaker → fallback) and this watchdog only catches a genuine hang
+#: where even that never returns. Override with ``NEO_CAR_TIMEOUT_SECONDS``.
+_CAR_CALL_TIMEOUT_S = 240.0
 
 
 def _car_call_timeout() -> float:

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -14,6 +14,7 @@ This module serves as the thin CLI entry point. Core logic has been split into:
 import json
 import logging
 import os
+import select
 import sys
 
 # Disable tokenizer parallelism warning (fastembed uses HuggingFace tokenizers)
@@ -357,6 +358,44 @@ def parse_args():
     return p.parse_args()
 
 
+def _stdin_read_timeout() -> float:
+    """Seconds to wait for stdin to become readable before treating it as
+    empty. Overridable via ``NEO_STDIN_TIMEOUT_SECONDS``."""
+    raw = os.environ.get("NEO_STDIN_TIMEOUT_SECONDS")
+    if raw:
+        try:
+            v = float(raw)
+            if v >= 0:
+                return v
+        except ValueError:
+            pass
+    return 1.0
+
+
+def _read_stdin_guarded() -> str:
+    """Read all of stdin, but never block forever waiting for it.
+
+    ``sys.stdin.read()`` is a read-until-EOF: if stdin is a non-tty that the
+    peer holds open without sending data or EOF — a background job, a daemon,
+    a mis-wired subprocess pipe — it blocks indefinitely (observed once as a
+    multi-hour neo hang). We first ``select()`` for readability with a short
+    deadline; if nothing is ready we treat stdin as empty rather than hang.
+    A real pipe (``echo x | neo``) or a redirect (``neo < f``) reports ready
+    immediately, so legitimate piping is unaffected. ``select`` can raise on
+    odd stdin objects (already a StringIO, closed, no fileno — the latter is
+    ``io.UnsupportedOperation``, a subclass of both ``OSError`` and
+    ``ValueError``); any failure falls through to a best-effort direct read.
+    """
+    try:
+        ready, _, _ = select.select([sys.stdin], [], [], _stdin_read_timeout())
+    except (ValueError, OSError):
+        ready = [sys.stdin]  # can't poll it; fall back to a direct read
+    if not ready:
+        logger.debug("stdin not readable within deadline; treating as empty")
+        return ""
+    return sys.stdin.read()
+
+
 def detect_input_mode(args):
     """Detect whether input is JSON or plain text."""
     import io
@@ -366,9 +405,14 @@ def detect_input_mode(args):
     if args.stdin_text:
         return "text"
 
-    # Auto-detect from stdin
+    # A prompt supplied on argv never needs stdin — skip the read entirely so
+    # `neo "query"` can't hang on a non-tty stdin that never sends EOF.
+    if getattr(args, "prompt", None) and args.prompt != "-":
+        return "text"
+
+    # Auto-detect from stdin (guarded so a never-EOF stdin can't hang us).
     if not sys.stdin.isatty():
-        buf = sys.stdin.read()
+        buf = _read_stdin_guarded()
         stripped = buf.lstrip()
         if stripped.startswith(("{", "[")):
             try:
@@ -391,7 +435,7 @@ def read_prompt_from_argv_or_stdin(args):
         return args.prompt
 
     if not sys.stdin.isatty():
-        return sys.stdin.read().strip()
+        return _read_stdin_guarded().strip()
 
     print("Error: No prompt provided. Use: neo \"your prompt\" or pipe via stdin", file=sys.stderr)
     sys.exit(2)
@@ -669,7 +713,7 @@ def main():
     # Parse input based on mode
     if input_mode == "json":
         try:
-            input_data = json.loads(sys.stdin.read())
+            input_data = json.loads(_read_stdin_guarded())
             working_dir = input_data.get("working_directory") or args.cwd or os.getcwd()
             neo_input = NeoInput(
                 prompt=input_data["prompt"],

--- a/tests/test_car_adapter.py
+++ b/tests/test_car_adapter.py
@@ -7,6 +7,7 @@ fake runtime injected via the constructor or via ``car_inference.set_runtime``.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -93,7 +94,8 @@ def test_generate_returns_text_field_from_infer_tracked():
     # Default IntentHint should request the code task so the router
     # picks a code-capable model instead of the chat default.
     assert "intent_json" in kwargs
-    assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
+    intent = json.loads(kwargs["intent_json"])
+    assert intent["task"] == "code" and intent["prefer_quality"] is True
 
 
 def test_default_intent_hint_is_code_task():
@@ -104,6 +106,27 @@ def test_default_intent_hint_is_code_task():
     adapter.generate("anything", max_tokens=8)
     _, kwargs = rt.calls[0]
     assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
+
+
+def test_sets_car_daemon_timeout_default_when_unset(monkeypatch):
+    """Large-context inference needs more than CAR's 30s FFI default, so neo
+    raises the floor — but only when the operator hasn't set it."""
+    monkeypatch.delenv("CAR_DAEMON_TIMEOUT", raising=False)
+    CarAdapter(runtime=FakeRuntime())
+    assert int(os.environ["CAR_DAEMON_TIMEOUT"]) >= 180
+
+
+def test_respects_operator_car_daemon_timeout(monkeypatch):
+    monkeypatch.setenv("CAR_DAEMON_TIMEOUT", "45")
+    CarAdapter(runtime=FakeRuntime())
+    assert os.environ["CAR_DAEMON_TIMEOUT"] == "45"  # not overridden
+
+
+def test_watchdog_default_exceeds_daemon_timeout():
+    """The AutoAdapter watchdog must sit above CAR's own read timeout so CAR's
+    clean timeout fires first; the watchdog only catches a true hang."""
+    import neo.adapters as A
+    assert A._CAR_CALL_TIMEOUT_S > A._CAR_DAEMON_TIMEOUT_DEFAULT_S
 
 
 def test_explicit_intent_hint_overrides_default():
@@ -130,7 +153,8 @@ def test_generate_string_prompt_skips_messages_json():
     assert prompt == "just a string prompt"
     assert "messages_json" not in kwargs
     # Default coding intent still applies on bare-string prompts.
-    assert json.loads(kwargs["intent_json"]) == {"task": "code", "prefer_quality": True}
+    intent = json.loads(kwargs["intent_json"])
+    assert intent["task"] == "code" and intent["prefer_quality"] is True
 
 
 def test_generate_pins_model_when_set():

--- a/tests/test_car_first.py
+++ b/tests/test_car_first.py
@@ -130,3 +130,34 @@ def test_autoadapter_fallback_built_lazily():
     a = AutoAdapter(car, lambda: built.append(1) or _FakeAdapter("fb"))
     a.generate([])                        # CAR ok -> fallback never constructed
     assert built == []
+
+
+class _HangingAdapter:
+    """A CAR adapter whose generate() blocks until released — models a dead
+    daemon leaving infer_tracked stuck on a socket read (no exception, ever)."""
+
+    def __init__(self):
+        self.release = __import__("threading").Event()
+        self.entered = __import__("threading").Event()
+
+    def generate(self, messages, **kw):
+        self.entered.set()
+        self.release.wait(30)             # blocks; test never releases in time
+        return "car"
+
+    def name(self):
+        return "car"
+
+
+def test_autoadapter_times_out_hang_and_falls_back():
+    # A *hang* (not an exception) must still trip the breaker. The error-only
+    # path never fires here — the watchdog deadline is what saves us.
+    car, fb = _HangingAdapter(), _FakeAdapter("fb")
+    a = AutoAdapter(car, lambda: fb, car_timeout=0.2)
+    assert a.generate([]) == "fb"         # CAR hangs -> deadline -> fallback
+    assert car.entered.is_set()           # we really did enter the CAR call
+    assert fb.calls == 1
+    # breaker is now open: next call goes straight to fallback, no new hang
+    assert a.generate([]) == "fb"
+    assert fb.calls == 2
+    car.release.set()                     # let the orphaned worker exit cleanly

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -1,0 +1,81 @@
+"""Tests for CLI stdin handling — must never block forever on a non-tty
+stdin that the peer holds open without data or EOF (the multi-hour-hang bug)."""
+
+import os
+import sys
+import time
+import types
+
+import neo.cli as cli
+
+
+def _args(**kw):
+    """Minimal args namespace for detect_input_mode / read_prompt_from_argv_or_stdin."""
+    base = {"stdin_json": False, "stdin_text": False, "prompt": None}
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+class _BlockingStdin:
+    """A real, open pipe with no data and the write end held open: read()
+    would block forever, select() reports it as not-ready. Models the
+    background-job / daemon stdin that caused the hang."""
+
+    def __init__(self):
+        self._r, self._w = os.pipe()           # write end stays open -> never EOF
+        self._f = os.fdopen(self._r, "r")
+
+    def fileno(self):
+        return self._f.fileno()
+
+    def read(self, *a):                         # would block; the guard must avoid calling it
+        return self._f.read(*a)
+
+    def isatty(self):
+        return False
+
+    def close(self):
+        self._f.close()
+        os.close(self._w)
+
+
+def test_guarded_read_does_not_hang_on_open_stdin(monkeypatch):
+    monkeypatch.setenv("NEO_STDIN_TIMEOUT_SECONDS", "0.3")
+    blocking = _BlockingStdin()
+    monkeypatch.setattr(sys, "stdin", blocking)
+    try:
+        start = time.monotonic()
+        out = cli._read_stdin_guarded()
+        elapsed = time.monotonic() - start
+        assert out == ""                        # treated as empty, not hung
+        assert elapsed < 5.0                     # returned promptly via the deadline
+    finally:
+        blocking.close()
+
+
+def test_guarded_read_returns_piped_data(monkeypatch):
+    r, w = os.pipe()
+    os.write(w, b"hello from a real pipe")
+    os.close(w)                                  # EOF available immediately
+    monkeypatch.setattr(sys, "stdin", os.fdopen(r, "r"))
+    assert cli._read_stdin_guarded() == "hello from a real pipe"
+
+
+def test_argv_prompt_never_reads_stdin(monkeypatch):
+    # `neo "query"` with a blocking non-tty stdin must NOT touch stdin.
+    blocking = _BlockingStdin()
+    monkeypatch.setattr(sys, "stdin", blocking)
+    try:
+        start = time.monotonic()
+        assert cli.detect_input_mode(_args(prompt="a real prompt")) == "text"
+        assert cli.read_prompt_from_argv_or_stdin(_args(prompt="a real prompt")) == "a real prompt"
+        assert time.monotonic() - start < 2.0    # no blocking read happened
+    finally:
+        blocking.close()
+
+
+def test_guarded_read_tolerates_stringio(monkeypatch):
+    # select() can't poll a StringIO (no fileno) — must fall back, not raise.
+    import io
+    monkeypatch.setattr(sys, "stdin", io.StringIO("inline text"))
+    assert cli._read_stdin_guarded() == "inline text"


### PR DESCRIPTION
## Description

Three fixes hardening neo's inference path, all surfaced while validating CAR-routed inference. The first two stop `neo` from hanging indefinitely; the third lets CAR actually complete neo's large-context calls.

**1. `fix(cli)`: guard the stdin read.** `detect_input_mode()` eagerly drained stdin (`sys.stdin.read()`, read-until-EOF) whenever stdin wasn't a tty — even when the prompt came from argv. Under a non-tty stdin held open without data/EOF (a background job, daemon, or mis-wired pipe) that read blocks forever. A native stack (`sample`) showed the main thread parked in `_io_FileIO_readall_impl → read()` on fd 0 (an open unix socket). **This was the actual cause of the observed multi-day hangs.**
- An argv prompt now skips stdin entirely (`neo "query"` — the common case, and the one that hung).
- When stdin really is the input, `_read_stdin_guarded()` `select()`s for readability with a deadline (`NEO_STDIN_TIMEOUT_SECONDS`, default 1.0s). Real pipes/redirects report ready instantly and are unaffected.

**2. `feat(adapters)`: bound CAR calls with a wall-clock deadline.** `AutoAdapter`'s breaker only tripped on *exceptions*, so it couldn't catch a *hang*. `car_runtime.infer_tracked` is a blocking FFI call; a daemon restarted mid-call can leave the client's socket read blocked forever. The call now runs in a daemon worker thread joined with a deadline (`NEO_CAR_TIMEOUT_SECONDS`, default **240s**); on timeout it raises, opening the breaker and failing over. Kept above the CAR FFI read timeout so CAR's own timeout fires first and the watchdog only catches a true hang.

**3. `feat(adapters)`: raise CAR's FFI read-timeout floor.** Neo's CAR calls carry a large multi-file context; a quality remote serving it legitimately takes **~140s** (measured via parslee on a 143 KB prompt), but CAR's per-call FFI read timeout defaults to **30s** — so those calls are cut off mid-inference and neo falls back every time. `CarAdapter` now raises `CAR_DAEMON_TIMEOUT` to 180s when the operator hasn't set it, letting CAR complete a large-context call once the router picks a capable model.
- *Why not exclude tiny models instead?* An earlier draft did; it was whack-a-mole (only the router's *choice* was wrong — fixed properly in **Parslee-ai/car#469**), and the 30s cutoff, not model size, was the real blocker. Routing quality is car#469's job; this makes neo's side tolerate the latency CAR legitimately needs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

A real `neo` invocation (validating `inference_mode=auto`) blocked for ~5 days at 0% CPU. `lsof` + `sample` traced it to a readall of fd 0 (an open unix-socket stdin), not CAR. Fixing that surfaced the CAR routing/timeout reality: the router preferred a slow local MLX over the working parslee remote (car#469), and even parslee needs >30s for a large context (this PR). Interactive terminal use was never affected (tty stdin → `isatty()` True → no read).

## How Has This Been Tested?

- [x] `tests/test_cli_stdin.py` (4): guarded read returns promptly on a never-EOF pipe; reads real piped data; argv prompt never touches stdin; tolerates a `StringIO` stdin.
- [x] `test_autoadapter_times_out_hang_and_falls_back`: a hang (not an exception) trips the breaker and falls back.
- [x] `tests/test_car_adapter.py`: sets `CAR_DAEMON_TIMEOUT` default when unset; respects an operator-set value; watchdog default exceeds the FFI timeout.
- [x] End-to-end: the fixed source CLI, run under the exact background-harness conditions that previously hung for days, completes a `--dry-run` in **2s**. With `CAR_DAEMON_TIMEOUT` raised, parslee served a 143 KB context in **140.6s** with a correct answer (30s → cut off).
- [x] `test_car_adapter.py test_car_first.py test_cli_stdin.py test_cli_global_flags.py` → 52 passed, 4 skipped.

**Test Configuration**:
- Python version: 3.14.5
- OS: macOS (darwin 25.5)
- Neo version: 0.31.1

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fixes are effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`NEO_STDIN_TIMEOUT_SECONDS` (1.0s), `NEO_CAR_TIMEOUT_SECONDS` (240s), and `CAR_DAEMON_TIMEOUT` (180s default) are overridable. Pairs with the CAR router fix **Parslee-ai/car#469**. `inference_mode` stays `auto` (CAR-first, OpenAI fallback). No version bump — leaving release prep to `/ship-release`.
