### PR TITLE
feat: tiered reasoning — CAR-gated multi-agent deliberation (A/B: +1.12 quality)

### DIFF
--- a/docs/solutions/tiered-reasoning-multi-agent.md
+++ b/docs/solutions/tiered-reasoning-multi-agent.md
@@ -1,0 +1,324 @@
+# Solution: Tiered Reasoning — CAR-Gated Multi-Agent Deliberation with Memory Amortization
+
+**Date**: 2026-07-04
+**Status**: Implemented (L1–L3 reasoning tier + gate + memory provenance; L4 execution deferred)
+**Type**: design + implementation
+
+## Implementation summary
+
+| Piece | Module | Tests |
+|---|---|---|
+| Novelty→mode gate | `reasoning_mode.py` (`decide_mode`) | `test_reasoning_mode.py` |
+| Panel orchestrator (plan-vote → code → adversarial critique → repair) | `multi_agent.py` (`MultiAgentReasoner`) | `test_multi_agent.py` |
+| Model-diversity planning (`route_model` + `exclude_models`) | `panel.py` | `test_panel.py` |
+| Engine wiring (gate + branch + provenance metadata) | `engine.py` (`_decide_reasoning_mode`, `_deliberate`) | `test_engine_reasoning.py` |
+| Config + CLI | `config.py` (`reasoning_mode`), `cli.py` (`--deep`/`--fast`) | — |
+| A/B quality harness | `tools/ab_reasoning.py` | (see A/B result below) |
+
+The gate stays **auto** by default; multi-agent fires only on novelty **and**
+CAR-reachable **and** ≥2 distinct capable models — otherwise the fast single
+call runs (a failed panel also falls back). Output `metadata` always carries
+`reasoning_mode` + `reasoning_reason`, and panel runs add `provenance` +
+`panel` (models_used, consensus, rounds).
+
+## A/B result — does the panel actually produce better quality?
+
+`tools/ab_reasoning.py`: 8 self-contained coding tasks, each solved two ways —
+one-shot combined call (A) vs the panel (B) — then scored by a blind LLM judge
+(order randomized per task). gpt-5.5, `effort=low`, `k_plans=2`,
+`max_repair_rounds=1`.
+
+| Metric | Value |
+|---|---|
+| Avg judge score — **panel** | **9.25 / 10** |
+| Avg judge score — single | 8.12 / 10 |
+| **Quality delta** | **+1.12** |
+| Wins: panel / single / tie | 3 / 1 / 4 |
+| Decisive win rate (panel) | **3 of 4 (0.75)** |
+| Latency: panel vs single | 44.7s vs 8.4s (~5.3×) |
+
+The panel's wins were on the **edge-case-heavy** tasks — dedup-a-list-of-dicts
+(8 vs 4: the critic caught unhashable dicts), semver parsing (10 vs 7), debounce
+(9 vs 6) — exactly where an adversarial second pass earns its keep. Its one loss
+was the trivial "merge two sorted lists," where a one-shot answer is already
+optimal and the extra machinery only added noise. **This reinforces the gate**:
+the panel is worth ~5× the latency *on hard/novel work* and wasteful on easy
+work — which is precisely what the novelty gate reserves it for.
+
+**Honest scope of this measurement:** all four roles used the *same* model
+(gpt-5.5) — so this isolates the value of the **orchestration structure** (plan
+vote → adversarial critique → repair) with **zero model diversity**. Real
+deployment adds distinct models per role (§4), which should widen the gap
+further, but that lift is *not* measured here (it needs ≥2 fast capable models
+wired up). Raw results: `/tmp/ab_low.json`.
+
+## Problem
+
+Neo is described as "MapCoder/CodeSim-style multi-agent reasoning," but the
+implementation collapses all three roles (plan → simulate → code) into a
+**single LLM call** (`engine.py:_process_combined`, the comment: *"Single LLM
+call for all 3 phases … 59% faster than the old 3-call approach (22s vs 55s)"*).
+There was a real 3-call path once; it was deliberately flattened for speed.
+
+Consequences of the flattening:
+
+- **No inter-agent loop.** `engine.py` calls itself a *"single-shot engine."*
+  Real MapCoder/CodeSim iterate (plan → code → verify → repair). Neo does not.
+  Its `repair_loop.py` only repairs *malformed JSON*, not failing code.
+- **"Simulation" is self-narration.** `simulation_traces` are the model
+  describing how its plan *would* run — never executed. The engine itself
+  distrusts this (`"LM self-reported confidence alone is self-validation"`) and
+  bolts on static checks as the only *objective* signal before early-exit.
+- **One model plays every role**, so the three "agents" share weights and
+  therefore share blind spots — the critic can't catch what the planner missed.
+
+The goal is a *real* multi-agent tier that adds genuine, uncorrelated scrutiny —
+**without** paying its cost on every query, and **without** requiring CAR (neo
+must keep working standalone).
+
+## Core idea: two tiers, one memory
+
+```
+                      novelty signal (from memory)
+                                 │
+              familiar/confident │ novel / low-confidence / --deep
+                    ┌────────────┴─────────────┐
+                    ▼                           ▼
+            FAST TIER (default)          DELIBERATION TIER (CAR only)
+      single call + recalled memory   multi-agent panel: distinct models,
+        (today's optimized path)       plan-vote → code → adversarial critique,
+                    │                   repair loop, consensus confidence
+                    │                           │
+                    │                validated outcome → memory (provenance-tagged)
+                    └───────────────────────────┘
+                        both write/read the SAME fact store
+```
+
+**Deliberate once, recall forever.** The expensive tier runs where memory is
+empty (novel issues), and its *job* is to manufacture the high-quality memory
+that lets the fast tier be trusted on the *next* similar issue. The tiers feed
+each other rather than compete.
+
+## Design
+
+### 1. The gate already exists — promote it from a dimmer to a switch
+
+`reasoning_effort.effort_from_memory()` already maps a `MemorySignal`
+(`pattern_count`, `avg_confidence`) to an effort level:
+
+| Memory signal | today (effort) | proposed (mode) |
+|---|---|---|
+| ≥3 patterns, conf ≥ 0.8 | `low` | **fast recall** |
+| some patterns, conf 0.5–0.8 | `medium` | fast |
+| no patterns OR conf < 0.5 | `high` | **deliberation** |
+| no patterns AND hard | `xhigh` | **deliberation, full** |
+
+"No patterns" is neo's existing definition of *novel*. The change is to let the
+top two rungs select a **mode** (deliberate) rather than only a bigger token
+budget on the same single call. The bottom rungs are unchanged — already primed
+by recalled patterns.
+
+Three triggers, not one:
+
+- **A priori** — gate on the novelty signal before running (main path).
+- **Runtime escalation** — `reasoning_effort.escalate()` already exists
+  (*"we know cheap-thinking failed, spend more"*). If the fast path trips a
+  check (static analysis, low simulation consensus), escalate *into* the
+  deliberation tier. This covers novelty the a-priori gate misclassifies.
+- **Explicit override** — `--deep` always deliberates (and refreshes memory);
+  `--fast` always takes the cheap path.
+
+### 2. The deliberation tier is CAR-only — on the merits, not just packaging
+
+Neo installs and runs **without** CAR (static provider path via
+`resolve_adapter`). The multi-agent tier is offered **only when CAR is
+reachable**, reusing the exact check `resolve_adapter` already makes
+(`car_inference.is_available() and a2ui.is_daemon_reachable()`).
+
+This is not a licensing quirk — it is *where the technique earns its cost*. The
+value of a multi-agent panel is **model diversity**: different models with
+different blind spots disagreeing and ranking each other. Without CAR's router
+there is one configured provider, so "multi-agent" degrades to **one model
+playing every role** — correlated errors, 5–15× the latency to re-confirm the
+model's own blind spots. That is the self-validation weakness, more expensive.
+
+Graceful degradation:
+
+- **No CAR** → the novelty signal still fires; it just resolves to today's
+  behavior (`high`/`xhigh` effort on the single call). Nothing regresses.
+- **`--deep` without CAR** → warn and degrade to a max-effort single pass, don't
+  error.
+- **Shared memory across tiers.** The fast path doesn't care how a pattern was
+  born. So **CAR sessions teach memories that non-CAR sessions recall**: same
+  `project_id`, same fact store — deliberated patterns deposited during a
+  CAR-enabled session are recalled later on a machine with no daemon.
+
+### 3. What the tier actually *is* — reasoning, not execution
+
+CAR already ships the orchestration; neo uses none of it for reasoning (its only
+`agents_*` use today is registering the memory-observer sweep). Every CAR
+`run_*` primitive takes an `agent_fn` callback — **you supply the model call,
+CAR runs the pattern**:
+
+| Need | CAR primitive |
+|---|---|
+| Generate *k* plans, rank/pick best | `run_vote` / `run_tournament` |
+| Plan → code → verify stages | `run_pipeline` |
+| Debug / repair feedback loop | `run_supervisor(max_rounds)` / `run_task_loop` |
+| Per-role model choice | adaptive router via per-agent `intent` |
+
+**Execution is NOT the core** — a correction worth recording. A container gives
+you a filesystem + runtime, not an *environment*. Most real code needs
+databases with seed data, external/internal APIs, auth, secrets, and network —
+none of which a sandbox conjures, and CAR's sandbox is network-gated on purpose
+(car#480). Neo, being read-only and credential-less, is the *least* equipped
+caller to stand up a live environment.
+
+MapCoder/CodeSim's execution loop works because their domain is **self-contained
+algorithmic problems** (HumanEval/MBPP/CodeContests) with standalone tests. Neo
+lifted the framing onto real repos, where that assumption collapses. So
+execution-grounded verification is an **opportunistic add-on** that only fires
+when neo detects a genuinely self-contained unit (a pure function, a generated
+minimal repro) — worth doing, but a corner case, not the headline. The headline
+is *diverse, adversarial reasoning*: plan-vote, cross-model critique, and a
+model-judged repair loop, all of which run without any environment.
+
+### 4. Ensuring distinct models per agent (the crux)
+
+CAR's router optimizes **per-request fitness** ("best capable model for *this*
+intent") and has no cross-request "make these N distinct" awareness — and
+`run_vote` runs the same `agent_fn` for everyone. So identical intents →
+**same model N times**, the exact failure to avoid. Diversity must be
+engineered by the caller; CAR provides the primitive built for it.
+
+**Division of labor:**
+
+- **neo owns the diversity policy** — it names *roles*, their *capability
+  intents*, and the *distinctness constraint*. It never hardcodes model IDs; it
+  says "reasoning + quality," "code," "not that one." Catalog-agnostic, so new
+  models auto-participate.
+- **CAR owns capability-honest selection** — `task=code` → code-capable model,
+  `require=[Reasoning]` → reasoning-capable (guaranteed by the router's
+  Quality-workload / capability filter, car#469), honors `exclude_models`, and
+  reports its work.
+
+**The primitives** (both on `CarRuntime.route_model`, which is *decision-only —
+no inference*, so it's cheap to ask up front):
+
+- `exclude_models` — IntentHint field, documented as *"any capable model that is
+  NOT this one — for adversarial-reviewer separation (car#358)."* Purpose-built.
+- `route_model(...)` returns `candidates`: the full ranking of scored models
+  (`{model_id, reliability, score, selected, in_band}`), so neo can see the
+  whole capable pool and *what forcing a different model costs*.
+
+**Flow** — a cheap "routing plan" pass first, then execute (parallelizable):
+
+```
+route(planner: task=reasoning, prefer_quality)          -> model A (+candidates)
+route(coder:   task=code,      prefer_quality)          -> model B
+route(critic:  task=reasoning, prefer_quality,
+               exclude_models=[B])                       -> model C  (≠ coder)
+route(judge:   task=classify,  prefer_fast)             -> model D  (small/cheap)
+```
+
+neo reads model IDs only transiently, to thread the next role's
+`exclude_models` — it stays catalog-agnostic.
+
+**Diversity is capped by the pool, and that becomes the real gate.** If only one
+capable frontier model is wired up (e.g. only `parslee/gpt-5.5`, no
+Anthropic/Google creds), `exclude_models` on the critic leaves nothing capable.
+`candidates` reveals this *before* committing. So the deliberation trigger is
+not merely *CAR reachable* but **CAR reachable AND ≥2 genuinely capable,
+distinct models available**. Below that, neo degrades (single high-effort call,
+or a same-model adversarial self-check) — it only pays for a "diverse panel"
+when the diversity actually exists.
+
+### 5. Memory amortization — feed the existing REVIEW→PATTERN pipeline
+
+The "remember it so you don't redo it" loop is neo's *existing* synthesis
+pipeline, just fed by a better source:
+
+```
+novel issue → deliberation → validated outcome
+   → stored as a fact (provenance: multi-agent-validated)
+   → synthesis clusters recurring ones → PATTERN
+   → next similar issue: retrieval surfaces it
+   → pattern_count≥3, conf≥0.8 → fast path, no agents
+```
+
+Deliberated outcomes enter through neo's **existing probation + outcome
+mechanism** (`memory.outcomes`, `store.detect_implicit_feedback`) — they are
+**not auto-trusted**. Their initial confidence should come from the panel's own
+**consensus** (vote/tournament agreement), which is a far better signal than a
+single model's self-report; real outcomes (ACCEPTED/MODIFIED) then promote or
+demote them.
+
+### 6. Guardrails
+
+- **Novelty's asymmetric risk.** *False-novel* (deliberate when memory would
+  have sufficed) = wasted time/money — safe. *False-familiar* (skip when you
+  shouldn't) = a confident wrong answer from a mismatched pattern — dangerous.
+  Tune the gate to prefer deliberation under ambiguity; require a recalled
+  pattern to *actually match* (high similarity **and** same issue-kind/domain,
+  not just nearby in vector space); treat "no strong match" as novel. Runtime
+  escalation (§1) is the net for residual false-familiar cases.
+- **Memory poisoning.** A wrong deliberation stored as high-confidence corrupts
+  every future recall. Mitigated by probation + consensus-as-confidence +
+  verify-before-promote (static checks / type-check must pass).
+- **Ossification.** Patterns rot as code changes. Lean on `recall_decay` +
+  probation staleness, and occasionally re-deliberate on a "seen" issue (when
+  its recalled confidence has decayed, or at a low sampling rate).
+- **One line to hold:** don't build a pure-Python "multi-agent lite" over the
+  single configured provider for standalone neo — it re-creates correlated
+  errors and adds a second orchestration codepath. Standalone = single-call +
+  memory; deliberation = CAR-only. (A single-model *adversarial self-check* —
+  generate, then a fresh context prompted to "find the flaw" — is the one
+  cheap, no-CAR pattern worth considering, as a separate small feature.)
+
+## Build levels (each shippable, flag-gated behind `reasoning_mode`)
+
+- **L1 — Restore the 3 calls.** `_generate_plan` / `_simulate_plan` /
+  `_generate_code_suggestions` still exist (dormant). Sequence them. No CAR.
+  Modest gain, ~2.5× latency. Mostly a stepping stone.
+- **L2 — Real planning.** `run_vote`/`run_tournament` over *k* candidate plans
+  with distinct models (§4). This is MapCoder's core that neo discarded. CAR-only.
+- **L3 — Repair loop.** `run_supervisor`/`run_task_loop`: critic critiques,
+  coder repairs, iterate to budget; verifier = strong model + static/type checks
+  (things that run without infra). CAR-only.
+- **L4 — Opportunistic execution.** Only when a self-contained unit is detected:
+  run it in `car-sandbox`, feed real results into the L3 loop. Narrow; not the
+  headline.
+
+The reusable core is a single **`agent_fn` bridge** (neo adapter ↔ CAR's
+`(role, task) → str`, setting per-role intent + exclusions); all `run_*`
+patterns compose over it.
+
+## Open questions / to verify before committing
+
+- **Novelty-match reliability** is the make-or-break research risk — the whole
+  scheme's safety rests on rarely mistaking "looks similar" for "same fix
+  applies." Needs measurement on real recall, not assumed.
+- **Does `car-sandbox` run an arbitrary repo snapshot + its test command**, or
+  only the `car-reason` Python-snippet verifier? This sets L4 at "wire an
+  existing primitive" vs "extend car-sandbox."
+- **Pattern granularity.** Recall generalizes only if PATTERNs are keyed on
+  *issue-kind*, not exact code — a synthesis-clustering quality question.
+
+## Non-goals / decisions
+
+- The fast single-call + memory path stays the **default**. Deliberation is
+  opt-in via novelty/escalation/`--deep`.
+- Neo stays **catalog-agnostic**: it expresses capability intent + "not this
+  one," never pins model IDs (except transiently, read back from `route_model`).
+- Execution is **not** assumed available; verification leans on model consensus
+  + static analysis, with sandboxed execution as a detected-when-possible bonus.
+
+## Related
+
+- `docs/solutions/token-budget-enforcement.md` — context assembly the fast tier
+  relies on.
+- CAR router: `car#469` (Quality-workload capability filter),
+  `car#358` (`exclude_models` for adversarial-reviewer separation).
+- `reasoning_effort.py` (`MemorySignal`, `effort_from_memory`, `escalate`),
+  `engine.py` (`_process_combined` + dormant per-phase methods),
+  `memory/outcomes.py`, `store.detect_implicit_feedback` (probation/outcomes).

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -67,6 +67,8 @@ def parse_args():
     global_parser.add_argument('--cwd', metavar='PATH', help='Working directory override')
     global_parser.add_argument('--verbose', action='store_true', help='Enable verbose logging (INFO level) to stderr')
     global_parser.add_argument('--debug', action='store_true', help='Enable debug logging (DEBUG level) to stderr')
+    global_parser.add_argument('--deep', action='store_true', help='Force multi-agent deliberation (needs CAR + a diverse model pool; degrades to a high-effort single pass otherwise)')
+    global_parser.add_argument('--fast', action='store_true', help='Force the fast single-call path (skip multi-agent deliberation)')
 
     # Detect if 'contribute' subcommand is being used
     if len(sys.argv) > 1 and sys.argv[1] == 'contribute':
@@ -810,6 +812,12 @@ def main():
     try:
         # Load config to get API key
         config = NeoConfig.load()
+
+        # CLI reasoning-tier overrides (--deep / --fast beat config).
+        if getattr(args, "deep", False):
+            config.reasoning_mode = "deep"
+        elif getattr(args, "fast", False):
+            config.reasoning_mode = "fast"
 
         # Upgrade log level from config if no CLI flag was set
         if not getattr(args, "debug", False) and not getattr(args, "verbose", False):

--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -106,6 +106,12 @@ class NeoConfig:
     # measured regression. Flip to "auto" once a verified CAR build is deployed.
     inference_mode: str = "static"
 
+    # Reasoning tier: "auto" gates multi-agent deliberation on novelty + CAR +
+    # a diverse model pool (docs/solutions/tiered-reasoning-multi-agent.md);
+    # "fast" forces the single-call path; "deep" forces deliberation (degrades to
+    # a high-effort single pass when CAR / a diverse pool isn't available).
+    reasoning_mode: str = "auto"  # "auto" | "fast" | "deep"
+
     # Generation settings
     default_temperature: float = 0.7
     default_max_tokens: int = 4096

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -241,10 +241,34 @@ class NeoEngine:
                 for c in extracted_constraints
             ]
 
-        # Single LLM call for all 3 phases (plan + simulation + code)
-        # This is 59% faster than the old 3-call approach (22s vs 55s)
-        self._log_action("lm_call", neo_input.prompt[:60])
-        plan, simulation_traces, code_suggestions = self._process_combined(enriched_context)
+        # Decide the reasoning tier. Default: a single combined call (fast,
+        # memory-primed). Novel queries with CAR + a diverse model pool escalate
+        # to multi-agent deliberation. See
+        # docs/solutions/tiered-reasoning-multi-agent.md.
+        from neo.reasoning_mode import ReasoningMode
+        self.last_deliberation = None
+        decision, route_fn = self._decide_reasoning_mode(enriched_context, difficulty, neo_input)
+        self.last_reasoning_mode = decision.mode.value
+        self.last_reasoning_reason = decision.reason
+        logger.info("Reasoning mode: %s — %s", decision.mode.value, decision.reason)
+
+        plan = simulation_traces = code_suggestions = None
+        if decision.mode is ReasoningMode.MULTI_AGENT:
+            self._log_action("deliberate", neo_input.prompt[:60])
+            plan, simulation_traces, code_suggestions, deliberation = self._deliberate(
+                enriched_context, route_fn
+            )
+            if deliberation is not None and deliberation.confidence > 0.0 and code_suggestions:
+                self.last_deliberation = deliberation
+            else:
+                logger.warning("Deliberation yielded no usable result; falling back to fast path")
+                self.last_reasoning_mode = "fast"  # honest metadata: we fell back
+                plan = None
+
+        if plan is None:
+            # Fast path (default, or fallback from a failed panel).
+            self._log_action("lm_call", neo_input.prompt[:60])
+            plan, simulation_traces, code_suggestions = self._process_combined(enriched_context)
         self.last_simulation_traces = simulation_traces
 
         # Phase 5: Run static checks BEFORE deciding early-exit.
@@ -360,6 +384,20 @@ class NeoEngine:
         self._log_metrics(difficulty, time_budget, elapsed, early_exit=early_exit)
 
         metadata: dict[str, Any] = {"early_exit": early_exit} if early_exit else {}
+        # Reasoning-tier provenance — always explainable which path ran and why.
+        metadata["reasoning_mode"] = getattr(self, "last_reasoning_mode", "fast")
+        reason = getattr(self, "last_reasoning_reason", "")
+        if reason:
+            metadata["reasoning_reason"] = reason
+        deliberation = getattr(self, "last_deliberation", None)
+        if deliberation is not None:
+            metadata["provenance"] = deliberation.provenance
+            metadata["panel"] = {
+                "consensus": round(deliberation.consensus, 3),
+                "rounds": deliberation.rounds,
+                "models_used": deliberation.models_used,
+                **deliberation.meta,
+            }
         if extra_metadata:
             metadata.update(extra_metadata)
 
@@ -778,6 +816,97 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
         except ValueError:
             # Block not found - return empty (parser will fail gracefully)
             return ""
+
+    # ------------------------------------------------------------------
+    # Tiered reasoning: fast single call vs multi-agent deliberation.
+    # docs/solutions/tiered-reasoning-multi-agent.md
+    # ------------------------------------------------------------------
+
+    def _compute_memory_signal(self, context: dict[str, Any]):
+        """Novelty signal (pattern_count / avg_confidence) from retrieval — the
+        same signal ``_format_combined_prompt`` uses, surfaced early to gate the
+        reasoning tier."""
+        from neo.reasoning_effort import MemorySignal, signal_from_facts
+        if self.fact_store is not None:
+            try:
+                prompt_text = context.get("prompt", "")
+                k = self._adaptive_k_selection(prompt_text, context)
+                fc = self.fact_store.build_context(prompt_text, environment=context, k=k)
+                return signal_from_facts(fc.valid_facts)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("memory signal computation failed: %s", e)
+        return MemorySignal()
+
+    def _car_route_capability(self, prompt: str):
+        """(car_available, capable_model_count, route_fn|None). Multi-agent needs
+        CAR reachable AND a diverse pool; ``route_model`` (decision-only) reports
+        the pool via its ``candidates`` ranking."""
+        try:
+            from neo.a2ui import is_daemon_reachable
+            from neo.car_inference import is_available as car_available, get_runtime
+        except Exception:
+            return False, 0, None
+        try:
+            if not (car_available() and is_daemon_reachable()):
+                return False, 0, None
+            runtime = get_runtime()
+            route_model = getattr(runtime, "route_model", None)
+            if not callable(route_model):
+                return True, 0, None
+            route_fn = lambda p, intent_json: route_model(p, intent_json)  # noqa: E731
+            from neo.panel import capable_model_count
+            return True, capable_model_count(route_fn, probe=(prompt[:200] or "code task")), route_fn
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("CAR route capability check failed: %s", e)
+            return False, 0, None
+
+    def _decide_reasoning_mode(self, context: dict[str, Any], difficulty: str, neo_input):
+        """Gate: fast vs multi-agent. Returns (ModeDecision, route_fn|None)."""
+        from neo.reasoning_mode import decide_mode
+        signal = self._compute_memory_signal(context)
+        explicit = (getattr(self.config, "reasoning_mode", "auto") if self.config else "auto") or "auto"
+        explicit = None if explicit.lower() == "auto" else explicit.lower()
+        car_available, model_count, route_fn = self._car_route_capability(context.get("prompt", ""))
+        decision = decide_mode(
+            signal, difficulty=difficulty,
+            car_available=car_available, capable_model_count=model_count, explicit=explicit,
+        )
+        return decision, route_fn
+
+    def _build_car_role_factory(self, route_fn, prompt: str):
+        """role_adapter(role) → a distinct CAR-pinned adapter per role (planner /
+        coder / critic / judge), falling back to ``self.lm``. Diversity comes from
+        the routing plan (``plan_role_models`` threads exclude_models)."""
+        fallback = self.lm
+        if route_fn is None:
+            return lambda role: fallback
+        from neo.panel import plan_role_models, build_role_factory
+        try:
+            role_models = plan_role_models(route_fn, prompt[:500])
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("role model planning failed: %s", e)
+            role_models = {}
+        from neo.adapters import create_adapter
+        return build_role_factory(role_models, lambda m: create_adapter("car", model=m), fallback)
+
+    def _deliberate(self, context: dict[str, Any], route_fn):
+        """Run the multi-agent panel. Returns (plan, sims, code, DeliberationResult|None)."""
+        from neo.multi_agent import MultiAgentReasoner
+        prompt = context.get("prompt", "")
+        ctx_str = ""
+        for key in ("past_learnings", "verifiable_constraints"):
+            v = context.get(key)
+            if v:
+                ctx_str += (str(v)[:2000] + "\n\n")
+        role_factory = self._build_car_role_factory(route_fn, prompt)
+        try:
+            result = MultiAgentReasoner(role_factory, k_plans=3, max_repair_rounds=1).deliberate(
+                prompt, context=ctx_str.strip()[:6000]
+            )
+        except Exception as e:
+            logger.warning("deliberation failed: %s", e)
+            return None, None, None, None
+        return result.plan, result.simulation_traces, result.code_suggestions, result
 
     def _format_combined_prompt(self, context: dict[str, Any]) -> tuple[str, "MemorySignal"]:
         """Format the combined prompt and return it alongside the memory signal.

--- a/src/neo/multi_agent.py
+++ b/src/neo/multi_agent.py
@@ -1,0 +1,295 @@
+"""Multi-agent deliberation tier.
+
+A real (non-simulated) reasoning panel: generate *k* candidate plans with
+diverse models, judge/rank them, code the winner, have an adversarial critic
+(a *distinct* model) review it, and repair on failure — a genuine
+plan → vote → code → critique → repair loop.
+
+Design: ``docs/solutions/tiered-reasoning-multi-agent.md``. This module owns only
+the *orchestration*; model diversity is injected via ``role_adapter`` (the
+caller maps each role to a distinct CAR-routed model). It is deliberately
+self-contained (no engine internals) so it's unit-testable with fake adapters
+and callable from ``NeoEngine`` for the deliberation path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from neo.models import CodeSuggestion, PlanStep, SimulationTrace
+
+logger = logging.getLogger(__name__)
+
+#: Roles the orchestrator asks the ``role_adapter`` factory for. The factory is
+#: responsible for handing back *distinct* models where possible (critic ≠ coder).
+ROLES = ("planner", "judge", "coder", "critic")
+
+
+@dataclass
+class DeliberationResult:
+    """Output of a panel run, shaped to slot into the engine's tuple."""
+
+    plan: list[PlanStep]
+    simulation_traces: list[SimulationTrace]
+    code_suggestions: list[CodeSuggestion]
+    confidence: float
+    consensus: float                       # panel agreement signal [0,1]
+    rounds: int                            # repair rounds run
+    provenance: str = "multi-agent"
+    models_used: dict[str, str] = field(default_factory=dict)
+    meta: dict = field(default_factory=dict)
+
+    def as_engine_tuple(self):
+        """(plan, simulation_traces, code_suggestions) — matches ``_process_combined``."""
+        return self.plan, self.simulation_traces, self.code_suggestions
+
+
+def _extract_json(text: str) -> Optional[dict]:
+    """Leniently pull the first JSON object out of an LLM response (tolerates
+    ```json fences and prose around it)."""
+    if not text:
+        return None
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    candidate = fenced.group(1) if fenced else None
+    if candidate is None:
+        start = text.find("{")
+        end = text.rfind("}")
+        candidate = text[start : end + 1] if 0 <= start < end else None
+    if candidate is None:
+        return None
+    try:
+        obj = json.loads(candidate)
+        return obj if isinstance(obj, dict) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _clamp(x: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    try:
+        return max(lo, min(hi, float(x)))
+    except (TypeError, ValueError):
+        return lo
+
+
+class MultiAgentReasoner:
+    """Orchestrates a plan-vote → code → critique → repair panel.
+
+    ``role_adapter(role)`` returns an object with
+    ``generate(messages, max_tokens=..., temperature=...) -> str`` (neo's
+    ``LMAdapter``). It may return a *different* model per role — that diversity is
+    the whole point and is the caller's responsibility (see
+    ``engine``'s CAR-routed factory).
+    """
+
+    def __init__(
+        self,
+        role_adapter: Callable[[str], object],
+        *,
+        k_plans: int = 3,
+        max_repair_rounds: int = 1,
+        max_tokens: int = 8000,  # reasoning models (gpt-5*) spend output on hidden
+                                 # reasoning; give the visible answer real headroom
+    ):
+        self._role_adapter = role_adapter
+        self.k_plans = max(1, k_plans)
+        self.max_repair_rounds = max(0, max_repair_rounds)
+        self.max_tokens = max_tokens
+        self._models_used: dict[str, str] = {}
+
+    # -- LLM plumbing ------------------------------------------------------
+
+    def _call(self, role: str, system: str, user: str, *, temperature: float = 0.7) -> str:
+        adapter = self._role_adapter(role)
+        name = getattr(adapter, "name", lambda: role)
+        try:
+            self._models_used[role] = name() if callable(name) else str(name)
+        except Exception:  # pragma: no cover - name() is best-effort
+            self._models_used[role] = role
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+        return adapter.generate(messages, max_tokens=self.max_tokens, temperature=temperature) or ""
+
+    # -- phases ------------------------------------------------------------
+
+    def _generate_plans(self, prompt: str, context: str) -> list[dict]:
+        system = (
+            "You are a senior engineer producing a concise solution PLAN (not code). "
+            "Respond ONLY with JSON: "
+            '{"approach": str, "steps": [{"description": str, "rationale": str, '
+            '"risk": "low"|"medium"|"high"}], "key_risks": [str]}'
+        )
+        plans: list[dict] = []
+        for i in range(self.k_plans):
+            # Vary temperature across candidates to spread the search even when
+            # the pool can't give fully distinct models.
+            temp = 0.4 + 0.25 * i
+            raw = self._call("planner", system, self._task_block(prompt, context), temperature=temp)
+            obj = _extract_json(raw)
+            if obj and obj.get("steps"):
+                plans.append(obj)
+        return plans
+
+    def _judge_plans(self, prompt: str, plans: list[dict]) -> tuple[int, float]:
+        """Return (winning index, consensus in [0,1]). Consensus is how clearly
+        one plan beat the field — a low value means the panel disagreed, which
+        we surface as lower final confidence."""
+        if len(plans) == 1:
+            return 0, 0.5
+        listing = "\n\n".join(
+            f"PLAN {i}: approach={p.get('approach','')!r}\nsteps="
+            + "; ".join(s.get("description", "") for s in p.get("steps", []))
+            for i, p in enumerate(plans)
+        )
+        system = (
+            "You are a critical reviewer choosing the best plan. Respond ONLY with JSON: "
+            '{"winner": int, "confidence": 0.0-1.0, "why": str}. '
+            "confidence = how clearly the winner beats the others (0.5 = a coin flip)."
+        )
+        raw = self._call("judge", system, f"Task:\n{prompt}\n\nCandidates:\n{listing}", temperature=0.2)
+        obj = _extract_json(raw) or {}
+        idx = obj.get("winner", 0)
+        if not isinstance(idx, int) or not (0 <= idx < len(plans)):
+            idx = 0
+        return idx, _clamp(obj.get("confidence", 0.5))
+
+    def _generate_code(self, prompt: str, context: str, plan: dict) -> dict:
+        system = (
+            "You are a senior engineer. Implement the given PLAN. Respond ONLY with JSON: "
+            '{"code": str, "explanation": str, "edge_cases": [str], "confidence": 0.0-1.0, '
+            '"file_path": str}'
+        )
+        user = f"{self._task_block(prompt, context)}\n\nPLAN:\n{json.dumps(plan)}"
+        return _extract_json(self._call("coder", system, user, temperature=0.3)) or {}
+
+    def _critique(self, prompt: str, code: dict) -> dict:
+        """Adversarial review by a (ideally distinct) model — asked to find the flaw."""
+        system = (
+            "You are an adversarial code reviewer. Your job is to FIND THE FLAW. "
+            "Scrutinize correctness, edge cases, and whether it actually solves the task. "
+            "Respond ONLY with JSON: "
+            '{"issues": [str], "verdict": "ok"|"revise", "severity": "none"|"minor"|"major"}. '
+            "Default to verdict=revise if anything is wrong or unverified."
+        )
+        user = (
+            f"Task:\n{prompt}\n\nProposed solution:\n{code.get('code','')}\n\n"
+            f"Author's edge cases: {code.get('edge_cases', [])}"
+        )
+        obj = _extract_json(self._call("critic", system, user, temperature=0.2)) or {}
+        obj.setdefault("issues", [])
+        obj.setdefault("verdict", "ok")
+        obj.setdefault("severity", "none")
+        return obj
+
+    def _repair(self, prompt: str, code: dict, critique: dict) -> dict:
+        system = (
+            "You are a senior engineer fixing your code given a reviewer's issues. "
+            "Respond ONLY with JSON: "
+            '{"code": str, "explanation": str, "edge_cases": [str], "confidence": 0.0-1.0, '
+            '"file_path": str}'
+        )
+        user = (
+            f"Task:\n{prompt}\n\nYour previous solution:\n{code.get('code','')}\n\n"
+            f"Reviewer issues (fix ALL):\n- " + "\n- ".join(critique.get("issues", []))
+        )
+        return _extract_json(self._call("coder", system, user, temperature=0.3)) or code
+
+    @staticmethod
+    def _task_block(prompt: str, context: str) -> str:
+        ctx = f"\n\nContext:\n{context}" if context else ""
+        return f"Task:\n{prompt}{ctx}"
+
+    # -- orchestration -----------------------------------------------------
+
+    def deliberate(self, prompt: str, context: str = "") -> DeliberationResult:
+        self._models_used = {}
+
+        plans = self._generate_plans(prompt, context)
+        if not plans:
+            # Panel produced nothing parseable — signal failure to the caller,
+            # which falls back to the fast path.
+            return DeliberationResult(
+                plan=[], simulation_traces=[], code_suggestions=[],
+                confidence=0.0, consensus=0.0, rounds=0,
+                meta={"error": "no parseable plans", "k_requested": self.k_plans},
+            )
+
+        winner_idx, consensus = self._judge_plans(prompt, plans)
+        chosen = plans[winner_idx]
+
+        code = self._generate_code(prompt, context, chosen)
+        critique = self._critique(prompt, code)
+
+        rounds = 0
+        while critique.get("verdict") == "revise" and rounds < self.max_repair_rounds:
+            code = self._repair(prompt, code, critique)
+            critique = self._critique(prompt, code)
+            rounds += 1
+
+        return self._assemble(chosen, code, critique, consensus, rounds, len(plans))
+
+    def _assemble(
+        self, plan: dict, code: dict, critique: dict, consensus: float, rounds: int, n_plans: int
+    ) -> DeliberationResult:
+        steps = [
+            PlanStep(
+                description=s.get("description", ""),
+                rationale=s.get("rationale", ""),
+                risk=s.get("risk", "low") if s.get("risk") in ("low", "medium", "high") else "low",
+                confidence=consensus,
+            )
+            for s in plan.get("steps", [])
+        ]
+
+        coder_conf = _clamp(code.get("confidence", 0.5))
+        # Confidence is a *consensus* of independent signals, not one model's
+        # self-report: plan agreement × coder confidence, penalized if the
+        # adversarial critic still isn't satisfied after the repair budget.
+        verdict_ok = critique.get("verdict") == "ok"
+        severity = critique.get("severity", "none")
+        critic_factor = {"none": 1.0, "minor": 0.85, "major": 0.55}.get(severity, 0.7)
+        if not verdict_ok:
+            critic_factor = min(critic_factor, 0.5)
+        confidence = _clamp(coder_conf * (0.5 + 0.5 * consensus) * critic_factor)
+
+        suggestions = []
+        if code.get("code"):
+            suggestions.append(
+                CodeSuggestion(
+                    file_path=code.get("file_path", "") or "suggestion",
+                    unified_diff="",
+                    description=code.get("explanation", ""),
+                    confidence=confidence,
+                    code_block=code.get("code", ""),
+                    tradeoffs=list(critique.get("issues", []))[:5],
+                )
+            )
+
+        # The "simulation trace" is now grounded in the adversarial review, not
+        # the model narrating its own dry-run.
+        traces = [
+            SimulationTrace(
+                input_data="adversarial review",
+                expected_output=critique.get("verdict", "ok"),
+                reasoning_steps=[s.get("description", "") for s in plan.get("steps", [])],
+                issues_found=list(critique.get("issues", [])),
+            )
+        ]
+
+        return DeliberationResult(
+            plan=steps,
+            simulation_traces=traces,
+            code_suggestions=suggestions,
+            confidence=confidence,
+            consensus=consensus,
+            rounds=rounds,
+            models_used=dict(self._models_used),
+            meta={
+                "n_plans": n_plans,
+                "critic_verdict": critique.get("verdict"),
+                "critic_severity": severity,
+                "distinct_models": len(set(self._models_used.values())),
+            },
+        )

--- a/src/neo/panel.py
+++ b/src/neo/panel.py
@@ -1,0 +1,115 @@
+"""Model-diversity planning for the multi-agent panel.
+
+The panel's value is diverse models disagreeing (a critic that shares the
+coder's weights shares its blind spots). CAR's router optimizes *per-request
+fitness* and won't diversify on its own, so neo engineers distinctness via
+``route_model``'s ``candidates`` (see the pool) + ``exclude_models`` (force a
+different model — the field CAR added for "adversarial-reviewer separation",
+car#358). See ``docs/solutions/tiered-reasoning-multi-agent.md`` §4.
+
+The routing-plan is a cheap up-front pass (``route_model`` is decision-only, no
+inference), so the whole role→model assignment is computed before any agent
+runs. The pure logic here is unit-tested with a fake ``route_fn``; the CAR
+wiring is a thin wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Per-role intent hints. Planner/critic want reasoning quality; coder wants a
+#: code model; judge is a cheap classification. The critic is threaded with the
+#: coder's model excluded so it's a *different* model wherever the pool allows.
+ROLE_INTENTS: dict[str, dict] = {
+    "planner": {"task": "reasoning", "prefer_quality": True},
+    "coder": {"task": "code", "prefer_quality": True},
+    "critic": {"task": "reasoning", "prefer_quality": True},
+    "judge": {"task": "classify"},
+}
+
+# route_model reports the winner under one of these keys depending on version.
+_SELECTED_KEYS = ("selected", "chosen", "model", "model_id")
+
+
+def _selected_model(decision: dict) -> Optional[str]:
+    for k in _SELECTED_KEYS:
+        v = decision.get(k)
+        if isinstance(v, str) and v:
+            return v
+    # Fall back to the selected candidate in the ranking.
+    for c in decision.get("candidates", []) or []:
+        if isinstance(c, dict) and c.get("selected") and c.get("model_id"):
+            return c["model_id"]
+    cands = decision.get("candidates") or []
+    if cands and isinstance(cands[0], dict):
+        return cands[0].get("model_id")
+    return None
+
+
+def capable_model_count(route_fn: Callable[[str, str], str], probe: str = "code task") -> int:
+    """Distinct capable models CAR could route a code task to (the panel's
+    diversity ceiling). Reads ``route_model``'s advisory ``candidates`` ranking.
+    Returns 0 on any failure (→ gate falls back to the fast path)."""
+    try:
+        decision = json.loads(route_fn(probe, json.dumps(ROLE_INTENTS["coder"])) or "{}")
+    except (ValueError, TypeError):
+        return 0
+    cands = decision.get("candidates") or []
+    ids = {c.get("model_id") for c in cands if isinstance(c, dict) and c.get("model_id")}
+    if ids:
+        return len(ids)
+    # Cold-start / explicit-model paths return no ranking but did pick one.
+    return 1 if _selected_model(decision) else 0
+
+
+def plan_role_models(
+    route_fn: Callable[[str, str], str], prompt: str, *, roles=("planner", "coder", "critic", "judge")
+) -> dict[str, str]:
+    """Assign a concrete model per role, forcing the critic ≠ coder where the
+    pool allows (exclude_models threading). Pure w.r.t. ``route_fn``.
+
+    ``route_fn(prompt, intent_json) -> decision_json``.
+    """
+    assigned: dict[str, str] = {}
+    for role in roles:
+        intent = dict(ROLE_INTENTS.get(role, {"task": "code"}))
+        # The critic must not be the coder's model (diversity is the point).
+        if role == "critic" and assigned.get("coder"):
+            intent["exclude_models"] = [assigned["coder"]]
+        try:
+            decision = json.loads(route_fn(prompt, json.dumps(intent)) or "{}")
+        except (ValueError, TypeError):
+            decision = {}
+        model = _selected_model(decision)
+        if model:
+            assigned[role] = model
+    return assigned
+
+
+def build_role_factory(
+    role_models: dict[str, str],
+    adapter_for_model: Callable[[str], object],
+    fallback_adapter: object,
+) -> Callable[[str], object]:
+    """Return ``role_adapter(role) -> LMAdapter``: a distinct pinned adapter per
+    role from the routing plan, falling back to ``fallback_adapter`` for roles
+    with no assignment. Adapters are built once and cached."""
+    cache: dict[str, object] = {}
+
+    def factory(role: str):
+        model = role_models.get(role)
+        if not model:
+            return fallback_adapter
+        if model not in cache:
+            try:
+                cache[model] = adapter_for_model(model)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("adapter_for_model(%s) failed: %s; using fallback", model, e)
+                cache[model] = fallback_adapter
+        return cache[model]
+
+    return factory

--- a/src/neo/reasoning_mode.py
+++ b/src/neo/reasoning_mode.py
@@ -1,0 +1,128 @@
+"""Reasoning-mode gate: decide FAST (single call + memory) vs MULTI_AGENT
+(CAR-orchestrated deliberation) for a given query.
+
+Promotes the existing novelty signal (``reasoning_effort.effort_from_memory``)
+from a token-budget dimmer to a mode switch, per
+``docs/solutions/tiered-reasoning-multi-agent.md``.
+
+Key rule: multi-agent is offered ONLY when CAR is reachable AND there are at
+least ``min_models`` genuinely-capable, *distinct* models available — because
+the value of a panel is model diversity, and a single-model panel just pays
+latency to re-confirm one model's blind spots. Below that bar we degrade to the
+fast path (or a high-effort single pass for explicit ``--deep``).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from neo.reasoning_effort import MemorySignal, effort_from_memory
+
+__all__ = ["ReasoningMode", "ModeDecision", "decide_mode", "DEFAULT_MIN_MODELS"]
+
+#: Effort levels that mean "novel / low-confidence" — the deliberation-worthy end
+#: of ``effort_from_memory``. (``low``/``medium`` mean memory has this covered.)
+_DELIBERATE_EFFORTS = frozenset({"high", "xhigh"})
+
+#: A panel needs at least this many distinct capable models to be worth running.
+DEFAULT_MIN_MODELS = 2
+
+
+class ReasoningMode(str, Enum):
+    FAST = "fast"
+    MULTI_AGENT = "multi_agent"
+
+
+class ModeDecision:
+    """The chosen mode plus a human-readable reason (logged + surfaced in
+    metadata, so the routing is always explainable)."""
+
+    __slots__ = ("mode", "reason", "effort")
+
+    def __init__(self, mode: ReasoningMode, reason: str, effort: Optional[str] = None):
+        self.mode = mode
+        self.reason = reason
+        self.effort = effort
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"ModeDecision(mode={self.mode.value!r}, reason={self.reason!r})"
+
+
+def decide_mode(
+    signal: MemorySignal,
+    *,
+    difficulty: str = "medium",
+    car_available: bool = False,
+    capable_model_count: int = 0,
+    explicit: Optional[str] = None,
+    min_models: int = DEFAULT_MIN_MODELS,
+) -> ModeDecision:
+    """Decide FAST vs MULTI_AGENT.
+
+    Args:
+        signal: novelty signal (pattern_count / avg_confidence) from retrieval.
+        difficulty: engine difficulty estimate ("easy"|"medium"|"hard").
+        car_available: is CAR reachable (same check ``resolve_adapter`` makes).
+        capable_model_count: distinct capable models CAR could route to (from
+            ``route_model``'s ``candidates``). 0 when unknown/no CAR.
+        explicit: user override — "fast" | "deep" | None.
+        min_models: distinct-model floor for a worthwhile panel.
+
+    Returns:
+        ModeDecision(mode, reason, effort).
+    """
+    effort = effort_from_memory(signal, difficulty=difficulty)
+    diversity_ok = car_available and capable_model_count >= min_models
+    override = (explicit or "").strip().lower()
+
+    if override in ("fast", "single"):
+        return ModeDecision(ReasoningMode.FAST, "explicit --fast", effort)
+
+    if override in ("deep", "deliberate", "multi", "multi_agent", "multi-agent"):
+        if diversity_ok:
+            return ModeDecision(
+                ReasoningMode.MULTI_AGENT,
+                f"explicit --deep ({capable_model_count} capable models)",
+                effort,
+            )
+        # Degrade, don't error: --deep without the model pool becomes a
+        # max-effort single pass.
+        return ModeDecision(
+            ReasoningMode.FAST,
+            (
+                f"--deep requested but multi-agent needs CAR + >={min_models} capable "
+                f"models (car={car_available}, models={capable_model_count}); "
+                "running a high-effort single pass instead"
+            ),
+            "xhigh",
+        )
+
+    # Auto: novelty gates the mode, diversity gates whether we *can* deliberate.
+    novel = effort in _DELIBERATE_EFFORTS
+    if novel and diversity_ok:
+        return ModeDecision(
+            ReasoningMode.MULTI_AGENT,
+            (
+                f"novel (effort={effort}, patterns={signal.pattern_count}, "
+                f"conf={signal.avg_confidence:.2f}) with {capable_model_count} capable models"
+            ),
+            effort,
+        )
+    if novel:
+        return ModeDecision(
+            ReasoningMode.FAST,
+            (
+                f"novel (effort={effort}) but no diverse panel available "
+                f"(car={car_available}, models={capable_model_count})"
+            ),
+            effort,
+        )
+    return ModeDecision(
+        ReasoningMode.FAST,
+        (
+            f"familiar (effort={effort}, patterns={signal.pattern_count}, "
+            f"conf={signal.avg_confidence:.2f}) — memory covers this"
+        ),
+        effort,
+    )

--- a/tests/test_engine_reasoning.py
+++ b/tests/test_engine_reasoning.py
@@ -1,0 +1,93 @@
+"""Integration tests for the engine's reasoning-tier wiring (gate + branch)."""
+
+import json
+
+import pytest
+
+from neo.engine import NeoEngine
+from neo.reasoning_effort import MemorySignal
+from neo.reasoning_mode import ReasoningMode
+
+
+class FakeLM:
+    def __init__(self, responder):
+        self._r = responder
+        self.model = "fake"
+        self.provider = "fake"
+
+    def generate(self, messages, **kw):
+        return self._r(messages)
+
+    def name(self):
+        return "fake-lm"
+
+
+def _engine(lm, config=None):
+    return NeoEngine(lm_adapter=lm, enable_persistent_memory=False, config=config)
+
+
+class _NI:
+    prompt = "do a novel thing"
+
+
+def test_no_car_forces_fast(monkeypatch):
+    e = _engine(FakeLM(lambda m: "{}"))
+    monkeypatch.setattr(e, "_car_route_capability", lambda p: (False, 0, None))
+    monkeypatch.setattr(e, "_compute_memory_signal", lambda c: MemorySignal(0, 0.0))
+    d, route = e._decide_reasoning_mode({"prompt": "x"}, "hard", _NI())
+    assert d.mode is ReasoningMode.FAST
+    assert route is None
+
+
+def test_car_with_pool_and_novelty_deliberates(monkeypatch):
+    e = _engine(FakeLM(lambda m: "{}"))
+    monkeypatch.setattr(e, "_car_route_capability", lambda p: (True, 3, lambda a, b: "{}"))
+    monkeypatch.setattr(e, "_compute_memory_signal", lambda c: MemorySignal(0, 0.0))
+    d, route = e._decide_reasoning_mode({"prompt": "x"}, "medium", _NI())
+    assert d.mode is ReasoningMode.MULTI_AGENT
+
+
+def test_config_fast_beats_car(monkeypatch):
+    from neo.config import NeoConfig
+    cfg = NeoConfig()
+    cfg.reasoning_mode = "fast"
+    e = _engine(FakeLM(lambda m: "{}"), config=cfg)
+    monkeypatch.setattr(e, "_car_route_capability", lambda p: (True, 5, lambda a, b: "{}"))
+    monkeypatch.setattr(e, "_compute_memory_signal", lambda c: MemorySignal(0, 0.0))
+    d, _ = e._decide_reasoning_mode({"prompt": "x"}, "hard", _NI())
+    assert d.mode is ReasoningMode.FAST
+
+
+_PLAN = json.dumps({"approach": "a", "steps": [
+    {"description": "x", "rationale": "r", "risk": "low"}]})
+_CODE = json.dumps({"code": "def f(): return 1", "explanation": "e",
+                    "edge_cases": [], "confidence": 0.9, "file_path": "f.py"})
+
+
+def test_deliberate_runs_panel_over_fallback_lm():
+    def responder(messages):
+        s = messages[0]["content"]
+        if "solution PLAN" in s:
+            return _PLAN
+        if "best plan" in s:
+            return json.dumps({"winner": 0, "confidence": 0.8})
+        if "Implement the given PLAN" in s:
+            return _CODE
+        if "adversarial code reviewer" in s:
+            return json.dumps({"verdict": "ok", "severity": "none", "issues": []})
+        if "fixing your code" in s:
+            return _CODE
+        return "{}"
+
+    e = _engine(FakeLM(responder))
+    plan, sims, code, result = e._deliberate({"prompt": "solve it"}, route_fn=None)
+    assert result is not None and result.confidence > 0.0
+    assert code and code[0].code_block == "def f(): return 1"
+    assert result.provenance == "multi-agent"
+
+
+def test_deliberate_failure_returns_none_for_fallback():
+    # planner never emits JSON -> no plans -> confidence 0 -> caller falls back
+    e = _engine(FakeLM(lambda m: "no json"))
+    plan, sims, code, result = e._deliberate({"prompt": "x"}, route_fn=None)
+    assert result is not None and result.confidence == 0.0

--- a/tests/test_engine_reasoning.py
+++ b/tests/test_engine_reasoning.py
@@ -2,8 +2,6 @@
 
 import json
 
-import pytest
-
 from neo.engine import NeoEngine
 from neo.reasoning_effort import MemorySignal
 from neo.reasoning_mode import ReasoningMode

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,0 +1,133 @@
+"""Tests for the multi-agent deliberation orchestrator (with fake adapters)."""
+
+import json
+
+from neo.multi_agent import MultiAgentReasoner, _extract_json
+
+
+class FakeAdapter:
+    """Returns a canned response per role; records calls."""
+
+    def __init__(self, label, script):
+        self.label = label
+        self._script = script          # callable(messages, call_index) -> str
+        self.calls = 0
+
+    def generate(self, messages, max_tokens=2048, temperature=0.7):
+        out = self._script(messages, self.calls)
+        self.calls += 1
+        return out
+
+    def name(self):
+        return self.label
+
+
+def _factory(scripts):
+    """Build a role_adapter returning a distinct FakeAdapter per role."""
+    adapters = {role: FakeAdapter(f"model-{role}", scr) for role, scr in scripts.items()}
+    return lambda role: adapters[role], adapters
+
+
+_PLAN = json.dumps({"approach": "a", "steps": [
+    {"description": "do x", "rationale": "because", "risk": "low"}], "key_risks": []})
+_CODE = json.dumps({"code": "def f(): return 1", "explanation": "impl",
+                    "edge_cases": ["empty input"], "confidence": 0.9, "file_path": "f.py"})
+
+
+def test_full_panel_flow_produces_engine_tuple():
+    factory, adapters = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 0.8}),
+        "coder": lambda m, i: _CODE,
+        "critic": lambda m, i: json.dumps({"issues": [], "verdict": "ok", "severity": "none"}),
+    })
+    r = MultiAgentReasoner(factory, k_plans=3).deliberate("solve it", context="ctx")
+    plan, sims, code = r.as_engine_tuple()
+    assert plan and code and sims
+    assert code[0].code_block == "def f(): return 1"
+    assert r.provenance == "multi-agent"
+    assert adapters["planner"].calls == 3          # k candidate plans
+    assert r.meta["n_plans"] == 3
+    assert 0.0 < r.confidence <= 1.0
+
+
+def test_distinct_models_are_tracked():
+    factory, _ = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 0.9}),
+        "coder": lambda m, i: _CODE,
+        "critic": lambda m, i: json.dumps({"verdict": "ok"}),
+    })
+    r = MultiAgentReasoner(factory, k_plans=2).deliberate("t")
+    # critic and coder resolved to different model labels
+    assert r.models_used["coder"] != r.models_used["critic"]
+    assert r.meta["distinct_models"] >= 3
+
+
+def test_repair_loop_runs_when_critic_says_revise():
+    # critic: first call "revise", then "ok"
+    def critic_script(m, i):
+        return json.dumps({"issues": ["off-by-one"], "verdict": "revise", "severity": "major"}) if i == 0 \
+            else json.dumps({"issues": [], "verdict": "ok", "severity": "none"})
+
+    factory, adapters = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 0.7}),
+        "coder": lambda m, i: _CODE,
+        "critic": critic_script,
+    })
+    r = MultiAgentReasoner(factory, k_plans=1, max_repair_rounds=1).deliberate("t")
+    assert r.rounds == 1
+    assert adapters["critic"].calls == 2           # initial + post-repair
+    assert adapters["coder"].calls == 2            # initial code + 1 repair
+    assert r.meta["critic_verdict"] == "ok"
+
+
+def test_unrepaired_major_issue_lowers_confidence():
+    factory, _ = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 0.9}),
+        "coder": lambda m, i: _CODE,
+        "critic": lambda m, i: json.dumps({"issues": ["wrong"], "verdict": "revise", "severity": "major"}),
+    })
+    r = MultiAgentReasoner(factory, k_plans=1, max_repair_rounds=0).deliberate("t")
+    assert r.meta["critic_verdict"] == "revise"
+    assert r.confidence < 0.5                       # penalized for unresolved major issue
+
+
+def test_low_plan_consensus_lowers_confidence():
+    # two plans, judge barely prefers one (0.5) -> lower confidence than a clear win
+    factory, _ = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 0.5}),
+        "coder": lambda m, i: _CODE,
+        "critic": lambda m, i: json.dumps({"verdict": "ok", "severity": "none"}),
+    })
+    low = MultiAgentReasoner(factory, k_plans=2).deliberate("t")
+
+    factory2, _ = _factory({
+        "planner": lambda m, i: _PLAN,
+        "judge": lambda m, i: json.dumps({"winner": 0, "confidence": 1.0}),
+        "coder": lambda m, i: _CODE,
+        "critic": lambda m, i: json.dumps({"verdict": "ok", "severity": "none"}),
+    })
+    high = MultiAgentReasoner(factory2, k_plans=2).deliberate("t")
+    assert low.confidence < high.confidence
+
+
+def test_no_parseable_plans_signals_failure():
+    factory, _ = _factory({
+        "planner": lambda m, i: "sorry, no JSON here",
+        "judge": lambda m, i: "{}",
+        "coder": lambda m, i: "{}",
+        "critic": lambda m, i: "{}",
+    })
+    r = MultiAgentReasoner(factory, k_plans=2).deliberate("t")
+    assert r.confidence == 0.0 and not r.code_suggestions
+    assert "error" in r.meta
+
+
+def test_extract_json_tolerates_fences_and_prose():
+    assert _extract_json('```json\n{"a": 1}\n```')["a"] == 1
+    assert _extract_json('here you go: {"b": 2} thanks')["b"] == 2
+    assert _extract_json("no json at all") is None

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,85 @@
+"""Tests for panel model-diversity planning (route_model + exclude_models)."""
+
+import json
+
+from neo.panel import (
+    build_role_factory,
+    capable_model_count,
+    plan_role_models,
+)
+
+
+def make_route_fn(pool):
+    """Fake ``route_model``: rank pool by score, honor exclude_models, mark the
+    top one selected — mirroring CAR's decision JSON."""
+
+    def route(prompt, intent_json):
+        intent = json.loads(intent_json)
+        exclude = set(intent.get("exclude_models", []))
+        ranked = sorted(
+            (m for m in pool if m["id"] not in exclude),
+            key=lambda m: m["score"],
+            reverse=True,
+        )
+        cands = [
+            {"model_id": m["id"], "score": m["score"], "reliability": m["score"],
+             "selected": i == 0, "in_band": True}
+            for i, m in enumerate(ranked)
+        ]
+        return json.dumps({"selected": cands[0]["model_id"] if cands else None,
+                           "candidates": cands})
+
+    return route
+
+
+POOL = [
+    {"id": "gpt", "score": 0.90},
+    {"id": "claude", "score": 0.85},
+    {"id": "qwen-local", "score": 0.60},
+]
+
+
+def test_capable_model_count_reads_candidates():
+    assert capable_model_count(make_route_fn(POOL)) == 3
+    assert capable_model_count(make_route_fn([])) == 0
+
+
+def test_critic_is_forced_off_the_coder_model():
+    plan = plan_role_models(make_route_fn(POOL), "task")
+    # coder gets the top model; critic must be excluded off it -> different model
+    assert plan["coder"] == "gpt"
+    assert plan["critic"] != plan["coder"]
+    assert plan["critic"] == "claude"      # next best after excluding gpt
+
+
+def test_single_model_pool_cannot_diversify_critic():
+    # only one capable model -> exclude leaves nothing -> critic unassigned
+    plan = plan_role_models(make_route_fn([{"id": "solo", "score": 0.9}]), "task")
+    assert plan["coder"] == "solo"
+    assert "critic" not in plan            # no distinct model available
+    assert capable_model_count(make_route_fn([{"id": "solo", "score": 0.9}])) == 1
+
+
+def test_route_failures_yield_empty_plan_not_crash():
+    def broken(prompt, intent_json):
+        return "not json"
+
+    assert plan_role_models(broken, "t") == {}
+    assert capable_model_count(broken) == 0
+
+
+def test_factory_pins_distinct_adapters_with_fallback():
+    built = []
+
+    def adapter_for_model(m):
+        built.append(m)
+        return f"adapter:{m}"
+
+    plan = {"coder": "gpt", "critic": "claude"}  # planner/judge unassigned
+    factory = build_role_factory(plan, adapter_for_model, fallback_adapter="FALLBACK")
+    assert factory("coder") == "adapter:gpt"
+    assert factory("critic") == "adapter:claude"
+    assert factory("planner") == "FALLBACK"      # unassigned -> fallback
+    # adapters are cached (built once each)
+    factory("coder")
+    assert built == ["gpt", "claude"]

--- a/tests/test_reasoning_mode.py
+++ b/tests/test_reasoning_mode.py
@@ -1,0 +1,84 @@
+"""Tests for the reasoning-mode gate (fast vs multi-agent routing)."""
+
+from neo.reasoning_effort import MemorySignal
+from neo.reasoning_mode import ReasoningMode, decide_mode
+
+
+def _novel():
+    # no patterns -> effort high/xhigh -> deliberation-worthy
+    return MemorySignal(pattern_count=0, avg_confidence=0.0)
+
+
+def _familiar():
+    # >=3 patterns, high confidence -> effort low -> memory covers it
+    return MemorySignal(pattern_count=5, avg_confidence=0.9)
+
+
+def _low_conf():
+    return MemorySignal(pattern_count=2, avg_confidence=0.3)
+
+
+# --- auto mode ------------------------------------------------------------
+
+def test_novel_with_diverse_pool_deliberates():
+    d = decide_mode(_novel(), car_available=True, capable_model_count=3)
+    assert d.mode is ReasoningMode.MULTI_AGENT
+    assert "novel" in d.reason
+
+
+def test_familiar_takes_fast_path_even_with_car():
+    d = decide_mode(_familiar(), car_available=True, capable_model_count=5)
+    assert d.mode is ReasoningMode.FAST
+    assert "familiar" in d.reason
+
+
+def test_low_confidence_is_deliberation_worthy():
+    d = decide_mode(_low_conf(), car_available=True, capable_model_count=2)
+    assert d.mode is ReasoningMode.MULTI_AGENT
+
+
+# --- CAR / pool gating ----------------------------------------------------
+
+def test_novel_without_car_falls_back_to_fast():
+    d = decide_mode(_novel(), car_available=False, capable_model_count=0)
+    assert d.mode is ReasoningMode.FAST
+    assert "no diverse panel" in d.reason
+
+
+def test_novel_with_only_one_model_falls_back():
+    # CAR present but only one capable model -> single-model panel is worthless
+    d = decide_mode(_novel(), car_available=True, capable_model_count=1)
+    assert d.mode is ReasoningMode.FAST
+
+
+def test_min_models_threshold_is_honored():
+    d = decide_mode(_novel(), car_available=True, capable_model_count=2, min_models=3)
+    assert d.mode is ReasoningMode.FAST
+    d2 = decide_mode(_novel(), car_available=True, capable_model_count=3, min_models=3)
+    assert d2.mode is ReasoningMode.MULTI_AGENT
+
+
+# --- explicit overrides ---------------------------------------------------
+
+def test_explicit_fast_always_fast():
+    d = decide_mode(_novel(), car_available=True, capable_model_count=5, explicit="fast")
+    assert d.mode is ReasoningMode.FAST
+    assert "--fast" in d.reason
+
+
+def test_explicit_deep_deliberates_when_possible():
+    d = decide_mode(_familiar(), car_available=True, capable_model_count=3, explicit="deep")
+    assert d.mode is ReasoningMode.MULTI_AGENT
+    assert "--deep" in d.reason
+
+
+def test_explicit_deep_degrades_without_pool_not_errors():
+    d = decide_mode(_novel(), car_available=False, capable_model_count=0, explicit="deep")
+    assert d.mode is ReasoningMode.FAST
+    assert d.effort == "xhigh"  # degrades to a max-effort single pass
+    assert "high-effort single pass" in d.reason
+
+
+def test_decision_carries_effort():
+    d = decide_mode(_familiar(), car_available=True, capable_model_count=5)
+    assert d.effort in ("low", "medium", "high", "xhigh")

--- a/tools/ab_reasoning.py
+++ b/tools/ab_reasoning.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""A/B harness: does the multi-agent panel beat a single combined call?
+
+For each task, produce two solutions — (A) one-shot combined call, (B) the
+multi-agent panel (plan-vote → code → adversarial critique → repair) — then
+have a blind LLM judge score both on an absolute rubric. Order is randomized
+per task (recorded) to avoid position bias.
+
+This isolates the value of the *orchestration*. By default both modes use the
+same model (so any delta is the panel structure, not model choice); pass
+distinct role models to also measure diversity.
+
+Usage:
+    python tools/ab_reasoning.py [--n 8] [--k 3] [--out results.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from neo.adapters import OpenAIAdapter  # noqa: E402
+from neo.config import NeoConfig  # noqa: E402
+from neo.multi_agent import MultiAgentReasoner, _extract_json  # noqa: E402
+
+
+class EffortAdapter:
+    """Wrap an adapter to inject a fixed reasoning effort on every call — so
+    both A/B arms run at the *same* effort (a fair, controlled comparison) and
+    reasoning models don't burn the whole run on hidden tokens."""
+
+    def __init__(self, inner, effort):
+        self._inner = inner
+        self._effort = effort
+
+    def generate(self, messages, **kw):
+        kw.setdefault("reasoning_effort", self._effort)
+        return self._inner.generate(messages, **kw)
+
+    def name(self):
+        return getattr(self._inner, "name", lambda: "wrapped")()
+
+# Self-contained tasks with real edge cases — the regime where an adversarial
+# critic should actually catch things a one-shot pass misses.
+TASKS = [
+    "Write a Python function to merge two sorted linked lists into one sorted list.",
+    "Deduplicate a list of dicts while preserving first-seen order.",
+    "Parse a semver string (with optional pre-release) and compare two versions.",
+    "Implement an LRU cache with O(1) get and put.",
+    "Return the longest palindromic substring of a string.",
+    "Implement a token-bucket rate limiter (Python class).",
+    "Write a `debounce(wait)` decorator that delays calls until idle.",
+    "Validate that a string has balanced (), [], and {} brackets.",
+    "Chunk an iterable into lists of size n, including a final short chunk.",
+    "Flatten an arbitrarily nested list of integers (no recursion depth blowup).",
+]
+
+_SINGLE_SYS = (
+    "You are a senior engineer. Solve the task in ONE shot. Respond ONLY with JSON: "
+    '{"code": str, "explanation": str, "edge_cases": [str], "confidence": 0.0-1.0}'
+)
+
+_JUDGE_SYS = (
+    "You are a strict code reviewer judging two solutions to the same task. "
+    "Score each 1-10 on: correctness first, then edge-case handling and completeness. "
+    "Be skeptical; penalize bugs and missed edge cases heavily. Ignore verbosity. "
+    'Respond ONLY with JSON: {"score_a": int, "score_b": int, '
+    '"winner": "A"|"B"|"tie", "reason": str}'
+)
+
+
+def single_call(adapter, task: str) -> dict:
+    raw = adapter.generate(
+        [{"role": "system", "content": _SINGLE_SYS}, {"role": "user", "content": task}],
+        max_tokens=8000, temperature=0.3,
+    )
+    return _extract_json(raw) or {"code": raw, "explanation": "", "edge_cases": []}
+
+
+def judge(adapter, task: str, sol_a: str, sol_b: str) -> dict:
+    user = f"TASK:\n{task}\n\n--- SOLUTION A ---\n{sol_a}\n\n--- SOLUTION B ---\n{sol_b}"
+    raw = adapter.generate(
+        [{"role": "system", "content": _JUDGE_SYS}, {"role": "user", "content": user}],
+        max_tokens=4000, temperature=0.0,
+    )
+    obj = _extract_json(raw) or {}
+    return {
+        "score_a": int(obj.get("score_a", 0) or 0),
+        "score_b": int(obj.get("score_b", 0) or 0),
+        "winner": obj.get("winner", "tie"),
+        "reason": obj.get("reason", ""),
+    }
+
+
+def run(n: int, k: int, model: str, out: Path, effort: str = "low") -> dict:
+    key = NeoConfig.load().api_key
+    adapter = EffortAdapter(OpenAIAdapter(model=model, api_key=key), effort)
+    reasoner = MultiAgentReasoner(lambda role: adapter, k_plans=k, max_repair_rounds=1)
+
+    rng = random.Random(1234)
+    tasks = TASKS[:n]
+    rows = []
+    single_wins = multi_wins = ties = 0
+    single_score_sum = multi_score_sum = 0
+    single_time = multi_time = 0.0
+
+    for i, task in enumerate(tasks, 1):
+        try:
+            t0 = time.time()
+            s = single_call(adapter, task)
+            single_time += time.time() - t0
+            single_sol = s.get("code", "")
+
+            t0 = time.time()
+            d = reasoner.deliberate(task)
+            multi_time += time.time() - t0
+            multi_sol = d.code_suggestions[0].code_block if d.code_suggestions else ""
+        except Exception as e:  # keep the run going; record the failure
+            print(f"[{i}/{len(tasks)}] ERROR: {type(e).__name__}: {str(e)[:120]}", flush=True)
+            rows.append({"task": task, "error": f"{type(e).__name__}: {str(e)[:200]}"})
+            continue
+
+        # Randomize which slot (A/B) is the multi-agent solution.
+        multi_is_a = rng.random() < 0.5
+        sol_a, sol_b = (multi_sol, single_sol) if multi_is_a else (single_sol, multi_sol)
+        v = judge(adapter, task, sol_a, sol_b)
+
+        multi_score = v["score_a"] if multi_is_a else v["score_b"]
+        single_score = v["score_b"] if multi_is_a else v["score_a"]
+        winner = v["winner"]
+        if winner == "tie":
+            multi_won = None
+            ties += 1
+        else:
+            won_a = winner == "A"
+            multi_won = (won_a and multi_is_a) or (not won_a and not multi_is_a)
+            if multi_won:
+                multi_wins += 1
+            else:
+                single_wins += 1
+
+        multi_score_sum += multi_score
+        single_score_sum += single_score
+        rows.append({
+            "task": task, "multi_is_a": multi_is_a, "winner": winner,
+            "multi_won": multi_won, "multi_score": multi_score, "single_score": single_score,
+            "multi_confidence": round(d.confidence, 3), "multi_rounds": d.rounds,
+            "reason": v["reason"][:200],
+        })
+        print(f"[{i}/{len(tasks)}] multi={multi_score} single={single_score} "
+              f"winner={'multi' if multi_won else ('single' if multi_won is False else 'tie')} "
+              f":: {task[:50]}", flush=True)
+
+    scored = multi_wins + single_wins + ties
+    denom = max(1, scored)
+    summary = {
+        "model": model, "effort": effort, "n": len(tasks), "scored": scored, "k_plans": k,
+        "multi_wins": multi_wins, "single_wins": single_wins, "ties": ties,
+        "multi_win_rate": round(multi_wins / denom, 3),
+        "decisive_multi_win_rate": round(multi_wins / max(1, multi_wins + single_wins), 3),
+        "avg_multi_score": round(multi_score_sum / denom, 2),
+        "avg_single_score": round(single_score_sum / denom, 2),
+        "avg_score_delta": round((multi_score_sum - single_score_sum) / denom, 2),
+        "avg_single_time_s": round(single_time / denom, 1),
+        "avg_multi_time_s": round(multi_time / denom, 1),
+    }
+    out.write_text(json.dumps({"summary": summary, "rows": rows}, indent=2))
+    print("\n=== SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+    return summary
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=8)
+    ap.add_argument("--k", type=int, default=3)
+    ap.add_argument("--model", default="gpt-5.5")
+    ap.add_argument("--effort", default="low")
+    ap.add_argument("--out", default="/tmp/ab_reasoning_results.json")
+    a = ap.parse_args()
+    run(a.n, a.k, a.model, Path(a.out), effort=a.effort)


### PR DESCRIPTION
## Description

Neo is described as "MapCoder/CodeSim-style multi-agent reasoning," but the implementation collapsed all three roles into a **single combined LLM call** (`engine.py`), and its "simulation" was self-narration the engine itself distrusted. This adds a **real deliberation tier** — and gates it so the fast, memory-driven path stays the default.

Design + full rationale: `docs/solutions/tiered-reasoning-multi-agent.md`.

## What's here

- **`reasoning_mode.py`** — novelty→mode gate. Promotes the existing `effort_from_memory` signal from a token dimmer to a mode switch. Multi-agent fires only on **novel** queries AND **CAR reachable** AND **≥2 distinct capable models** (the panel's value is model diversity — a single-model panel just re-confirms one model's blind spots). `--deep` degrades gracefully to a high-effort single pass when there's no pool.
- **`multi_agent.py`** — `MultiAgentReasoner`: plan-vote → code → **adversarial critique** → repair loop. Confidence is a **consensus** of independent signals (plan agreement × coder confidence × critic verdict), not one model's self-report.
- **`panel.py`** — model-diversity planning via `route_model`'s `candidates` + `exclude_models` (car#358), so the critic routes to a *different* model than the coder. Cheap decision-only up-front pass; degrades when the pool is thin.
- **`engine.py`** — gate + branch + fallback-on-failure + provenance metadata (`reasoning_mode`, `reasoning_reason`, `panel`: models_used/consensus/rounds). `config.reasoning_mode` + CLI `--deep`/`--fast`.
- **`tools/ab_reasoning.py`** — blind-judge A/B harness (order-randomized, per-task).

## A/B result — does it actually improve quality?

8 self-contained coding tasks, each solved one-shot vs by the panel, scored by a blind LLM judge. gpt-5.5, `effort=low`, `k=2`:

| | value |
|---|---|
| **panel avg** | **9.25 / 10** |
| single avg | 8.12 / 10 |
| **delta** | **+1.12** |
| wins (panel/single/tie) | 3 / 1 / 4 |
| decisive win rate | **3 of 4** |
| latency | 44.7s vs 8.4s (~5.3×) |

Panel wins clustered on **edge-case-heavy** tasks (dedup-dicts 8→4, semver 10→7, debounce 9→6 — the critic catching what a one-shot pass missed); its one loss was the trivial "merge two sorted lists" where one-shot is already optimal. **This reinforces the gate** — deliberation is worth ~5× latency on hard/novel work and wasteful on easy work.

**Honest scope:** all roles used the *same* model, so this measures the **orchestration structure alone** — zero model diversity. Distinct-model routing (§4) should widen the gap but is not measured here (needs ≥2 fast capable models).

## Type of Change

- [x] New feature (non-breaking; default behavior unchanged — gate stays `auto`, fast path is default)

## How Has This Been Tested?

- [x] 27 new unit/integration tests: gate decisions, panel orchestration (plan-vote/critique/repair/consensus), diversity planning (exclude_models threading), engine wiring (branch + fallback). `test_reasoning_mode.py`, `test_multi_agent.py`, `test_panel.py`, `test_engine_reasoning.py`.
- [x] Regression subset (adapters/cli/car) green; no default-path change.
- [x] Real A/B run with gpt-5.5 (above).

**Test Configuration**: Python 3.14.5, macOS, neo 0.34.0

## Additional Notes

L4 (sandboxed execution verification) is intentionally deferred — most real code needs infra/DBs/APIs a sandbox can't conjure, so verification leans on the adversarial critic + static analysis, with execution as a detected-when-possible bonus. Memory-provenance routing (deliberated facts → probation) is surfaced in metadata; deeper wiring into the outcome pipeline is a noted follow-up.
