### PR TITLE
docs: correct observer 'single global' model + document replay-feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@
     specific project's fact file, use `neo memory prune [--all] [--dry-run]`
     (`neo/subcommands.py:_compact_fact_file` — at the package root, not
     under `memory/`).
+  - `neo memory replay-feedback [--all] [--dry-run] [--include-legacy-fallback]
+    [--limit N]` re-processes linked session outcomes (ACCEPTED/MODIFIED/UNVERIFIED)
+    to update the linked facts' confidence + `success_count` — a manual re-run of
+    the implicit-feedback pass, for after a memory-loop fix (`store.replay_linked_feedback`).
+    `--dry-run` reports what would change without mutating; `--include-legacy-fallback`
+    also inspects legacy `session_*.json` files (may re-replay already-processed
+    sessions). Only touches linked, non-independent outcomes.
   - Diagnostics (read-only, flag-and-propose): `neo memory issues [--since 14d]
     [--min-cluster 3] [--suggest-rules] [--json]` surfaces recurring frictions mined from
     transcript history (Claude Code / Codex / CAR) as ranked, evidence-cited issues

--- a/docs/solutions/async-observer.md
+++ b/docs/solutions/async-observer.md
@@ -152,10 +152,16 @@ gains.
 
 ## Open questions
 
-- **Should the observer run per-project or per-machine?** ECC runs per-project
-  (each has its own PID file). Neo's `metrics.jsonl` is global; per-project
-  observers would need to filter by `project_id`. Easier: one observer per
-  machine that handles all active projects. Recommend per-machine to start.
+- **Should the observer run per-project or per-machine? — RESOLVED: per-machine
+  (single global).** The first shipped cut ran **per-project** agents
+  (`neo-observer-<id12>`, one CAR agent per discovered project). That was
+  replaced by a **single global** observer (CAR agent `neo-observer`, daemon
+  `--daemon --all`) that sweeps every discovered project each cycle —
+  round-robin/budgeted (`max_projects_per_cycle`, watermark-gated so unchanged
+  projects do near-zero work). On bootstrap the legacy per-project agents are
+  stopped and `agents_remove`d. Lifecycle/`status`/orphan-checks all operate on
+  the one global agent. See `src/neo/memory/observer.py` and the "Async
+  synthesis observer" note in `CLAUDE.md` for the current shape.
 - **What's "active"?** ECC uses the metrics file's mtime. Same approach works
   here — if `metrics.jsonl` hasn't been touched in 30 minutes, exit.
 - **Routing cost.** Each observer cycle costs ~1 cheap LM call. At 5-min

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -1,15 +1,22 @@
 """Async out-of-band synthesis observer, supervised by car-server.
 
-A per-project background process that runs REVIEW→PATTERN/FAILURE
-synthesis on a wall-clock cadence. Lifecycle is owned by CAR's
-agent supervisor:
+A **single global** background process (CAR agent ``neo-observer``,
+``GLOBAL_AGENT_ID``) that runs REVIEW→PATTERN/FAILURE synthesis on a
+wall-clock cadence, **sweeping every discovered project each cycle** —
+round-robin/budgeted (``max_projects_per_cycle``, watermark-gated so
+unchanged projects do near-zero work). The earlier model spawned one
+per-project agent (``neo-observer-<id12>``, ``--cwd <root>``); those
+legacy agents are stopped and ``agents_remove``d on bootstrap. Lifecycle
+is owned by CAR's agent supervisor:
 
   - ``agents_upsert`` registers the spec under ``~/.car/agents.json``
   - ``agents_start`` spawns the child
-    (``python -m neo.memory.observer --daemon --cwd <root>``)
+    (``python -m neo.memory.observer --daemon --all``; the legacy
+    ``--cwd <root>`` form runs a single project and is kept only for
+    migration/back-compat)
   - Supervisor handles restart-on-failure, clean SIGTERM shutdown, log
-    redirection to ``~/.car/logs/<id>.{stdout,stderr}.log``, and auto-
-    start at daemon boot when ``auto_start=True``.
+    redirection to ``~/.car/logs/neo-observer.{stdout,stderr}.log``, and
+    auto-start at daemon boot when ``auto_start=True``.
 
 Hard dependency on ``car-runtime>=0.18.0`` (the ``agents_*`` lifecycle
 API landed in 0.16.1, but earlier bindings grab the supervisor manifest


### PR DESCRIPTION
## Description

Fixes two stale points in neo's **self-knowledge** — surfaced by querying neo about itself, then traced to the source-of-truth docs it reads/ingests.

## Type of Change
- [x] Documentation update

## Motivation and Context

1. **Observer described as per-project (stale).** The `observer.py` module docstring and `docs/solutions/async-observer.md` still described the synthesis observer as a per-project background process. It has been a **single global** CAR agent (`neo-observer`, `--daemon --all`) that sweeps all discovered projects since the per-project agents (`neo-observer-<id12>`) were migrated away. Docstring now leads with the global model; the async-observer doc's "open question" is marked **resolved**. (Confirmed live: the running observer is the global `neo-observer`.)
2. **`neo memory replay-feedback` undocumented.** It's a real subcommand (`cli.py`) but appeared in no doc, so neo never learned it. Added to CLAUDE.md's memory-hygiene notes with its flags and behavior (re-processes linked ACCEPTED/MODIFIED/UNVERIFIED outcomes to update fact confidence + `success_count`).

Docstring/doc-only — no behavior change.

## How Has This Been Tested?
- [x] Full suite **1260 passed, 3 skipped**; ruff clean (pre-commit hook).
- [x] Re-queried neo after the fix: it now answers *"a single global CAR-managed process… `--daemon --all`, sweeping discovered projects… the older per-project model is superseded"* and lists `replay-feedback` among the `neo memory` subcommands.

## Checklist
- [x] Self-reviewed
- [x] Documentation updated
- [x] Existing tests pass locally

## Additional Notes

Root cause also included neo's **memory**: several stale/truncated CLAUDE.md snapshots had been auto-ingested as `CONSTRAINT` facts (which bypass decay), and my verification queries wrote self-reinforcing wrong episodes. Those stale facts were invalidated in the local `~/.neo` store (not part of this PR — memory is regenerable local state) so the correction takes effect immediately; this PR fixes the durable sources so re-ingestion stays correct.