### PR TITLE
Release v0.36.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.36.0] - 2026-07-06
+
+### Fixed
+
+- **LM adapters no longer break on newer reasoning models that reject standard chat parameters.** Neo unconditionally sent `temperature` (and `max_tokens`) on every request, but newer reasoning models reject them with a 400 — surfacing as the reported `ProcessingError` / `BadRequestError`: Anthropic Opus 4.7+/Sonnet 5/Fable 5 reject `temperature` ("temperature is deprecated for this model"); OpenAI o-series/gpt-5, Azure reasoning deployments, and OpenAI-compatible reasoners (xAI Grok, DeepSeek behind a `base_url`) reject `temperature`, and the OpenAI-family additionally require `max_completion_tokens` instead of `max_tokens`. There is no reliable model-string rule (`opus-4-6` accepts `temperature`, `opus-4-7` rejects it; on Azure `model` is an arbitrary deployment name), so a hardcoded allow/deny list would silently break on the next model. Instead the adapters **adapt reactively**: catch the 400, drop/rename the offending param, retry, and remember the model so subsequent calls skip it up front. Any 400 for another reason re-raises untouched (fail-fast preserved). The three OpenAI-SDK adapters (OpenAI chat path, Azure, Local) share `_chat_completion_resilient`, which handles both the `temperature` drop and the `max_completion_tokens` rename, copies its kwargs, and is robust to minor error-wording changes; `AnthropicAdapter` has its own inline learn-and-retry. The OpenAI `gpt-5`/codex `/v1/responses` path (which already omits `temperature`) is unchanged. (`adapters.py`)
+
+### Added
+
+- **Learned reasoning-model parameter adaptations now persist across invocations.** The reactive learn-and-retry above recorded each model's needed adaptations in in-memory sets, so every short-lived CLI invocation re-paid the first-call 400-retry penalty (up to two wasted round-trips for a model that rejects both params). Learnings now persist in `_ModelParamCompat` (`~/.neo/model_param_compat.json`, keyed `"<provider>:<model>" → [flags]`) so a fresh process skips the bad params on the first call. The store is provider-keyed (a bare `gpt-4` behind a Local endpoint can't collide with Azure/OpenAI), uses merge-on-write + atomic `os.replace` without an flock (writes are rare and additive-only, so a lost update self-heals on the next reactive retry), resolves its path at call time (per-test `Path.home()` stubs apply), and is **best-effort and totally guarded** — a missing/corrupt/wrong-shape file or an unresolvable home degrades to "not learned" and never breaks inference. (`adapters.py`)
+
 ## [0.35.0] - 2026-07-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.35.0"
+version = "0.36.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
Release **v0.36.0**. Version bumped in `pyproject.toml`, `src/neo/__init__.py`, `.claude-plugin/plugin.json`; CHANGELOG updated; sdist + wheel built.

## Changelog — [0.36.0] - 2026-07-06

### Fixed
- **LM adapters no longer break on newer reasoning models that reject standard chat parameters** (`temperature` on Anthropic Opus 4.7+/Sonnet 5/Fable 5, OpenAI o-series/gpt-5, Azure reasoning deployments, xAI Grok / DeepSeek; `max_tokens`→`max_completion_tokens` on the OpenAI-family). Adapters adapt reactively — catch the 400, drop/rename the param, retry, remember — with no hardcoded model taxonomy. Shared `_chat_completion_resilient` for the OpenAI-SDK adapters; inline learn-and-retry for Anthropic. (#132)

### Added
- **Learned reasoning-model parameter adaptations persist across invocations** via `_ModelParamCompat` (`~/.neo/model_param_compat.json`), so a fresh CLI process skips known-bad params on the first call instead of re-paying the 400-retry penalty. Provider-keyed, merge-on-write + atomic replace, best-effort and totally guarded (never breaks inference). (#134)

## Ships
Merging this triggers `.github/workflows/publish.yml` → PyPI (`neo-reasoner`) once the tag + GitHub Release are created (post-merge phases of the release workflow).

Both changes landed via #132 and #134, each Linus-reviewed with CI green on Python 3.10–3.13.
