### PR TITLE
feat: deliberation memory-provenance + diversity-count gate fix (tiered-reasoning follow-ups)

### DIFF
--- a/docs/solutions/tiered-reasoning-multi-agent.md
+++ b/docs/solutions/tiered-reasoning-multi-agent.md
@@ -49,8 +49,34 @@ work — which is precisely what the novelty gate reserves it for.
 (gpt-5.5) — so this isolates the value of the **orchestration structure** (plan
 vote → adversarial critique → repair) with **zero model diversity**. Real
 deployment adds distinct models per role (§4), which should widen the gap
-further, but that lift is *not* measured here (it needs ≥2 fast capable models
-wired up). Raw results: `/tmp/ab_low.json`.
+further. Raw results: `/tmp/ab_low.json`.
+
+### Model diversity: mechanism validated, quality lift not yet measurable
+
+The **routing mechanism works** against real CAR: `plan_role_models` +
+`exclude_models` routed the critic to a *different* model than the coder
+(`coder → parslee/advisor`, `critic → parslee/reasoning`; `critic ≠ coder`
+confirmed). But the **quality lift from diversity could not be measured on this
+host**, for two concrete reasons — neither of which is an unreleased CAR
+feature:
+
+1. **`capable_model_count` overcounts.** It reported 3 models, but
+   `parslee/advisor` and `parslee/reasoning` are **both Azure gpt-5.5 underneath**
+   (Parslee assistant personas). So the "diverse pool" is really gpt-5.5 ×2 plus
+   one local qwen — the `≥2 distinct models` gate can be *fooled* by same-backend
+   personas. **Refinement needed:** dedupe the diversity count by backing model,
+   not catalog ID (neo can't currently tell that `parslee/*` share a backend).
+2. **No second *fast+capable+distinct* model exists here.** The only genuinely
+   different family is a local MLX model, and it **timed out (180s) on every
+   critique** — a 4B local model answers a one-word probe in ~8s but can't do a
+   real critique (full solution + token budget) in time. And there's no
+   Anthropic/Google credential wired up.
+
+So a real frontier-vs-frontier diversity A/B needs a **second fast capable model
+credential** (a Parslee/infra decision), or Parslee's `/inference/responses`
+backend serving a genuinely different model family (its model-agnostic future).
+The harness supports it now (`tools/ab_reasoning.py --critic-model ...`); it just
+needs a viable second model to point at.
 
 ## Problem
 

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -1472,13 +1472,25 @@ RULES:
             if pitfalls:
                 body_parts.append("Pitfalls: " + "; ".join(pitfalls[:5]))
 
+            tags = [task_type_str]
+            deliberation = getattr(self, "last_deliberation", None)
+            if deliberation is not None:
+                # Provenance for deliberated outcomes: recognizable (`multi-agent`)
+                # and trust-first (`probation`). They enter on probation and are
+                # promoted only by real outcomes (access_count>=2 / success_count>0)
+                # via the existing pipeline — so a wrong panel answer never becomes
+                # confident memory unchecked. `confidence` here already reflects the
+                # panel *consensus*, not a single model's self-report.
+                # docs/solutions/tiered-reasoning-multi-agent.md §5.
+                tags += ["multi-agent", "probation"]
+
             fact = self.fact_store.add_fact(
                 subject=pattern,
                 body="\n".join(body_parts),
                 kind=fact_kind,
                 confidence=confidence,
                 source_prompt=neo_input.prompt[:200],
-                tags=[task_type_str],
+                tags=tags,
             )
             logger.info(f"_store_reasoning: created fact id={fact.id} subject={pattern[:50]}")
             return fact

--- a/src/neo/panel.py
+++ b/src/neo/panel.py
@@ -50,18 +50,33 @@ def _selected_model(decision: dict) -> Optional[str]:
     return None
 
 
+def _family(model_id: str) -> str:
+    """Coarse model-*family* key for diversity counting. Providers expose
+    multiple catalog IDs backed by the *same* model — e.g. ``parslee/advisor``
+    and ``parslee/reasoning`` are both Azure gpt-5.5 (assistant personas), so
+    they must count as ONE, not two, or the ``>=2 distinct models`` gate is
+    fooled into deliberating with no real diversity. We key on the provider
+    prefix before the first ``/`` (``parslee/*`` → ``parslee``, ``mlx/*`` →
+    ``mlx``). This is conservative — it may merge genuinely-distinct models of
+    one provider — which is the safe direction (bias toward the fast path).
+    """
+    return model_id.split("/", 1)[0] if "/" in model_id else model_id
+
+
 def capable_model_count(route_fn: Callable[[str, str], str], probe: str = "code task") -> int:
-    """Distinct capable models CAR could route a code task to (the panel's
-    diversity ceiling). Reads ``route_model``'s advisory ``candidates`` ranking.
-    Returns 0 on any failure (→ gate falls back to the fast path)."""
+    """Distinct capable model *families* CAR could route a code task to (the
+    panel's real diversity ceiling — see ``_family``). Reads ``route_model``'s
+    advisory ``candidates`` ranking. Returns 0 on any failure (→ gate falls back
+    to the fast path)."""
     try:
         decision = json.loads(route_fn(probe, json.dumps(ROLE_INTENTS["coder"])) or "{}")
     except (ValueError, TypeError):
         return 0
     cands = decision.get("candidates") or []
-    ids = {c.get("model_id") for c in cands if isinstance(c, dict) and c.get("model_id")}
-    if ids:
-        return len(ids)
+    families = {_family(c["model_id"]) for c in cands
+                if isinstance(c, dict) and c.get("model_id")}
+    if families:
+        return len(families)
     # Cold-start / explicit-model paths return no ranking but did pick one.
     return 1 if _selected_model(decision) else 0
 

--- a/tests/test_engine_reasoning.py
+++ b/tests/test_engine_reasoning.py
@@ -89,3 +89,47 @@ def test_deliberate_failure_returns_none_for_fallback():
     e = _engine(FakeLM(lambda m: "no json"))
     plan, sims, code, result = e._deliberate({"prompt": "x"}, route_fn=None)
     assert result is not None and result.confidence == 0.0
+
+
+class _FakeStore:
+    def __init__(self):
+        self.added = []
+
+    def add_fact(self, **kw):
+        self.added.append(kw)
+        return type("F", (), {"id": "f1"})()
+
+
+def _store_engine():
+    from neo.models import NeoInput, PlanStep, CodeSuggestion, TaskType
+    e = _engine(FakeLM(lambda m: "{}"))
+    store = _FakeStore()
+    e.fact_store = store
+    e.persistent_memory = store
+    ni = NeoInput(prompt="do x", task_type=TaskType.FEATURE)
+    plan = [PlanStep(description="step", rationale="r")]
+    code = [CodeSuggestion(file_path="f.py", unified_diff="", description="d",
+                           confidence=0.8, code_block="x=1")]
+    return e, store, ni, plan, code
+
+
+def test_fast_path_facts_have_no_provenance_tags():
+    e, store, ni, plan, code = _store_engine()
+    e.last_deliberation = None
+    e._store_reasoning(ni, plan, code, 0.8, {})
+    assert "multi-agent" not in store.added[-1]["tags"]
+    assert "probation" not in store.added[-1]["tags"]
+
+
+def test_deliberated_facts_get_provenance_and_probation():
+    from neo.multi_agent import DeliberationResult
+    e, store, ni, plan, code = _store_engine()
+    e.last_deliberation = DeliberationResult(
+        plan=[], simulation_traces=[], code_suggestions=[],
+        confidence=0.7, consensus=0.8, rounds=0,
+    )
+    e._store_reasoning(ni, plan, code, 0.7, {})
+    tags = store.added[-1]["tags"]
+    assert "multi-agent" in tags and "probation" in tags
+    # confidence stored is the consensus-based value passed in, not self-report
+    assert store.added[-1]["confidence"] == 0.7

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -44,6 +44,16 @@ def test_capable_model_count_reads_candidates():
     assert capable_model_count(make_route_fn([])) == 0
 
 
+def test_capable_model_count_dedupes_same_backend_personas():
+    # parslee/advisor + parslee/reasoning are both gpt-5.5 -> one family.
+    pool = [
+        {"id": "parslee/advisor", "score": 0.90},
+        {"id": "parslee/reasoning", "score": 0.85},
+        {"id": "mlx/qwen3-4b:4bit", "score": 0.60},
+    ]
+    assert capable_model_count(make_route_fn(pool)) == 2  # {parslee, mlx}, not 3
+
+
 def test_critic_is_forced_off_the_coder_model():
     plan = plan_role_models(make_route_fn(POOL), "task")
     # coder gets the top model; critic must be excluded off it -> different model

--- a/tools/ab_reasoning.py
+++ b/tools/ab_reasoning.py
@@ -98,10 +98,23 @@ def judge(adapter, task: str, sol_a: str, sol_b: str) -> dict:
     }
 
 
-def run(n: int, k: int, model: str, out: Path, effort: str = "low") -> dict:
+def _role_factory(default_adapter, critic_model):
+    """Route the critic role to a *distinct-family* model (e.g. a local CAR
+    model) while other roles use the default — to measure model diversity, not
+    just orchestration."""
+    if not critic_model:
+        return lambda role: default_adapter
+    from neo.adapters import CarAdapter
+    critic = CarAdapter(model=critic_model)
+    return lambda role: critic if role == "critic" else default_adapter
+
+
+def run(n: int, k: int, model: str, out: Path, effort: str = "low",
+        critic_model: str = "") -> dict:
     key = NeoConfig.load().api_key
     adapter = EffortAdapter(OpenAIAdapter(model=model, api_key=key), effort)
-    reasoner = MultiAgentReasoner(lambda role: adapter, k_plans=k, max_repair_rounds=1)
+    reasoner = MultiAgentReasoner(_role_factory(adapter, critic_model),
+                                  k_plans=k, max_repair_rounds=1)
 
     rng = random.Random(1234)
     tasks = TASKS[:n]
@@ -160,7 +173,8 @@ def run(n: int, k: int, model: str, out: Path, effort: str = "low") -> dict:
     scored = multi_wins + single_wins + ties
     denom = max(1, scored)
     summary = {
-        "model": model, "effort": effort, "n": len(tasks), "scored": scored, "k_plans": k,
+        "model": model, "effort": effort, "critic_model": critic_model or model,
+        "n": len(tasks), "scored": scored, "k_plans": k,
         "multi_wins": multi_wins, "single_wins": single_wins, "ties": ties,
         "multi_win_rate": round(multi_wins / denom, 3),
         "decisive_multi_win_rate": round(multi_wins / max(1, multi_wins + single_wins), 3),
@@ -182,6 +196,7 @@ if __name__ == "__main__":
     ap.add_argument("--k", type=int, default=3)
     ap.add_argument("--model", default="gpt-5.5")
     ap.add_argument("--effort", default="low")
+    ap.add_argument("--critic-model", default="", help="Distinct-family model for the critic role (e.g. mlx/qwen3-4b:4bit)")
     ap.add_argument("--out", default="/tmp/ab_reasoning_results.json")
     a = ap.parse_args()
-    run(a.n, a.k, a.model, Path(a.out), effort=a.effort)
+    run(a.n, a.k, a.model, Path(a.out), effort=a.effort, critic_model=a.critic_model)


### PR DESCRIPTION
## Description

Two follow-ups to the tiered-reasoning design (#129), both **doable now** — clarifying that neither was actually blocked on an unreleased CAR feature.

### #2 — Memory provenance (deliberate once, recall forever)
Deliberated outcomes now enter memory tagged `[multi-agent, probation]`: recognizable and **trust-first**. They're promoted only by real outcomes (`access_count>=2` / `success_count>0`) via the existing pipeline — so a wrong panel answer never becomes confident memory unchecked. The stored confidence is the panel **consensus**, not a single model's self-report. Fast-path facts are unchanged.

### #1 — Model diversity: mechanism validated + a gate fix
Validating the diversity path against **real CAR** confirmed the mechanism works (`exclude_models` routed `critic → parslee/reasoning`, distinct from `coder → parslee/advisor`) — but surfaced a **gate bug**:

- `capable_model_count` counted `parslee/advisor` + `parslee/reasoning` as 2 distinct models, but **both are Azure gpt-5.5** (assistant personas). So the `≥2 distinct models` gate could deliberate with *no real diversity*. **Fix:** count distinct provider *families* (`parslee/*` → 1). Conservative — biases toward the fast path.

**Why the diversity quality A/B isn't here:** it's not an unreleased CAR feature. It needs a second *fast + capable + distinct* model, and this host has none: `parslee` *is* gpt-5.5, the only distinct family (local MLX) **timed out at 180s on every critique**, and there's no Anthropic/Google key. The harness supports it (`--critic-model`); it just needs a viable second model — a credential/infra decision. Details in the design doc.

## Type of Change
- [x] New feature (memory provenance) + [x] Bug fix (diversity-count gate)

## How Has This Been Tested?
- [x] +3 tests (provenance tagging on deliberated vs fast facts; family-dedup count). Full reasoning suite: 30 passing.
- [x] Diversity *mechanism* validated end-to-end against live CAR (critic ≠ coder).

## Additional Notes
`main` state check: CAR router fix (#469) is live in installed CarHost 0.32.1; the parslee raw-endpoint (#485) is merged to car `main` but not yet in a release — and is irrelevant to diversity since parslee is gpt-5.5. The real diversity gap is a second frontier credential.
