### PR TITLE
fix: recover from reasoning-model param rejections across LM adapters

### DIFF
--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -25,6 +25,87 @@ logger = logging.getLogger(__name__)
 
 
 # ============================================================================
+# Reasoning-model parameter compatibility (OpenAI-SDK adapters)
+# ============================================================================
+#
+# Newer reasoning models reject standard chat-completions parameters:
+#   - `temperature` is rejected (OpenAI o-series / gpt-5, xAI Grok and DeepSeek
+#     reasoners behind an OpenAI-compatible endpoint, Azure reasoning deploys).
+#   - `max_tokens` must be sent as `max_completion_tokens`.
+# There is no reliable model-string rule — and on Azure `model` is an arbitrary
+# deployment name — so we learn each adaptation from the API's own 400 and
+# remember it process-wide to avoid repeat round-trips. Same learn-and-retry
+# shape as AnthropicAdapter's temperature handling.
+_MODELS_REJECTING_TEMPERATURE: set[str] = set()
+_MODELS_NEEDING_MAX_COMPLETION_TOKENS: set[str] = set()
+
+
+def _chat_completion_resilient(client, kwargs: dict):
+    """Call ``client.chat.completions.create(**kwargs)``, recovering from the
+    reasoning-model parameter rejections described above.
+
+    Adaptations already learned for this model are applied up front; anything
+    new is discovered from the 400, applied, remembered, and retried. A 400 for
+    any other reason re-raises untouched. Loop is bounded implicitly: each
+    adaptation removes the key it keys on, so it can fire at most once (worst
+    case: temperature + max_tokens + success = 3 calls). ``kwargs`` is copied,
+    not mutated, so callers may safely pass a shared/cached dict.
+
+    Scope of each adaptation:
+      - `temperature` drop is broad — o-series / gpt-5, Azure reasoning
+        deployments, and OpenAI-compatible reasoners (xAI Grok, DeepSeek) all
+        reject it.
+      - `max_completion_tokens` rename is OpenAI-family only (OpenAI + Azure,
+        which share the `openai` SDK's error text). Grok/DeepSeek accept
+        `max_tokens`, so they never hit that branch.
+    """
+    import openai
+
+    kwargs = dict(kwargs)  # own our copy — never mutate the caller's dict
+    model = kwargs.get("model", "")
+    if model in _MODELS_REJECTING_TEMPERATURE:
+        kwargs.pop("temperature", None)
+    if model in _MODELS_NEEDING_MAX_COMPLETION_TOKENS and "max_tokens" in kwargs:
+        kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+
+    while True:
+        try:
+            return client.chat.completions.create(**kwargs)
+        except openai.BadRequestError as e:
+            msg = str(e).lower()
+            # NOTE: we can't distinguish "temperature is deprecated/unsupported"
+            # from an out-of-range value error ("temperature must be <= 2") by
+            # message alone. That's fine here: neo only ever sends in-range
+            # temperatures, so a `temperature` 400 always means rejection.
+            if "temperature" in kwargs and "temperature" in msg:
+                _MODELS_REJECTING_TEMPERATURE.add(model)
+                kwargs.pop("temperature", None)
+                logger.debug(
+                    "Model %s rejected `temperature`; dropped it and retrying",
+                    model,
+                )
+                continue
+            # Rename trigger: the message references `max_tokens` and signals
+            # the param is unsupported (either by naming the replacement or by
+            # an unsupported/not-supported phrase — robust to minor OpenAI
+            # wording changes). A plain value error on max_tokens carries none
+            # of these and correctly re-raises.
+            if "max_tokens" in kwargs and "max_tokens" in msg and (
+                "max_completion_tokens" in msg
+                or "unsupported" in msg
+                or "not supported" in msg
+            ):
+                _MODELS_NEEDING_MAX_COMPLETION_TOKENS.add(model)
+                kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+                logger.debug(
+                    "Model %s requires `max_completion_tokens`; renamed and "
+                    "retrying", model,
+                )
+                continue
+            raise
+
+
+# ============================================================================
 # OpenAI Adapter
 # ============================================================================
 
@@ -107,14 +188,17 @@ class OpenAIAdapter(LMAdapter):
 
                 raise ValueError(f"No completed message in response: {data}")
             else:
-                # Standard chat completions for other models
-                response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    stop=stop,
-                )
+                # Standard chat completions for other models. Route through the
+                # resilient helper so o-series (and other reasoning models that
+                # aren't matched above) recover from `temperature` /
+                # `max_tokens` rejections instead of erroring.
+                response = _chat_completion_resilient(self.client, {
+                    "model": self.model,
+                    "messages": messages,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "stop": stop,
+                })
                 self._emit_usage_metric(getattr(response, "usage", None))
                 return response.choices[0].message.content
 
@@ -195,6 +279,15 @@ class OpenAIAdapter(LMAdapter):
 class AnthropicAdapter(LMAdapter):
     """Adapter for Anthropic models (Claude)."""
 
+    # Claude models that reject the `temperature` sampling parameter with a 400
+    # ("temperature is deprecated for this model") — Opus 4.7+, Sonnet 5,
+    # Fable 5, and later. There's no clean model-string rule (opus-4-6 accepts
+    # it, opus-4-7 rejects it), so instead of hardcoding a taxonomy that goes
+    # stale on the next release, we learn it from the API's own error and
+    # remember it. Class-level so the lesson persists across adapter instances
+    # in a process (multi_agent makes several calls per query).
+    _models_without_temperature: set[str] = set()
+
     def __init__(self, model: str = "claude-sonnet-4-5-20250929", api_key: Optional[str] = None):
         self.model = model
         self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
@@ -233,8 +326,12 @@ class AnthropicAdapter(LMAdapter):
             "model": self.model,
             "messages": formatted_messages,
             "max_tokens": max_tokens,
-            "temperature": temperature,
         }
+        # Only send `temperature` to models known to accept it. Newer Claude
+        # models (Opus 4.7+, Sonnet 5, Fable 5) reject it; see
+        # `_models_without_temperature`.
+        if self.model not in self._models_without_temperature:
+            kwargs["temperature"] = temperature
 
         if system_message:
             kwargs["system"] = system_message
@@ -242,6 +339,7 @@ class AnthropicAdapter(LMAdapter):
         if stop:
             kwargs["stop_sequences"] = stop
 
+        import anthropic
         from neo.memory.metrics import capture_lm_call_failure
         with capture_lm_call_failure(
             provider="anthropic",
@@ -249,7 +347,21 @@ class AnthropicAdapter(LMAdapter):
             max_tokens=max_tokens,
             temperature=temperature,
         ):
-            response = self.client.messages.create(**kwargs)
+            try:
+                response = self.client.messages.create(**kwargs)
+            except anthropic.BadRequestError as e:
+                # Newer Claude models reject `temperature` with a 400. Learn
+                # the model, drop the param, and retry once so the call still
+                # succeeds. A 400 for any other reason re-raises untouched.
+                if "temperature" not in kwargs or "temperature" not in str(e).lower():
+                    raise
+                self._models_without_temperature.add(self.model)
+                kwargs.pop("temperature", None)
+                logger.debug(
+                    "Anthropic model %s rejected `temperature`; dropped it "
+                    "and retrying", self.model,
+                )
+                response = self.client.messages.create(**kwargs)
             self._emit_usage_metric(response)
             return response.content[0].text
 
@@ -414,13 +526,17 @@ class LocalAdapter(LMAdapter):
         reasoning_effort: Optional[str] = None,  # not supported; accepted for ABC compat
     ) -> str:
         """Generate response using local API."""
-        response = self.client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            stop=stop,
-        )
+        # OpenAI-compatible endpoints front many providers (vLLM, llama.cpp,
+        # xAI Grok, DeepSeek); resilient helper recovers if the model behind
+        # the endpoint is a reasoning model that rejects `temperature` /
+        # `max_tokens`.
+        response = _chat_completion_resilient(self.client, {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stop": stop,
+        })
         return response.choices[0].message.content
 
     def name(self) -> str:
@@ -538,13 +654,17 @@ class AzureOpenAIAdapter(LMAdapter):
         reasoning_effort: Optional[str] = None,  # not supported; accepted for ABC compat
     ) -> str:
         """Generate response using Azure OpenAI API."""
-        response = self.client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            stop=stop,
-        )
+        # Azure `model` is an arbitrary deployment name, so reasoning models
+        # (gpt-5 / o-series deployments) can't be detected by string — they
+        # reject `temperature` and require `max_completion_tokens` instead of
+        # `max_tokens`. The resilient helper learns both from the 400.
+        response = _chat_completion_resilient(self.client, {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stop": stop,
+        })
         return response.choices[0].message.content
 
     def name(self) -> str:

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,112 @@
+"""Tests for AnthropicAdapter request shaping.
+
+Focus: newer Claude models (Opus 4.7+, Sonnet 5, Fable 5) reject the
+`temperature` sampling parameter with a 400 ("temperature is deprecated for
+this model"). The adapter must recover by dropping the param and retrying,
+then remember the model so subsequent calls omit it up front.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Pre-warm the numpy-backed import chain that AnthropicAdapter.generate() pulls
+# in lazily (via neo.memory.metrics). If these are first imported *inside* a
+# patch.dict(sys.modules) window, patch.dict deletes them on teardown and the
+# numpy C-extensions can't reload ("cannot load module more than once per
+# process"). Importing them here keeps them out of the patched delta.
+import neo.memory.metrics  # noqa: E402,F401
+from neo import adapters  # noqa: E402,F401
+
+
+class _BadRequestError(Exception):
+    """Stand-in for anthropic.BadRequestError."""
+
+
+@pytest.fixture
+def _fake_anthropic():
+    """Inject a fake `anthropic` module and reset the learned-model cache."""
+    mock_anthropic = MagicMock()
+    mock_anthropic.BadRequestError = _BadRequestError
+    with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
+        from neo.adapters import AnthropicAdapter
+
+        AnthropicAdapter._models_without_temperature.clear()
+        try:
+            yield AnthropicAdapter
+        finally:
+            AnthropicAdapter._models_without_temperature.clear()
+
+
+def _ok_response(text="ok"):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=2,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        ),
+    )
+
+
+def test_temperature_sent_for_models_that_accept_it(_fake_anthropic):
+    adapter = _fake_anthropic(model="claude-sonnet-4-5-20250929", api_key="k")
+    adapter.client = MagicMock()
+    adapter.client.messages.create.return_value = _ok_response()
+
+    adapter.generate([{"role": "user", "content": "hi"}], temperature=0.3)
+
+    kwargs = adapter.client.messages.create.call_args.kwargs
+    assert kwargs["temperature"] == 0.3
+
+
+def test_drops_temperature_and_retries_on_400(_fake_anthropic):
+    """A 400 naming `temperature` triggers a param-stripped retry that succeeds."""
+    adapter = _fake_anthropic(model="claude-opus-4-8", api_key="k")
+    adapter.client = MagicMock()
+    adapter.client.messages.create.side_effect = [
+        _BadRequestError("`temperature` is deprecated for this model."),
+        _ok_response("recovered"),
+    ]
+
+    result = adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert result == "recovered"
+    assert adapter.client.messages.create.call_count == 2
+    # First call included temperature; retry omitted it.
+    assert "temperature" in adapter.client.messages.create.call_args_list[0].kwargs
+    assert "temperature" not in adapter.client.messages.create.call_args_list[1].kwargs
+    # The model is remembered process-wide.
+    assert "claude-opus-4-8" in adapter._models_without_temperature
+
+
+def test_remembered_model_omits_temperature_up_front(_fake_anthropic):
+    """After learning a model rejects temperature, later calls skip it — no
+    wasted 400."""
+    adapter = _fake_anthropic(model="claude-opus-4-8", api_key="k")
+    adapter._models_without_temperature.add("claude-opus-4-8")
+    adapter.client = MagicMock()
+    adapter.client.messages.create.return_value = _ok_response()
+
+    adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert adapter.client.messages.create.call_count == 1
+    assert "temperature" not in adapter.client.messages.create.call_args.kwargs
+
+
+def test_unrelated_400_reraises(_fake_anthropic):
+    """A 400 that isn't about temperature propagates — no silent retry."""
+    adapter = _fake_anthropic(model="claude-opus-4-8", api_key="k")
+    adapter.client = MagicMock()
+    adapter.client.messages.create.side_effect = _BadRequestError(
+        "max_tokens: must be positive"
+    )
+
+    with pytest.raises(_BadRequestError):
+        adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)
+
+    assert adapter.client.messages.create.call_count == 1
+    assert "claude-opus-4-8" not in adapter._models_without_temperature

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -4,6 +4,12 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+# Pre-warm the numpy-backed import chain that OpenAIAdapter.generate() pulls in
+# lazily (via neo.memory.metrics). Importing it inside a patch.dict(sys.modules)
+# window causes patch.dict to delete numpy's C-extensions on teardown, which
+# then fail to reload ("cannot load module more than once per process").
+import neo.memory.metrics  # noqa: E402,F401
+
 
 def _make_mock_response():
     return SimpleNamespace(

--- a/tests/test_reasoning_model_params.py
+++ b/tests/test_reasoning_model_params.py
@@ -1,0 +1,200 @@
+"""Tests for reasoning-model parameter compatibility across the OpenAI-SDK
+adapters (OpenAI chat path, Azure OpenAI, Local/OpenAI-compatible).
+
+Newer reasoning models reject `temperature` and require `max_completion_tokens`
+instead of `max_tokens`. `_chat_completion_resilient` learns each adaptation
+from the API's own 400 and remembers it. On Azure the model is an arbitrary
+deployment name, so this reactive approach is the only reliable one.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Pre-warm the numpy-backed import chain the OpenAI adapter pulls in lazily
+# (via neo.memory.metrics), so patch.dict(sys.modules) doesn't delete numpy's
+# C-extensions on teardown ("cannot load module more than once per process").
+import neo.memory.metrics  # noqa: E402,F401
+
+
+class _BadRequest(Exception):
+    """Stand-in for openai.BadRequestError."""
+
+
+_TEMP_ERR = _BadRequest(
+    "Unsupported value: 'temperature' does not support 0.7 with this model. "
+    "Only the default (1) value is supported."
+)
+_MAXTOK_ERR = _BadRequest(
+    "Unsupported parameter: 'max_tokens' is not supported with this model. "
+    "Use 'max_completion_tokens' instead."
+)
+
+
+def _ok(text="ok"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+        usage=None,
+    )
+
+
+@pytest.fixture
+def _fake_openai():
+    """Inject a fake `openai` module (with a real BadRequestError) and reset
+    the process-wide learned-model caches."""
+    mock_openai = MagicMock()
+    mock_openai.BadRequestError = _BadRequest
+    with patch.dict(sys.modules, {"openai": mock_openai}):
+        from neo import adapters
+
+        adapters._MODELS_REJECTING_TEMPERATURE.clear()
+        adapters._MODELS_NEEDING_MAX_COMPLETION_TOKENS.clear()
+        try:
+            yield adapters
+        finally:
+            adapters._MODELS_REJECTING_TEMPERATURE.clear()
+            adapters._MODELS_NEEDING_MAX_COMPLETION_TOKENS.clear()
+
+
+def _client_with(side_effect):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = side_effect
+    return client
+
+
+# --- the shared helper directly -------------------------------------------
+
+def test_helper_passes_through_when_accepted(_fake_openai):
+    client = _client_with([_ok("fine")])
+    out = _fake_openai._chat_completion_resilient(
+        client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100}
+    )
+    assert out.choices[0].message.content == "fine"
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_helper_drops_temperature_then_renames_max_tokens(_fake_openai):
+    """A reasoning model that rejects both params: temperature is dropped, then
+    max_tokens is renamed, then the call succeeds — three attempts total."""
+    client = _client_with([_TEMP_ERR, _MAXTOK_ERR, _ok("recovered")])
+    out = _fake_openai._chat_completion_resilient(
+        client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
+    )
+    assert out.choices[0].message.content == "recovered"
+    calls = client.chat.completions.create.call_args_list
+    assert len(calls) == 3
+    # call 1: both present
+    assert "temperature" in calls[0].kwargs and "max_tokens" in calls[0].kwargs
+    # call 2: temperature gone, max_tokens still there
+    assert "temperature" not in calls[1].kwargs and "max_tokens" in calls[1].kwargs
+    # call 3: renamed to max_completion_tokens, no max_tokens, no temperature
+    assert "max_tokens" not in calls[2].kwargs
+    assert calls[2].kwargs["max_completion_tokens"] == 100
+    assert "temperature" not in calls[2].kwargs
+    # both adaptations remembered
+    assert "o3-mini" in _fake_openai._MODELS_REJECTING_TEMPERATURE
+    assert "o3-mini" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+
+
+def test_helper_applies_learned_adaptations_up_front(_fake_openai):
+    """Once learned, a model skips both bad params on the first attempt."""
+    _fake_openai._MODELS_REJECTING_TEMPERATURE.add("o3-mini")
+    _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS.add("o3-mini")
+    client = _client_with([_ok()])
+
+    _fake_openai._chat_completion_resilient(
+        client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
+    )
+
+    assert client.chat.completions.create.call_count == 1
+    kw = client.chat.completions.create.call_args.kwargs
+    assert "temperature" not in kw
+    assert "max_tokens" not in kw
+    assert kw["max_completion_tokens"] == 100
+
+
+def test_helper_reraises_unrelated_400(_fake_openai):
+    client = _client_with([_BadRequest("messages: must be a non-empty array")])
+    with pytest.raises(_BadRequest):
+        _fake_openai._chat_completion_resilient(
+            client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100}
+        )
+    assert client.chat.completions.create.call_count == 1
+    assert not _fake_openai._MODELS_REJECTING_TEMPERATURE
+
+
+def test_helper_renames_on_unsupported_wording_without_replacement_named(_fake_openai):
+    """Robust to wording that doesn't name the replacement param — an
+    `unsupported`/`not supported` signal on max_tokens is enough."""
+    err = _BadRequest("Unsupported parameter: 'max_tokens' is not supported with this model.")
+    client = _client_with([err, _ok("renamed")])
+    out = _fake_openai._chat_completion_resilient(
+        client, {"model": "some-reasoner", "max_tokens": 100}
+    )
+    assert out.choices[0].message.content == "renamed"
+    assert client.chat.completions.create.call_args_list[-1].kwargs["max_completion_tokens"] == 100
+    assert "some-reasoner" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+
+
+def test_helper_does_not_rename_on_plain_max_tokens_value_error(_fake_openai):
+    """A value error on max_tokens (no unsupported signal) must re-raise, not
+    trigger a spurious rename."""
+    client = _client_with([_BadRequest("max_tokens must be at least 1")])
+    with pytest.raises(_BadRequest):
+        _fake_openai._chat_completion_resilient(
+            client, {"model": "gpt-4", "max_tokens": 0}
+        )
+    assert client.chat.completions.create.call_count == 1
+    assert not _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+
+
+def test_helper_does_not_mutate_callers_kwargs(_fake_openai):
+    """The helper copies kwargs — a caller passing a shared/cached dict is safe."""
+    caller_kwargs = {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
+    snapshot = dict(caller_kwargs)
+    client = _client_with([_TEMP_ERR, _MAXTOK_ERR, _ok()])
+    _fake_openai._chat_completion_resilient(client, caller_kwargs)
+    assert caller_kwargs == snapshot  # untouched despite two adaptations
+
+
+# --- through the adapters ---------------------------------------------------
+
+def test_local_adapter_recovers_from_temperature_rejection(_fake_openai):
+    adapter = _fake_openai.LocalAdapter(model="grok-4-reasoning")
+    adapter.client = _client_with([_TEMP_ERR, _ok("hi")])
+
+    out = adapter.generate([{"role": "user", "content": "yo"}], temperature=0.5)
+
+    assert out == "hi"
+    assert adapter.client.chat.completions.create.call_count == 2
+    assert "grok-4-reasoning" in _fake_openai._MODELS_REJECTING_TEMPERATURE
+
+
+def test_azure_adapter_recovers_from_both_rejections(_fake_openai):
+    adapter = _fake_openai.AzureOpenAIAdapter(
+        model="my-o3-deploy", api_key="k", endpoint="https://x.openai.azure.com"
+    )
+    adapter.client = _client_with([_TEMP_ERR, _MAXTOK_ERR, _ok("azure-ok")])
+
+    out = adapter.generate([{"role": "user", "content": "yo"}], temperature=0.5)
+
+    assert out == "azure-ok"
+    calls = adapter.client.chat.completions.create.call_args_list
+    assert len(calls) == 3
+    assert calls[-1].kwargs["max_completion_tokens"] == 4096
+    assert "temperature" not in calls[-1].kwargs
+    assert "my-o3-deploy" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+
+
+def test_openai_chat_path_recovers_for_o_series(_fake_openai):
+    """o-series slips past the gpt-5/codex responses-endpoint routing and lands
+    on the chat path, where the helper recovers it."""
+    adapter = _fake_openai.OpenAIAdapter(model="o3-mini", api_key="k")
+    adapter.client = _client_with([_TEMP_ERR, _ok("chat-ok")])
+
+    out = adapter.generate([{"role": "user", "content": "yo"}], temperature=0.9)
+
+    assert out == "chat-ok"
+    assert "o3-mini" in _fake_openai._MODELS_REJECTING_TEMPERATURE


### PR DESCRIPTION
## Description

Neo's LM adapters unconditionally sent standard chat-completions parameters (`temperature`, `max_tokens`) that newer **reasoning models reject with a 400** — producing the reported `ProcessingError` / `BadRequestError` for users on those models. This makes every adapter recover gracefully by adapting the request and retrying, learning per-model so repeat calls skip the bad param up front.

Reported symptom (Anthropic):
```
"error": "ProcessingError",
"message": "... Error code: 400 - {'type':'error','error':{'type':'invalid_request_error',
            'message':'`temperature` is deprecated for this model.'}}"
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

N/A (user-reported via support). Follow-up tracked in #133 (persist the learned param-compat cache to `~/.neo/`).

## Motivation and Context

Newer reasoning models changed their accepted parameter surface:

- **Anthropic** Opus 4.7+/Sonnet 5/Fable 5 reject `temperature`.
- **OpenAI** o-series/gpt-5, **Azure** reasoning deployments, and OpenAI-compatible reasoners (**xAI Grok, DeepSeek** via `LocalAdapter`) reject `temperature`; the OpenAI-family additionally require `max_completion_tokens` instead of `max_tokens`.

There is **no reliable model-string rule** (`opus-4-6` accepts `temperature`, `opus-4-7` rejects it; on Azure `model` is an arbitrary deployment name), so a hardcoded allow/deny list would silently break on the next model. Instead we adapt **reactively**: catch the 400, drop/rename the offending param, retry, and remember the model process-wide. Any 400 for another reason re-raises untouched (fail-fast preserved).

### Changes
- **`AnthropicAdapter`** — class-level `_models_without_temperature` learn-and-retry for `temperature`, inside the existing metrics context.
- **`_chat_completion_resilient`** — shared helper for the three `openai`-SDK adapters (**OpenAI chat path, Azure, Local**) handling both the `temperature` drop and the `max_completion_tokens` rename. Copies `kwargs` (never mutates the caller's dict) and logs each adaptation at debug level. Loop is bounded: each adaptation removes the key it keys on, so ≤3 calls worst case.
- The OpenAI `gpt-5`/codex `/v1/responses` path is unchanged (already omits `temperature`).

### Adapter coverage
| Adapter | temperature | max_tokens rename |
|---|---|---|
| Anthropic | ✅ learn-and-retry | n/a |
| OpenAI (chat) / Azure / Local | ✅ shared helper | ✅ shared helper |
| OpenAI (`gpt-5`/codex) | ✅ already | ✅ already |
| Google, Ollama, ClaudeCode, CAR | n/a | n/a |

### Review
Routed through a kernel-quality review; addressed both flagged items — broadened the `max_completion_tokens` discriminator (no longer coupled to exact OpenAI wording) and made the helper copy `kwargs` — plus the suggested debug logging.

## How Has This Been Tested?

- [x] `tests/test_anthropic_adapter.py` — temperature sent when accepted; drop-and-retry on 400; learned model skips it up front; unrelated 400 re-raises.
- [x] `tests/test_reasoning_model_params.py` — helper pass-through; drop-temp-then-rename-max_tokens; learned-adaptations-up-front; unrelated 400 re-raises; broadened rename wording; plain max_tokens value error does **not** rename; kwargs not mutated; plus Local/Azure/OpenAI adapter integration.
- [x] Fixed a pre-existing `patch.dict(sys.modules)` × numpy teardown crash in `test_openai_adapter.py`.

**Test Configuration**:
- Python version: 3.13
- OS: macOS (darwin)
- Neo version: 0.35.0

Full suite: **1243 passed, 3 skipped**. Ruff: clean.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The learned-model caches are process-local and not persisted — they mainly help *within* a multi-agent run (several LM calls per query), not across CLI invocations. Acceptable given rejected 400s cost latency, not tokens; if first-call latency ever bites, the two sets could be persisted to `~/.neo/` — tracked as a follow-up in #133.

