### PR TITLE
Release v0.37.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.37.0] - 2026-07-06
+
+### Changed
+
+- **Multi-agent deliberation now fires with ≥1 capable model, not ≥2 distinct ones — a controlled experiment overturned the "diversity is the value" assumption.** The tiered-reasoning gate (#129) offered the panel only when a query was novel AND CAR was reachable AND there were **≥2 genuinely-distinct capable models**, on the theory that a single-model panel just re-confirms one model's blind spots. A controlled A/B/A (n=8, three arms per task — single vs panel-with-gpt-critic vs panel-with-Claude-critic — scored in one judge call so the critic model is the only variable) measured: single **7.88**, panel same-model **9.00** (+1.12), panel distinct-critic **9.00** (diversity delta **~0**; head-to-head 1/1/6). The panel's win is the **orchestration structure** (plan-vote → code → adversarial critique → repair), which holds fully same-model; an adversarial critic in a fresh context catches errors via *reframing*, not different weights. So `DEFAULT_MIN_MODELS` drops 2 → 1: deliberation now fires on novelty + CAR + one capable model, and the parslee-family model-miscount no longer changes the decision. `min_models` stays tunable for callers who still want a diverse pool (harder/ambiguous tasks aren't yet measured). Internally `diversity_ok` → `can_deliberate`, with updated rationale/reason strings. Bounds: n=8 self-contained tasks, two strong critics. (`reasoning_mode.py`, `config.py`)
+
+### Added
+
+- **Controlled A/B/A reasoning harness with a pluggable critic provider.** `tools/ab_controlled.py` runs the three-arm, single-judge-call comparison above (isolating diversity from orchestration), and `tools/ab_reasoning.py` gains `--critic-provider {anthropic,openai,car}` so the panel critic can route to a different frontier model than the coder. (`tools/ab_controlled.py`, `tools/ab_reasoning.py`, `docs/solutions/tiered-reasoning-multi-agent.md`)
+
 ## [0.36.1] - 2026-07-06
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.36.1"
+version = "0.37.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.36.1"
+__version__ = "0.37.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
Release **v0.37.0** — minor. Version bumped in `pyproject.toml`, `src/neo/__init__.py`, `.claude-plugin/plugin.json`; CHANGELOG updated; sdist + wheel built.

## Changelog — [0.37.0] - 2026-07-06

### Changed
- **Multi-agent deliberation now fires with ≥1 capable model, not ≥2 distinct ones** (#137). A controlled A/B/A (n=8, single vs panel-gpt-critic vs panel-claude-critic in one judge call) found the panel's +1.12 gain is the **orchestration structure**, which holds fully same-model; a distinct frontier critic added ~0. `DEFAULT_MIN_MODELS` 2 → 1; `min_models` stays tunable. `diversity_ok` → `can_deliberate`.

### Added
- **Controlled A/B/A harness + pluggable critic provider** (#137): `tools/ab_controlled.py` (three-arm, single-judge isolation of diversity from orchestration) and `tools/ab_reasoning.py --critic-provider {anthropic,openai,car}`.

## Scope
Includes #137 (merged to main after v0.36.1 was tagged). Behavior change to the reasoning-mode gate → minor bump. Merging triggers the PyPI publish workflow (`neo-reasoner`) via Trusted Publishers.