### PR TITLE
Release v0.34.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.31.1",
+  "version": "0.34.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.34.0] - 2026-07-01
+
+### Fixed
+
+- **`neo` can no longer hang forever on a non-tty stdin.** `detect_input_mode()` eagerly drained stdin (`sys.stdin.read()`, a read-until-EOF) whenever stdin wasn't a tty — even when the prompt was supplied on argv. Launched with a non-tty stdin that the peer holds open without data or EOF (a background job, a daemon, a mis-wired subprocess pipe), that read blocks indefinitely; a native stack trace caught the main thread parked in `_io_FileIO_readall_impl → read()` on fd 0 (an open unix socket). An argv prompt now skips the stdin read entirely (`neo "query"` — the common case, and the one that hung), and when stdin genuinely is the input, `_read_stdin_guarded()` `select()`s for readability with a deadline (`NEO_STDIN_TIMEOUT_SECONDS`, default 1.0s) before reading, treating a never-EOF stdin as empty rather than hanging. Real pipes and redirects report ready immediately and are unaffected; interactive terminal use was never affected (tty stdin → the read was already skipped). (`cli.py`)
+
+### Added
+
+- **CAR inference calls are now bounded and large-context calls are given room to finish.** Two complementary changes to `AutoAdapter`/`CarAdapter`: (1) a wall-clock watchdog around each CAR call (`NEO_CAR_TIMEOUT_SECONDS`, default 240s) — `car_runtime.infer_tracked` is a blocking FFI call, and a daemon restarted mid-call could leave the client's socket read blocked forever with the breaker's exception-only path unable to catch it; the call now runs in a daemon worker thread joined with a deadline, so a hang trips the breaker and fails over to the static provider. (2) `CarAdapter` raises CAR's per-call FFI read-timeout floor (`CAR_DAEMON_TIMEOUT`, default 180s, only when the operator hasn't set it) — a quality remote serving neo's large multi-file context legitimately takes ~140s, but CAR's 30s default cut those calls off mid-inference and forced a fallback every time. The watchdog sits above the FFI timeout so CAR's own clean timeout fires first and the watchdog only catches a true hang. (`adapters.py`)
+
 ## [0.33.0] - 2026-06-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.33.0"
+version = "0.34.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Release v0.34.0

Bumps version to 0.34.0 and updates the changelog. Ships the inference-hardening work merged in #127.

### Fixed
- **`neo` can no longer hang forever on a non-tty stdin** — `detect_input_mode()` no longer eagerly drains stdin; an argv prompt skips it, and a genuine stdin read is `select()`-guarded (`NEO_STDIN_TIMEOUT_SECONDS`). This was the root cause of the observed multi-day hangs.

### Added
- **CAR inference calls are bounded and large-context calls given room to finish** — a wall-clock watchdog around each CAR call (`NEO_CAR_TIMEOUT_SECONDS`, 240s) so a hang trips the breaker → fallback, and a raised `CAR_DAEMON_TIMEOUT` floor (180s) so a quality remote's ~140s large-context inference isn't cut off at CAR's 30s default.

### Version bump
- `pyproject.toml`, `src/neo/__init__.py`: 0.33.0 → 0.34.0
- `.claude-plugin/plugin.json`: 0.31.1 → 0.34.0 (was stale — missed in the 0.32/0.33 bumps)

Merging this triggers the tag + GitHub release + PyPI publish.