### PR TITLE
feat: persist learned reasoning-model param-compat cache (#133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,4 +193,19 @@
   `CarAdapter.DEFAULT_INTENT_HINT` in `adapters.py`. Observer floor is car-runtime ≥0.18.0,
   now enforced at runtime by `_require_car_runtime` (version check, not just the `agents_*`
   attr); latest validated against car-runtime 0.27.0.
+- Reasoning-model param compatibility (`adapters.py`): newer models reject standard
+  chat params — Anthropic Opus 4.7+/Sonnet 5/Fable 5 reject `temperature`; OpenAI
+  o-series/gpt-5, Azure reasoning deployments, and OpenAI-compatible reasoners (xAI
+  Grok, DeepSeek) reject `temperature`, and the OpenAI-family require
+  `max_completion_tokens` instead of `max_tokens`. There's no reliable model-string
+  rule (opus-4-6 accepts `temperature`, opus-4-7 rejects it; Azure `model` is an
+  arbitrary deployment name), so adapters **learn reactively**: catch the 400, drop/
+  rename the param, retry, remember. The learnings persist in `_ModelParamCompat`
+  (`~/.neo/model_param_compat.json`, keyed `"<provider>:<model>" → [flags]`) so the
+  first-call retry penalty isn't re-paid every CLI invocation. Store is best-effort
+  (I/O failure → in-memory only, never breaks inference), merge-on-write + atomic
+  `os.replace`, path resolved at call time (per-test `Path.home()` stubs apply). The
+  OpenAI-family adapters share `_chat_completion_resilient(client, kwargs, provider)`;
+  Anthropic has its own inline learn-and-retry. **Footgun**: recovery keys on HTTP 400
+  (`BadRequestError`); a provider returning 422 for a param error won't be caught.
 - When creating a pull request, always use the PR template included in the repo.

--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -30,26 +30,135 @@ logger = logging.getLogger(__name__)
 #
 # Newer reasoning models reject standard chat-completions parameters:
 #   - `temperature` is rejected (OpenAI o-series / gpt-5, xAI Grok and DeepSeek
-#     reasoners behind an OpenAI-compatible endpoint, Azure reasoning deploys).
-#   - `max_tokens` must be sent as `max_completion_tokens`.
+#     reasoners behind an OpenAI-compatible endpoint, Azure reasoning deploys,
+#     Anthropic Opus 4.7+ / Sonnet 5 / Fable 5).
+#   - `max_tokens` must be sent as `max_completion_tokens` (OpenAI-family).
 # There is no reliable model-string rule — and on Azure `model` is an arbitrary
-# deployment name — so we learn each adaptation from the API's own 400 and
-# remember it process-wide to avoid repeat round-trips. Same learn-and-retry
-# shape as AnthropicAdapter's temperature handling.
-_MODELS_REJECTING_TEMPERATURE: set[str] = set()
-_MODELS_NEEDING_MAX_COMPLETION_TOKENS: set[str] = set()
+# deployment name — so we learn each adaptation from the API's own 400. The
+# learnings are persisted (see `_ModelParamCompat`) so the first-call retry
+# penalty isn't re-paid on every short-lived CLI invocation.
+
+# Adaptation flags recorded per model.
+_ADAPT_DROP_TEMPERATURE = "drop_temperature"
+_ADAPT_RENAME_MAX_TOKENS = "rename_max_tokens"
 
 
-def _chat_completion_resilient(client, kwargs: dict):
+class _ModelParamCompat:
+    """Persistent record of which parameter adaptations each model needs.
+
+    Backed by ``~/.neo/model_param_compat.json`` as ``{"<provider>:<model>":
+    ["<flag>", ...]}``. Keyed by provider so a bare model name (e.g. ``gpt-4``)
+    behind a Local endpoint can't collide with the same name on Azure/OpenAI.
+
+    - The path is resolved at call time so per-test ``Path.home()`` stubs apply
+      (mirrors ``neo.memory.metrics._metrics_path``).
+    - An in-memory cache avoids re-reading on every call; it reloads whenever
+      the resolved path changes (so each isolated test home starts clean, while
+      production loads once).
+    - Writes are merge-on-write + atomic replace, so concurrent neo processes
+      union their learnings rather than clobbering each other.
+    - Persistence is best-effort: any I/O failure degrades to in-memory-only
+      and never breaks inference.
+    """
+
+    def __init__(self) -> None:
+        self._path: Optional[Path] = None
+        self._data: dict[str, set[str]] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _resolve() -> Path:
+        return Path.home() / ".neo" / "model_param_compat.json"
+
+    @staticmethod
+    def _read(path: Path) -> dict[str, set[str]]:
+        """Load the store, tolerating anything. A missing file, invalid JSON,
+        or valid JSON of the wrong shape (``null``, a list, a scalar, non-list
+        values, unhashable flags) all degrade to an empty mapping — never a
+        raise. This cache must never break inference (see `has`/`learn`)."""
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, ValueError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, set[str]] = {}
+        for key, flags in raw.items():
+            if isinstance(key, str) and isinstance(flags, list):
+                out[key] = {f for f in flags if isinstance(f, str)}
+        return out
+
+    def _ensure_loaded(self, path: Path) -> None:
+        if path != self._path:
+            self._data = self._read(path)
+            self._path = path
+
+    def has(self, provider: str, model: str, adaptation: str) -> bool:
+        # Totally guarded: a compat cache must never propagate a failure into
+        # the inference path. Any error (unreadable ~/.neo, no resolvable home,
+        # …) degrades to "not learned" so the caller sends the param as usual.
+        try:
+            path = self._resolve()
+            with self._lock:
+                self._ensure_loaded(path)
+                return adaptation in self._data.get(f"{provider}:{model}", ())
+        except Exception:
+            logger.debug("param-compat has() failed; assuming not-learned", exc_info=True)
+            return False
+
+    def learn(self, provider: str, model: str, adaptation: str) -> None:
+        try:
+            path = self._resolve()
+            key = f"{provider}:{model}"
+            with self._lock:
+                self._ensure_loaded(path)
+                if adaptation in self._data.get(key, ()):
+                    return
+                self._data.setdefault(key, set()).add(adaptation)
+                self._persist(path)
+        except Exception:
+            logger.debug("param-compat learn() failed; skipping", exc_info=True)
+
+    def _persist(self, path: Path) -> None:
+        # Merge with whatever's on disk now — another process may have learned
+        # something since we loaded — then atomically replace. Deliberately no
+        # flock (unlike FactStore): writes are rare and additive-only, so the
+        # merge self-heals a lost update (the loser re-persists its own
+        # `self._data` on its next learn()). Not worth locking the hot path for.
+        merged = self._read(path)
+        for key, flags in self._data.items():
+            merged.setdefault(key, set()).update(flags)
+        self._data = merged
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump({k: sorted(v) for k, v in merged.items()}, f)
+                os.replace(tmp, str(path))
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            pass  # best-effort; in-memory cache still holds the learning
+
+
+_PARAM_COMPAT = _ModelParamCompat()
+
+
+def _chat_completion_resilient(client, kwargs: dict, provider: str):
     """Call ``client.chat.completions.create(**kwargs)``, recovering from the
     reasoning-model parameter rejections described above.
 
-    Adaptations already learned for this model are applied up front; anything
-    new is discovered from the 400, applied, remembered, and retried. A 400 for
-    any other reason re-raises untouched. Loop is bounded implicitly: each
-    adaptation removes the key it keys on, so it can fire at most once (worst
-    case: temperature + max_tokens + success = 3 calls). ``kwargs`` is copied,
-    not mutated, so callers may safely pass a shared/cached dict.
+    Adaptations already learned for ``provider``/model are applied up front;
+    anything new is discovered from the 400, applied, remembered, and retried.
+    A 400 for any other reason re-raises untouched. Loop is bounded implicitly:
+    each adaptation removes the key it keys on, so it can fire at most once
+    (worst case: temperature + max_tokens + success = 3 calls). ``kwargs`` is
+    copied, not mutated, so callers may safely pass a shared/cached dict.
 
     Scope of each adaptation:
       - `temperature` drop is broad — o-series / gpt-5, Azure reasoning
@@ -63,9 +172,9 @@ def _chat_completion_resilient(client, kwargs: dict):
 
     kwargs = dict(kwargs)  # own our copy — never mutate the caller's dict
     model = kwargs.get("model", "")
-    if model in _MODELS_REJECTING_TEMPERATURE:
+    if _PARAM_COMPAT.has(provider, model, _ADAPT_DROP_TEMPERATURE):
         kwargs.pop("temperature", None)
-    if model in _MODELS_NEEDING_MAX_COMPLETION_TOKENS and "max_tokens" in kwargs:
+    if _PARAM_COMPAT.has(provider, model, _ADAPT_RENAME_MAX_TOKENS) and "max_tokens" in kwargs:
         kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
 
     while True:
@@ -78,11 +187,11 @@ def _chat_completion_resilient(client, kwargs: dict):
             # message alone. That's fine here: neo only ever sends in-range
             # temperatures, so a `temperature` 400 always means rejection.
             if "temperature" in kwargs and "temperature" in msg:
-                _MODELS_REJECTING_TEMPERATURE.add(model)
+                _PARAM_COMPAT.learn(provider, model, _ADAPT_DROP_TEMPERATURE)
                 kwargs.pop("temperature", None)
                 logger.debug(
-                    "Model %s rejected `temperature`; dropped it and retrying",
-                    model,
+                    "Model %s/%s rejected `temperature`; dropped it and retrying",
+                    provider, model,
                 )
                 continue
             # Rename trigger: the message references `max_tokens` and signals
@@ -95,11 +204,11 @@ def _chat_completion_resilient(client, kwargs: dict):
                 or "unsupported" in msg
                 or "not supported" in msg
             ):
-                _MODELS_NEEDING_MAX_COMPLETION_TOKENS.add(model)
+                _PARAM_COMPAT.learn(provider, model, _ADAPT_RENAME_MAX_TOKENS)
                 kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
                 logger.debug(
-                    "Model %s requires `max_completion_tokens`; renamed and "
-                    "retrying", model,
+                    "Model %s/%s requires `max_completion_tokens`; renamed and "
+                    "retrying", provider, model,
                 )
                 continue
             raise
@@ -198,7 +307,7 @@ class OpenAIAdapter(LMAdapter):
                     "max_tokens": max_tokens,
                     "temperature": temperature,
                     "stop": stop,
-                })
+                }, provider="openai")
                 self._emit_usage_metric(getattr(response, "usage", None))
                 return response.choices[0].message.content
 
@@ -277,16 +386,14 @@ class OpenAIAdapter(LMAdapter):
 # ============================================================================
 
 class AnthropicAdapter(LMAdapter):
-    """Adapter for Anthropic models (Claude)."""
+    """Adapter for Anthropic models (Claude).
 
-    # Claude models that reject the `temperature` sampling parameter with a 400
-    # ("temperature is deprecated for this model") — Opus 4.7+, Sonnet 5,
-    # Fable 5, and later. There's no clean model-string rule (opus-4-6 accepts
-    # it, opus-4-7 rejects it), so instead of hardcoding a taxonomy that goes
-    # stale on the next release, we learn it from the API's own error and
-    # remember it. Class-level so the lesson persists across adapter instances
-    # in a process (multi_agent makes several calls per query).
-    _models_without_temperature: set[str] = set()
+    Newer Claude models (Opus 4.7+, Sonnet 5, Fable 5) reject the `temperature`
+    sampling parameter with a 400. There's no clean model-string rule (opus-4-6
+    accepts it, opus-4-7 rejects it), so rather than hardcode a taxonomy that
+    goes stale on the next release, we learn it from the API's own error and
+    remember it via the persistent `_PARAM_COMPAT` store.
+    """
 
     def __init__(self, model: str = "claude-sonnet-4-5-20250929", api_key: Optional[str] = None):
         self.model = model
@@ -327,10 +434,10 @@ class AnthropicAdapter(LMAdapter):
             "messages": formatted_messages,
             "max_tokens": max_tokens,
         }
-        # Only send `temperature` to models known to accept it. Newer Claude
-        # models (Opus 4.7+, Sonnet 5, Fable 5) reject it; see
-        # `_models_without_temperature`.
-        if self.model not in self._models_without_temperature:
+        # Only send `temperature` to models not already known to reject it
+        # (Opus 4.7+, Sonnet 5, Fable 5). The learn-and-retry below records
+        # rejections into the persistent `_PARAM_COMPAT` store.
+        if not _PARAM_COMPAT.has("anthropic", self.model, _ADAPT_DROP_TEMPERATURE):
             kwargs["temperature"] = temperature
 
         if system_message:
@@ -355,7 +462,7 @@ class AnthropicAdapter(LMAdapter):
                 # succeeds. A 400 for any other reason re-raises untouched.
                 if "temperature" not in kwargs or "temperature" not in str(e).lower():
                     raise
-                self._models_without_temperature.add(self.model)
+                _PARAM_COMPAT.learn("anthropic", self.model, _ADAPT_DROP_TEMPERATURE)
                 kwargs.pop("temperature", None)
                 logger.debug(
                     "Anthropic model %s rejected `temperature`; dropped it "
@@ -536,7 +643,7 @@ class LocalAdapter(LMAdapter):
             "max_tokens": max_tokens,
             "temperature": temperature,
             "stop": stop,
-        })
+        }, provider="local")
         return response.choices[0].message.content
 
     def name(self) -> str:
@@ -664,7 +771,7 @@ class AzureOpenAIAdapter(LMAdapter):
             "max_tokens": max_tokens,
             "temperature": temperature,
             "stop": stop,
-        })
+        }, provider="azure")
         return response.choices[0].message.content
 
     def name(self) -> str:

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -27,17 +27,23 @@ class _BadRequestError(Exception):
 
 @pytest.fixture
 def _fake_anthropic():
-    """Inject a fake `anthropic` module and reset the learned-model cache."""
+    """Inject a fake `anthropic` module and reset the persistent param-compat
+    store's in-memory cache (the autouse `isolate_neo_home` fixture keeps the
+    on-disk state in a fresh tmp dir)."""
     mock_anthropic = MagicMock()
     mock_anthropic.BadRequestError = _BadRequestError
     with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
-        from neo.adapters import AnthropicAdapter
+        from neo import adapters
 
-        AnthropicAdapter._models_without_temperature.clear()
+        def _reset():
+            adapters._PARAM_COMPAT._path = None
+            adapters._PARAM_COMPAT._data = {}
+
+        _reset()
         try:
-            yield AnthropicAdapter
+            yield adapters.AnthropicAdapter
         finally:
-            AnthropicAdapter._models_without_temperature.clear()
+            _reset()
 
 
 def _ok_response(text="ok"):
@@ -79,15 +85,15 @@ def test_drops_temperature_and_retries_on_400(_fake_anthropic):
     # First call included temperature; retry omitted it.
     assert "temperature" in adapter.client.messages.create.call_args_list[0].kwargs
     assert "temperature" not in adapter.client.messages.create.call_args_list[1].kwargs
-    # The model is remembered process-wide.
-    assert "claude-opus-4-8" in adapter._models_without_temperature
+    # The model is remembered in the persistent store.
+    assert adapters._PARAM_COMPAT.has("anthropic", "claude-opus-4-8", "drop_temperature")
 
 
 def test_remembered_model_omits_temperature_up_front(_fake_anthropic):
     """After learning a model rejects temperature, later calls skip it — no
     wasted 400."""
     adapter = _fake_anthropic(model="claude-opus-4-8", api_key="k")
-    adapter._models_without_temperature.add("claude-opus-4-8")
+    adapters._PARAM_COMPAT.learn("anthropic", "claude-opus-4-8", "drop_temperature")
     adapter.client = MagicMock()
     adapter.client.messages.create.return_value = _ok_response()
 
@@ -109,4 +115,4 @@ def test_unrelated_400_reraises(_fake_anthropic):
         adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)
 
     assert adapter.client.messages.create.call_count == 1
-    assert "claude-opus-4-8" not in adapter._models_without_temperature
+    assert not adapters._PARAM_COMPAT.has("anthropic", "claude-opus-4-8", "drop_temperature")

--- a/tests/test_model_param_compat.py
+++ b/tests/test_model_param_compat.py
@@ -1,0 +1,149 @@
+"""Tests for `_ModelParamCompat` — the persistent store that records which
+parameter adaptations each model needs (issue #133).
+
+The autouse `isolate_neo_home` fixture (tests/conftest.py) redirects
+`Path.home()` to a per-test tmp dir, so these exercise the real on-disk path
+without touching the user's ~/.neo.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neo.adapters import _ModelParamCompat
+
+
+def _store_file() -> Path:
+    return Path.home() / ".neo" / "model_param_compat.json"
+
+
+def test_learn_persists_to_disk():
+    store = _ModelParamCompat()
+    store.learn("openai", "o3-mini", "drop_temperature")
+
+    path = _store_file()
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data == {"openai:o3-mini": ["drop_temperature"]}
+
+
+def test_learning_survives_a_fresh_store_instance():
+    """The whole point of #133: a new process (a new store instance loading
+    from disk) skips the bad param without re-paying the 400 penalty."""
+    _ModelParamCompat().learn("openai", "o3-mini", "drop_temperature")
+
+    fresh = _ModelParamCompat()  # simulates a new CLI invocation
+    assert fresh.has("openai", "o3-mini", "drop_temperature")
+    assert not fresh.has("openai", "o3-mini", "rename_max_tokens")
+
+
+def test_has_false_for_unknown():
+    store = _ModelParamCompat()
+    assert not store.has("openai", "gpt-4", "drop_temperature")
+
+
+def test_provider_scoping_avoids_collisions():
+    store = _ModelParamCompat()
+    store.learn("azure", "gpt-4", "drop_temperature")
+    assert store.has("azure", "gpt-4", "drop_temperature")
+    assert not store.has("openai", "gpt-4", "drop_temperature")
+    assert not store.has("local", "gpt-4", "drop_temperature")
+
+
+def test_multiple_adaptations_accumulate():
+    store = _ModelParamCompat()
+    store.learn("openai", "o3-mini", "drop_temperature")
+    store.learn("openai", "o3-mini", "rename_max_tokens")
+
+    data = json.loads(_store_file().read_text())
+    assert sorted(data["openai:o3-mini"]) == ["drop_temperature", "rename_max_tokens"]
+
+
+def test_merge_on_write_unions_concurrent_learnings():
+    """Two independent store instances (stand-in for two neo processes) each
+    learn something; neither clobbers the other's on-disk entry."""
+    a = _ModelParamCompat()
+    b = _ModelParamCompat()
+    a.learn("openai", "model-a", "drop_temperature")
+    b.learn("azure", "model-b", "rename_max_tokens")  # b loaded before a wrote
+
+    disk = json.loads(_store_file().read_text())
+    assert disk["openai:model-a"] == ["drop_temperature"]
+    assert disk["azure:model-b"] == ["rename_max_tokens"]
+
+
+def test_reloads_when_home_changes(monkeypatch, tmp_path):
+    """The in-memory cache reloads when the resolved path changes, so an
+    isolated home never sees another home's state."""
+    home1 = tmp_path / "h1"
+    home1.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home1))
+    store = _ModelParamCompat()
+    store.learn("openai", "o3-mini", "drop_temperature")
+    assert store.has("openai", "o3-mini", "drop_temperature")
+
+    home2 = tmp_path / "h2"
+    home2.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home2))
+    assert not store.has("openai", "o3-mini", "drop_temperature")  # fresh home
+
+
+def test_corrupt_file_is_tolerated():
+    path = _store_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ this is not valid json")
+
+    store = _ModelParamCompat()
+    assert not store.has("openai", "o3-mini", "drop_temperature")  # no raise
+    # and it recovers by overwriting on the next learn
+    store.learn("openai", "o3-mini", "drop_temperature")
+    assert json.loads(path.read_text()) == {"openai:o3-mini": ["drop_temperature"]}
+
+
+@pytest.mark.parametrize("bad", [
+    "null",                        # valid JSON, not a dict
+    "[]",                          # a list
+    "42",                          # a scalar
+    '{"openai:gpt": "notalist"}',  # value isn't a list
+    '{"openai:gpt": [[1, 2]]}',    # unhashable flag element
+    '{"openai:gpt": [1, 2]}',      # non-str flag elements
+])
+def test_wrong_shape_json_is_tolerated(bad):
+    """Valid JSON of the wrong shape must NOT crash inference — it degrades to
+    empty (regression: `_read`'s structural coercion once ran outside the
+    try/except and raised AttributeError/TypeError on these inputs)."""
+    path = _store_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(bad)
+
+    store = _ModelParamCompat()
+    assert not store.has("openai", "gpt", "drop_temperature")  # no raise
+    # recovers cleanly on the next learn
+    store.learn("openai", "gpt", "drop_temperature")
+    assert store.has("openai", "gpt", "drop_temperature")
+
+
+def test_home_resolution_failure_is_tolerated(monkeypatch):
+    """If Path.home() itself raises, has()/learn() degrade silently rather than
+    breaking the inference path."""
+    def _boom():
+        raise RuntimeError("no home")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_boom))
+    store = _ModelParamCompat()
+    assert not store.has("openai", "o3-mini", "drop_temperature")  # no raise
+    store.learn("openai", "o3-mini", "drop_temperature")  # no raise
+
+
+def test_persistence_failure_is_best_effort(monkeypatch):
+    """If the file can't be written, learning still holds in memory and never
+    raises — inference must not break on a persistence failure."""
+    store = _ModelParamCompat()
+
+    def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("neo.adapters.tempfile.mkstemp", _boom)
+    store.learn("openai", "o3-mini", "drop_temperature")  # must not raise
+    assert store.has("openai", "o3-mini", "drop_temperature")  # in-memory holds

--- a/tests/test_reasoning_model_params.py
+++ b/tests/test_reasoning_model_params.py
@@ -3,8 +3,9 @@ adapters (OpenAI chat path, Azure OpenAI, Local/OpenAI-compatible).
 
 Newer reasoning models reject `temperature` and require `max_completion_tokens`
 instead of `max_tokens`. `_chat_completion_resilient` learns each adaptation
-from the API's own 400 and remembers it. On Azure the model is an arbitrary
-deployment name, so this reactive approach is the only reliable one.
+from the API's own 400 and remembers it via the persistent `_PARAM_COMPAT`
+store. On Azure the model is an arbitrary deployment name, so this reactive
+approach is the only reliable one.
 """
 
 import sys
@@ -42,20 +43,24 @@ def _ok(text="ok"):
 
 @pytest.fixture
 def _fake_openai():
-    """Inject a fake `openai` module (with a real BadRequestError) and reset
-    the process-wide learned-model caches."""
+    """Inject a fake `openai` module (with a real BadRequestError) and reset the
+    persistent param-compat store's in-memory cache. The autouse
+    `isolate_neo_home` fixture points ~/.neo at a fresh tmp dir, so on-disk
+    state starts empty per test; clearing the cache forces a reload from it."""
     mock_openai = MagicMock()
     mock_openai.BadRequestError = _BadRequest
     with patch.dict(sys.modules, {"openai": mock_openai}):
         from neo import adapters
 
-        adapters._MODELS_REJECTING_TEMPERATURE.clear()
-        adapters._MODELS_NEEDING_MAX_COMPLETION_TOKENS.clear()
+        def _reset():
+            adapters._PARAM_COMPAT._path = None
+            adapters._PARAM_COMPAT._data = {}
+
+        _reset()
         try:
             yield adapters
         finally:
-            adapters._MODELS_REJECTING_TEMPERATURE.clear()
-            adapters._MODELS_NEEDING_MAX_COMPLETION_TOKENS.clear()
+            _reset()
 
 
 def _client_with(side_effect):
@@ -64,13 +69,15 @@ def _client_with(side_effect):
     return client
 
 
+def _call(adapters, client, kwargs, provider="openai"):
+    return adapters._chat_completion_resilient(client, kwargs, provider)
+
+
 # --- the shared helper directly -------------------------------------------
 
 def test_helper_passes_through_when_accepted(_fake_openai):
     client = _client_with([_ok("fine")])
-    out = _fake_openai._chat_completion_resilient(
-        client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100}
-    )
+    out = _call(_fake_openai, client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100})
     assert out.choices[0].message.content == "fine"
     assert client.chat.completions.create.call_count == 1
 
@@ -79,9 +86,7 @@ def test_helper_drops_temperature_then_renames_max_tokens(_fake_openai):
     """A reasoning model that rejects both params: temperature is dropped, then
     max_tokens is renamed, then the call succeeds — three attempts total."""
     client = _client_with([_TEMP_ERR, _MAXTOK_ERR, _ok("recovered")])
-    out = _fake_openai._chat_completion_resilient(
-        client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
-    )
+    out = _call(_fake_openai, client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100})
     assert out.choices[0].message.content == "recovered"
     calls = client.chat.completions.create.call_args_list
     assert len(calls) == 3
@@ -93,20 +98,18 @@ def test_helper_drops_temperature_then_renames_max_tokens(_fake_openai):
     assert "max_tokens" not in calls[2].kwargs
     assert calls[2].kwargs["max_completion_tokens"] == 100
     assert "temperature" not in calls[2].kwargs
-    # both adaptations remembered
-    assert "o3-mini" in _fake_openai._MODELS_REJECTING_TEMPERATURE
-    assert "o3-mini" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+    # both adaptations remembered, scoped to the openai provider
+    assert _fake_openai._PARAM_COMPAT.has("openai", "o3-mini", "drop_temperature")
+    assert _fake_openai._PARAM_COMPAT.has("openai", "o3-mini", "rename_max_tokens")
 
 
 def test_helper_applies_learned_adaptations_up_front(_fake_openai):
     """Once learned, a model skips both bad params on the first attempt."""
-    _fake_openai._MODELS_REJECTING_TEMPERATURE.add("o3-mini")
-    _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS.add("o3-mini")
+    _fake_openai._PARAM_COMPAT.learn("openai", "o3-mini", "drop_temperature")
+    _fake_openai._PARAM_COMPAT.learn("openai", "o3-mini", "rename_max_tokens")
     client = _client_with([_ok()])
 
-    _fake_openai._chat_completion_resilient(
-        client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
-    )
+    _call(_fake_openai, client, {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100})
 
     assert client.chat.completions.create.call_count == 1
     kw = client.chat.completions.create.call_args.kwargs
@@ -118,11 +121,9 @@ def test_helper_applies_learned_adaptations_up_front(_fake_openai):
 def test_helper_reraises_unrelated_400(_fake_openai):
     client = _client_with([_BadRequest("messages: must be a non-empty array")])
     with pytest.raises(_BadRequest):
-        _fake_openai._chat_completion_resilient(
-            client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100}
-        )
+        _call(_fake_openai, client, {"model": "gpt-4", "temperature": 0.7, "max_tokens": 100})
     assert client.chat.completions.create.call_count == 1
-    assert not _fake_openai._MODELS_REJECTING_TEMPERATURE
+    assert not _fake_openai._PARAM_COMPAT.has("openai", "gpt-4", "drop_temperature")
 
 
 def test_helper_renames_on_unsupported_wording_without_replacement_named(_fake_openai):
@@ -130,12 +131,10 @@ def test_helper_renames_on_unsupported_wording_without_replacement_named(_fake_o
     `unsupported`/`not supported` signal on max_tokens is enough."""
     err = _BadRequest("Unsupported parameter: 'max_tokens' is not supported with this model.")
     client = _client_with([err, _ok("renamed")])
-    out = _fake_openai._chat_completion_resilient(
-        client, {"model": "some-reasoner", "max_tokens": 100}
-    )
+    out = _call(_fake_openai, client, {"model": "some-reasoner", "max_tokens": 100})
     assert out.choices[0].message.content == "renamed"
     assert client.chat.completions.create.call_args_list[-1].kwargs["max_completion_tokens"] == 100
-    assert "some-reasoner" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+    assert _fake_openai._PARAM_COMPAT.has("openai", "some-reasoner", "rename_max_tokens")
 
 
 def test_helper_does_not_rename_on_plain_max_tokens_value_error(_fake_openai):
@@ -143,11 +142,9 @@ def test_helper_does_not_rename_on_plain_max_tokens_value_error(_fake_openai):
     trigger a spurious rename."""
     client = _client_with([_BadRequest("max_tokens must be at least 1")])
     with pytest.raises(_BadRequest):
-        _fake_openai._chat_completion_resilient(
-            client, {"model": "gpt-4", "max_tokens": 0}
-        )
+        _call(_fake_openai, client, {"model": "gpt-4", "max_tokens": 0})
     assert client.chat.completions.create.call_count == 1
-    assert not _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+    assert not _fake_openai._PARAM_COMPAT.has("openai", "gpt-4", "rename_max_tokens")
 
 
 def test_helper_does_not_mutate_callers_kwargs(_fake_openai):
@@ -155,8 +152,16 @@ def test_helper_does_not_mutate_callers_kwargs(_fake_openai):
     caller_kwargs = {"model": "o3-mini", "temperature": 0.7, "max_tokens": 100}
     snapshot = dict(caller_kwargs)
     client = _client_with([_TEMP_ERR, _MAXTOK_ERR, _ok()])
-    _fake_openai._chat_completion_resilient(client, caller_kwargs)
+    _call(_fake_openai, client, caller_kwargs)
     assert caller_kwargs == snapshot  # untouched despite two adaptations
+
+
+def test_provider_keys_are_independent(_fake_openai):
+    """The same model name behind different providers doesn't collide."""
+    _fake_openai._PARAM_COMPAT.learn("azure", "gpt-4", "drop_temperature")
+    assert _fake_openai._PARAM_COMPAT.has("azure", "gpt-4", "drop_temperature")
+    assert not _fake_openai._PARAM_COMPAT.has("openai", "gpt-4", "drop_temperature")
+    assert not _fake_openai._PARAM_COMPAT.has("local", "gpt-4", "drop_temperature")
 
 
 # --- through the adapters ---------------------------------------------------
@@ -169,7 +174,7 @@ def test_local_adapter_recovers_from_temperature_rejection(_fake_openai):
 
     assert out == "hi"
     assert adapter.client.chat.completions.create.call_count == 2
-    assert "grok-4-reasoning" in _fake_openai._MODELS_REJECTING_TEMPERATURE
+    assert _fake_openai._PARAM_COMPAT.has("local", "grok-4-reasoning", "drop_temperature")
 
 
 def test_azure_adapter_recovers_from_both_rejections(_fake_openai):
@@ -185,7 +190,7 @@ def test_azure_adapter_recovers_from_both_rejections(_fake_openai):
     assert len(calls) == 3
     assert calls[-1].kwargs["max_completion_tokens"] == 4096
     assert "temperature" not in calls[-1].kwargs
-    assert "my-o3-deploy" in _fake_openai._MODELS_NEEDING_MAX_COMPLETION_TOKENS
+    assert _fake_openai._PARAM_COMPAT.has("azure", "my-o3-deploy", "rename_max_tokens")
 
 
 def test_openai_chat_path_recovers_for_o_series(_fake_openai):
@@ -197,4 +202,4 @@ def test_openai_chat_path_recovers_for_o_series(_fake_openai):
     out = adapter.generate([{"role": "user", "content": "yo"}], temperature=0.9)
 
     assert out == "chat-ok"
-    assert "o3-mini" in _fake_openai._MODELS_REJECTING_TEMPERATURE
+    assert _fake_openai._PARAM_COMPAT.has("openai", "o3-mini", "drop_temperature")


### PR DESCRIPTION
## Description

Persists the learned reasoning-model parameter-compatibility cache introduced in #132 to `~/.neo/model_param_compat.json`, so a fresh CLI invocation skips known-bad params up front instead of re-paying the first-call 400-retry penalty every time.

## Type of Change

- [x] Performance improvement

## Related Issue

Closes #133. Follow-up to #132.

## Motivation and Context

#132 made the adapters recover reactively from reasoning-model param rejections (some models reject `temperature`; OpenAI-family require `max_completion_tokens` instead of `max_tokens`), remembering each model in **in-memory** sets. Because neo is a short-lived CLI, those sets die with the process — so every invocation re-paid up to two wasted `400` round-trips per reasoning model before re-learning. This persists the learnings across invocations.

### Design (`_ModelParamCompat`)
- On-disk at `~/.neo/model_param_compat.json`, keyed `"<provider>:<model>" → [flags]`. **Provider-keyed** so a bare model name (e.g. `gpt-4`) behind a Local endpoint can't collide with Azure/OpenAI.
- Path resolved at call time (per-test `Path.home()` stubs apply, mirroring `metrics._metrics_path`).
- In-memory cache reloads when the resolved path changes → production loads once; each isolated test home starts clean.
- **Merge-on-write + atomic `os.replace`**, deliberately *without* an flock (unlike `FactStore`): writes are rare and additive-only, so a lost update self-heals — the loser re-persists its own `self._data` on its next `learn()`, worst case one extra reactive `400`.
- **Best-effort and totally guarded**: a missing / corrupt / wrong-shape file or an unresolvable home degrades to "not learned" and **never breaks inference**.

`AnthropicAdapter` and the shared `_chat_completion_resilient(client, kwargs, provider)` helper now read/write the store instead of the module/class-level sets from #132.

## How Has This Been Tested?

- [x] `tests/test_model_param_compat.py` (new): disk round-trip; survives a fresh store instance (the core #133 guarantee); provider scoping; multi-flag accumulation; merge-on-write union across two instances; reload-on-home-change; **corrupt JSON and 6 valid-JSON-wrong-shape inputs tolerated**; `Path.home()` failure tolerated; persistence-failure stays in-memory and never raises.
- [x] `tests/test_reasoning_model_params.py` / `tests/test_anthropic_adapter.py` updated to assert against the persistent store.
- [x] Real-filesystem smoke test (temp `HOME`): learnings persist and a fresh instance loads them; unknowns return `False`.

**Test Configuration**:
- Python version: 3.13
- OS: macOS (darwin)
- Neo version: 0.35.0

Full suite: **1260 passed, 3 skipped**. Ruff: clean.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CLAUDE.md adapter notes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#132 merged)

## Additional Notes

Reviewed for kernel-quality standards; the review caught a real defect — `_read` did structural JSON coercion outside its `try/except`, so a valid-JSON-but-wrong-shape cache file would crash the inference path. Fixed by making `_read` total and wrapping the public `has`/`learn` bodies so nothing in this cache can escape into inference; added regression tests for all the wrong-shape inputs.

Known limit (unchanged from #132): recovery keys on HTTP 400 (`BadRequestError`); a provider returning 422 for a param error wouldn't be caught.
