### PR TITLE
fix(memory): cap per-project attempt-outcome EPISODE facts

### DIFF
--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -87,6 +87,16 @@ PROTECTION_BOOST = 0.05        # Confidence boost for consistently helpful facts
 # Independent outcome limits (second layer — outcomes.py caps at 5/session)
 MAX_INDEPENDENT_FACTS = 50     # Cap per project to prevent bloat from active repos
 
+# Attempt-outcome EPISODE limits. persist_attempt_outcome writes one EPISODE
+# fact per caller-reported attempt/outcome, and EPISODE facts deliberately
+# bypass dedup/supersession (trajectory attribution needs each observation
+# distinct). A stuck external agent loop that re-reports the same failed attempt
+# each iteration would therefore flood the project fact file unbounded and evict
+# more valuable REVIEW facts. Cap the newest N per project — well below the
+# per-scope 500 limit — so a live flood stays bounded (mirrors
+# MAX_INDEPENDENT_FACTS / _cap_independent_facts).
+MAX_ATTEMPT_OUTCOME_FACTS = 25
+
 # Tags that protect facts from pruning/demotion (curated knowledge)
 # Tag-based janitor immunity for TRUSTED-INTERNAL provenance only: seed corpus,
 # community feed, synthesis output. These tags are written solely by neo's own
@@ -933,6 +943,10 @@ class FactStore:
         )
         fact.metadata.event_time = time.time()
         fact.metadata.ingest_time = fact.metadata.event_time
+        # Bound a live flood within the process, not only on cold start: a stuck
+        # loop re-reporting the same attempt each call is capped here so it can
+        # never fill the project budget and evict useful REVIEW facts.
+        self._cap_attempt_outcome_facts(save=False)
         self.save()
         return fact
 
@@ -2713,6 +2727,7 @@ class FactStore:
         logger.info(f"FactStore: Loaded {len(self._facts)} facts")
         # Cap runs in-memory only; save is deferred to initialize()
         self._cap_independent_facts(save=False)
+        self._cap_attempt_outcome_facts(save=False)
 
     def _cap_independent_facts(self, save: bool = True) -> None:
         """Prevent bloat: invalidate excess independent-tagged facts.
@@ -2745,6 +2760,45 @@ class FactStore:
             else:
                 self._cap_pending = True
             logger.info(f"Capped independent facts: invalidated {pruned}, kept {MAX_INDEPENDENT_FACTS}")
+
+    def _cap_attempt_outcome_facts(self, save: bool = True) -> None:
+        """Prevent bloat: invalidate excess attempt-outcome EPISODE facts.
+
+        persist_attempt_outcome writes one EPISODE fact per caller-reported
+        attempt/outcome, and EPISODE facts bypass dedup/supersession by design.
+        A stuck agent loop re-reporting the same failed attempt each iteration
+        would otherwise flood the project fact file unbounded and evict more
+        valuable REVIEW facts. Keep only the newest MAX_ATTEMPT_OUTCOME_FACTS.
+        Protected-tag / promoted facts are never capped.
+
+        Args:
+            save: If True, persist after capping. Set False when called from
+                  load() to avoid save-during-load (deferred to initialize()).
+        """
+        attempts = [
+            f for f in self._facts
+            if f.is_valid
+            and "attempt" in f.tags and "observed-outcome" in f.tags
+            and not self._is_protected(f)
+        ]
+        if len(attempts) <= MAX_ATTEMPT_OUTCOME_FACTS:
+            return
+        attempts.sort(key=lambda f: f.metadata.created_at, reverse=True)
+        pruned = 0
+        for f in attempts[MAX_ATTEMPT_OUTCOME_FACTS:]:
+            # cascade=False mirrors _cap_independent_facts: these episodes are
+            # redundant observation noise with no dependents worth flagging.
+            self._invalidate(f, cascade=False)
+            pruned += 1
+        if pruned:
+            if save:
+                self.save()
+            else:
+                self._cap_pending = True
+            logger.info(
+                f"Capped attempt-outcome facts: invalidated {pruned}, "
+                f"kept {MAX_ATTEMPT_OUTCOME_FACTS}"
+            )
 
     def _save_file(self, path: Path, facts: list[Fact]) -> None:
         """Save a list of facts to a JSON file atomically.

--- a/tests/test_attempt_outcome_cap.py
+++ b/tests/test_attempt_outcome_cap.py
@@ -1,0 +1,111 @@
+"""Reproduction test for the attempt-outcome memory flood.
+
+A stuck agent loop that keeps reporting the same failed attempt makes Neo persist
+a fresh, high-confidence EPISODE fact every iteration. EPISODE facts bypass
+dedup/supersession by design, so without a cap the flood fills the PROJECT scope
+budget and the scope-limit evictor discards the lower-confidence REVIEW fact that
+feeds synthesis, while the redundant 0.7 attempt episodes survive.
+
+Two claims, each RED on the unpatched code and GREEN with the cap:
+  (a) the attempt-outcome facts are bounded FAR below the flood — not merely at
+      the scope limit;
+  (b) a pre-existing, more-valuable REVIEW fact SURVIVES the flood.
+
+The PROJECT scope budget is monkeypatched to a small value so the eviction harm
+in (b) is reproduced quickly (the real budget is 500; driving past it unpatched
+is correct but slow). The loop drives more iterations than that budget on purpose
+so the unpatched evictor actually removes the REVIEW fact — making (b) genuinely
+discriminating, and keeping the RED a behavioural failure, not an ImportError on
+the fix's own constant.
+"""
+
+import neo.memory.store as store_mod
+from neo.execution_context import (
+    AttemptContext,
+    OutcomeContext,
+    resolve_execution_context,
+)
+from neo.memory.models import FactKind, FactScope
+from neo.memory.store import FactStore
+from neo.models import NeoInput
+
+_SMALL_PROJECT_BUDGET = 100
+
+
+def _flood(store, iterations):
+    context = resolve_execution_context(NeoInput(
+        prompt="Why is this timeout happening?",
+        attempt=AttemptContext("Added a retry"),
+        outcome=OutcomeContext(
+            "failed", summary="Duplicates appeared", side_effects=["duplicate writes"],
+        ),
+    )).to_dict()
+    for i in range(iterations):
+        store.persist_attempt_outcome(
+            execution_context=context,
+            learning_episode_id=f"episode-{i}",
+            repository_revision=f"rev{i}",
+        )
+
+
+def test_attempt_flood_is_capped_and_spares_review(tmp_path, monkeypatch):
+    # Shrink the PROJECT scope budget so the eviction harm reproduces fast.
+    monkeypatch.setitem(
+        store_mod.SCOPE_LIMITS, FactScope.PROJECT.value, _SMALL_PROJECT_BUDGET
+    )
+
+    store = FactStore(
+        codebase_root=str(tmp_path),
+        eager_init=False,
+        facts_dir=tmp_path / "facts",
+        episodes_dir=tmp_path / "episodes",
+        emit_metrics=False,
+    )
+
+    # A genuinely useful, lower-confidence REVIEW fact that feeds synthesis.
+    review = store.add_fact(
+        subject="Prefer retry-with-backoff for flaky network calls",
+        body="Observed pattern worth synthesizing.",
+        kind=FactKind.REVIEW,
+        scope=FactScope.PROJECT,
+        confidence=0.4,
+    )
+
+    # Drive MORE iterations than the (patched) PROJECT scope budget so the
+    # unpatched (uncapped) code is forced to evict — and by eviction score the
+    # 0.4 REVIEW fact goes before the 0.7 attempt episodes.
+    iterations = _SMALL_PROJECT_BUDGET + 140
+    _flood(store, iterations)
+
+    valid_attempts = [
+        f for f in store._facts
+        if f.is_valid and "attempt" in f.tags and "observed-outcome" in f.tags
+    ]
+
+    # (a) BEHAVIOURAL red: bounded FAR below the flood. Unpatched, the only bound
+    # is the scope limit, so this count sits near the budget (>> 50); with the cap
+    # it sits at MAX_ATTEMPT_OUTCOME_FACTS (25). A value-tolerant threshold of 50
+    # fails on base and passes on the fix without hard-coding the exact cap — and
+    # is a behavioural assertion, not an ImportError on the fix's own constant.
+    assert len(valid_attempts) <= 50, (
+        f"attempt-outcome facts not capped: {len(valid_attempts)} valid "
+        f"(unpatched code is bounded only by the scope limit)"
+    )
+
+    # Tighter check only when the cap constant exists (fix side); guarded so the
+    # RED on base is the behavioural assertion above, never an import failure.
+    try:
+        from neo.memory.store import MAX_ATTEMPT_OUTCOME_FACTS
+    except ImportError:
+        MAX_ATTEMPT_OUTCOME_FACTS = None
+    if MAX_ATTEMPT_OUTCOME_FACTS is not None:
+        assert len(valid_attempts) <= MAX_ATTEMPT_OUTCOME_FACTS
+
+    # (b) DISCRIMINATING harm: the valuable REVIEW fact survives the flood. On the
+    # unpatched code the scope evictor removes it (lowest eviction score, evicted
+    # once the flood pushes the PROJECT scope past its budget); with the cap the
+    # scope never fills, so it survives.
+    survivor = next((f for f in store._facts if f.id == review.id), None)
+    assert survivor is not None and survivor.is_valid is True, (
+        "the pre-existing REVIEW fact was evicted by the uncapped attempt flood"
+    )


### PR DESCRIPTION
## Defect
`persist_attempt_outcome` writes one confidence-0.7 EPISODE fact per caller-reported attempt/outcome with **no cap**, and EPISODE facts deliberately bypass dedup/supersession. A stuck agent loop re-reporting the same failed attempt floods the project fact file toward the 500 budget and evicts more valuable lower-confidence REVIEW facts.

## Fix
Add `MAX_ATTEMPT_OUTCOME_FACTS` + `_cap_attempt_outcome_facts()`, mirroring the existing `_cap_independent_facts`; call it on load **and** inside `persist_attempt_outcome` so a live flood is bounded in-process. Preserves the deliberate EPISODE dedup-bypass invariant.

## Reproduction test
`tests/test_attempt_outcome_cap.py` — 120-iteration flood; asserts attempt facts are capped and a pre-existing REVIEW fact survives. Verified **red on base → green with fix**.

---
_Provenance: surfaced by **parslee-morpheus** (post-merge review of `ab484e4`, "Repeated attempts flood project memory and evict more useful entries"); candidate fix authored by **parslee-trinity** and verified red→green locally. A candidate fix that passes CI — not a human-verified fix; review before merge._
