### PR TITLE
Release v0.36.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.1] - 2026-07-06
+
+### Documentation
+
+- **Corrected neo's self-description of the synthesis observer, and documented `neo memory replay-feedback`.** The `observer.py` module docstring and `docs/solutions/async-observer.md` still described the background synthesis observer as a *per-project* process; it has been a **single global** CAR agent (`neo-observer`, `--daemon --all`) that sweeps every discovered project each cycle since the per-project agents (`neo-observer-<id12>`) were migrated away. The docstring now leads with the global model and the async-observer proposal's "open question" is marked resolved. Separately, the `neo memory replay-feedback` subcommand (re-processes linked ACCEPTED/MODIFIED/UNVERIFIED outcomes to update fact confidence + `success_count`) was undocumented and is now covered in the memory-hygiene notes. Docstring/doc-only — no behavior change. (#136)
+
 ## [0.36.0] - 2026-07-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.36.0"
+version = "0.36.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.36.0"
+__version__ = "0.36.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
Release **v0.36.1** — patch. Version bumped in `pyproject.toml`, `src/neo/__init__.py`, `.claude-plugin/plugin.json`; CHANGELOG updated; sdist + wheel built.

## Changelog — [0.36.1] - 2026-07-06

### Documentation
- **Corrected neo's self-description of the synthesis observer, and documented `neo memory replay-feedback`** (#136). The observer is a **single global** CAR agent (`neo-observer`, `--daemon --all`) sweeping all discovered projects — the docstring/doc previously described the retired per-project model. `replay-feedback` (re-processes linked outcomes to update fact confidence + `success_count`) is now documented. Docstring/doc-only — no behavior change.

## Scope
Only change since v0.36.0 is #136 (docs). Merging triggers the PyPI publish workflow (`neo-reasoner`) via Trusted Publishers.