### PR TITLE
fix(memory): discriminating suggestion fingerprint for common edit shapes

### DIFF
--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import textwrap
 import time
 from collections import deque
 from pathlib import Path
@@ -2192,6 +2193,42 @@ RULES:
             return ""
         return hashlib.sha256(skeleton.encode("utf-8")).hexdigest()[:12]
 
+    def _parse_snippet(self, code: str):
+        """Best-effort ``ast.parse`` of a possibly-fragmentary code snippet.
+
+        The raw snippet is often NOT top-level-parseable, and the two shapes
+        that fail are the dominant real-world ones (issue #9005): a method
+        indented inside a class (``IndentationError``) and a partial diff hunk
+        whose added lines are a mid-block fragment (``SyntaxError`` on a bare
+        ``return``/``else``). When parsing fails the fingerprint is "" and
+        episode correlation silently degrades to a prompt-prefix-only key,
+        letting unrelated accepted fixes merge into one over-trusted memory.
+
+        We progressively normalize: (1) parse as-is; (2) ``textwrap.dedent``
+        then parse — an indented class method dedents to a top-level ``def``,
+        and a dedented hunk body parses on its own; (3) wrap the dedented
+        snippet in a synthetic ``class _S: / def _f(self):`` scaffold so a bare
+        statement fragment (``return``/``yield``/``self.x = ...``) still yields
+        a tree. Returns the parsed module, or ``None`` when the snippet is
+        genuinely unparseable (non-Python, prose) so the caller degrades to "".
+        """
+        candidates = [code]
+        dedented = textwrap.dedent(code)
+        if dedented != code:
+            candidates.append(dedented)
+        # Nest the fragment inside a class method so statements only legal
+        # inside a function body (return/yield) parse too. Deterministic, so
+        # identical fragments still fingerprint identically.
+        candidates.append(
+            "class _S:\n    def _f(self):\n" + textwrap.indent(dedented, "        ")
+        )
+        for candidate in candidates:
+            try:
+                return ast.parse(candidate)
+            except (SyntaxError, ValueError):
+                continue
+        return None
+
     def _extract_code_skeleton(self, code: str) -> str:
         """
         Extract structural pattern from code using AST analysis.
@@ -2216,62 +2253,60 @@ RULES:
                     added_lines.append(line[1:])  # Remove the '+' prefix
             code = '\n'.join(added_lines)
 
-        skeleton_tokens = []
-        try:
-            tree = ast.parse(code)
-
-            # Walk AST and extract structural patterns
-            for node in ast.walk(tree):
-                # Control flow
-                if isinstance(node, ast.For):
-                    skeleton_tokens.append("for-loop")
-                elif isinstance(node, ast.While):
-                    skeleton_tokens.append("while-loop")
-                elif isinstance(node, ast.If):
-                    skeleton_tokens.append("if-stmt")
-
-                # Data structures (common in algorithmic code)
-                elif isinstance(node, ast.List):
-                    skeleton_tokens.append("list")
-                elif isinstance(node, ast.Dict):
-                    skeleton_tokens.append("dict")
-                elif isinstance(node, ast.Set):
-                    skeleton_tokens.append("set")
-                elif isinstance(node, ast.ListComp):
-                    skeleton_tokens.append("list-comp")
-                elif isinstance(node, ast.DictComp):
-                    skeleton_tokens.append("dict-comp")
-                elif isinstance(node, ast.SetComp):
-                    skeleton_tokens.append("set-comp")
-
-                # Function definitions
-                elif isinstance(node, ast.FunctionDef):
-                    skeleton_tokens.append(f"def:{node.name}")
-                elif isinstance(node, ast.Lambda):
-                    skeleton_tokens.append("lambda")
-
-                # Common algorithmic patterns
-                elif isinstance(node, ast.Call):
-                    if isinstance(node.func, ast.Name):
-                        # Track common collections/algorithms
-                        if node.func.id in ('deque', 'defaultdict', 'Counter',
-                                          'heapq', 'bisect', 'sorted', 'reversed',
-                                          'set', 'list', 'dict'):  # Also track constructor calls
-                            skeleton_tokens.append(node.func.id)
-                    elif isinstance(node.func, ast.Attribute):
-                        # Track common methods (append, pop, etc)
-                        if node.func.attr in ('append', 'pop', 'popleft',
-                                             'add', 'remove', 'sort'):
-                            skeleton_tokens.append(f"method:{node.func.attr}")
-
-                # Recursion indicator
-                elif isinstance(node, ast.Return):
-                    skeleton_tokens.append("return")
-
-        except SyntaxError:
-            # Not valid Python, return empty skeleton
+        tree = self._parse_snippet(code)
+        if tree is None:
+            # Not valid Python even after dedent/scaffold, return empty skeleton
             logger.debug(f"Could not parse code for skeleton extraction: {code[:100]}")
             return ""
+
+        skeleton_tokens = []
+        # Walk AST and extract structural patterns
+        for node in ast.walk(tree):
+            # Control flow
+            if isinstance(node, ast.For):
+                skeleton_tokens.append("for-loop")
+            elif isinstance(node, ast.While):
+                skeleton_tokens.append("while-loop")
+            elif isinstance(node, ast.If):
+                skeleton_tokens.append("if-stmt")
+
+            # Data structures (common in algorithmic code)
+            elif isinstance(node, ast.List):
+                skeleton_tokens.append("list")
+            elif isinstance(node, ast.Dict):
+                skeleton_tokens.append("dict")
+            elif isinstance(node, ast.Set):
+                skeleton_tokens.append("set")
+            elif isinstance(node, ast.ListComp):
+                skeleton_tokens.append("list-comp")
+            elif isinstance(node, ast.DictComp):
+                skeleton_tokens.append("dict-comp")
+            elif isinstance(node, ast.SetComp):
+                skeleton_tokens.append("set-comp")
+
+            # Function definitions
+            elif isinstance(node, ast.FunctionDef):
+                skeleton_tokens.append(f"def:{node.name}")
+            elif isinstance(node, ast.Lambda):
+                skeleton_tokens.append("lambda")
+
+            # Common algorithmic patterns
+            elif isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name):
+                    # Track common collections/algorithms
+                    if node.func.id in ('deque', 'defaultdict', 'Counter',
+                                      'heapq', 'bisect', 'sorted', 'reversed',
+                                      'set', 'list', 'dict'):  # Also track constructor calls
+                        skeleton_tokens.append(node.func.id)
+                elif isinstance(node.func, ast.Attribute):
+                    # Track common methods (append, pop, etc)
+                    if node.func.attr in ('append', 'pop', 'popleft',
+                                         'add', 'remove', 'sort'):
+                        skeleton_tokens.append(f"method:{node.func.attr}")
+
+            # Recursion indicator
+            elif isinstance(node, ast.Return):
+                skeleton_tokens.append("return")
 
         # Deduplicate while preserving order, limit to 500 chars
         seen = set()

--- a/tests/test_suggestion_fingerprint_shapes.py
+++ b/tests/test_suggestion_fingerprint_shapes.py
@@ -1,0 +1,121 @@
+"""Reproduction test for issue #9005.
+
+The structural fingerprint (engine._suggestion_fingerprint) is meant to tighten
+episode correlation for promotion: two accepted suggestions only merge toward a
+durable memory when their prompt-prefix AND diff shape agree. But the underlying
+_extract_code_skeleton ast.parse()s the raw snippet, which is empty for the two
+MOST COMMON edit shapes:
+
+  1. a method indented inside a class (IndentationError -> ""),
+  2. a small/partial unified diff whose added lines are a mid-block fragment.
+
+When the fingerprint is "", the correlation key degrades to subject (prompt+path)
+only, so two unrelated fixes sharing a similar prompt and file can be promoted
+together into one over-trusted memory. These tests assert the fingerprint IS
+populated (and shape-sensitive) for those shapes, and therefore FAIL on the
+buggy code.
+"""
+
+from types import SimpleNamespace
+
+from neo.engine import NeoEngine
+
+
+class FakeLM:
+    def __init__(self):
+        self.model = "fake"
+        self.provider = "fake"
+
+    def generate(self, messages, **kw):
+        return ""
+
+    def name(self):
+        return "fake-lm"
+
+
+def _engine():
+    return NeoEngine(lm_adapter=FakeLM(), enable_persistent_memory=False)
+
+
+def test_indented_class_method_has_non_empty_fingerprint():
+    """An edit to a method inside a class is the dominant real-world suggestion
+    shape. Its code_block is indented one level, so a bare ast.parse raises
+    IndentationError and yields "". The fingerprint must be non-empty."""
+    e = _engine()
+    method_edit = SimpleNamespace(
+        code_block=(
+            "    def refresh(self, items):\n"
+            "        result = []\n"
+            "        seen = set()\n"
+            "        for x in items:\n"
+            "            if x not in seen:\n"
+            "                seen.add(x)\n"
+            "                result.append(x)\n"
+            "        return result\n"
+        ),
+        unified_diff="",
+    )
+    fp = e._suggestion_fingerprint(method_edit)
+    assert fp, "indented class method should yield a non-empty fingerprint"
+    assert len(fp) == 12
+
+
+def test_partial_unified_diff_has_non_empty_fingerprint():
+    """A realistic small patch: the added lines are a mid-block fragment indented
+    inside an existing function. ast.parse of the bare added lines fails, so the
+    fingerprint is "". It must be populated."""
+    e = _engine()
+    partial_diff = SimpleNamespace(
+        code_block="",
+        unified_diff=(
+            "--- a/src/neo/foo.py\n"
+            "+++ b/src/neo/foo.py\n"
+            "@@ -10,6 +10,9 @@ def handle(self, items):\n"
+            "         seen = set()\n"
+            "+        for x in items:\n"
+            "+            if x not in seen:\n"
+            "+                seen.add(x)\n"
+            "         return seen\n"
+        ),
+    )
+    fp = e._suggestion_fingerprint(partial_diff)
+    assert fp, "partial unified diff should yield a non-empty fingerprint"
+    assert len(fp) == 12
+
+
+def test_two_different_method_edits_fingerprint_differently():
+    """Structurally different method edits must not collapse to the same
+    fingerprint (which would let unrelated fixes correlate)."""
+    e = _engine()
+    loop_method = SimpleNamespace(
+        code_block=(
+            "    def refresh(self, items):\n"
+            "        result = []\n"
+            "        for x in items:\n"
+            "            result.append(x)\n"
+            "        return result\n"
+        ),
+        unified_diff="",
+    )
+    comprehension_method = SimpleNamespace(
+        code_block=(
+            "    def refresh(self, items):\n"
+            "        return list(dict.fromkeys(items))\n"
+        ),
+        unified_diff="",
+    )
+    fp_loop = e._suggestion_fingerprint(loop_method)
+    fp_comp = e._suggestion_fingerprint(comprehension_method)
+    assert fp_loop and fp_comp
+    assert fp_loop != fp_comp
+
+
+def test_non_python_code_still_degrades_to_empty():
+    """Truly unparseable / non-Python code must still return "" (subject-only
+    fallback preserved)."""
+    e = _engine()
+    prose = SimpleNamespace(
+        code_block="this is not code at all -- just a sentence.",
+        unified_diff="",
+    )
+    assert e._suggestion_fingerprint(prose) == ""


### PR DESCRIPTION
## Defect
`_suggestion_fingerprint` returns `""` for indented class methods and partial diffs — the **most common** edit shapes — degrading episode correlation to a subject-only key. Combined with `generalize()` collapsing deep paths, two *unrelated* accepted fixes sharing a generalized prompt prefix + task type could promote a **spurious durable PATTERN** (over-promotion).

## Fix
Produce a non-empty, **discriminating** fingerprint for class-method / partial-hunk shapes so distinct edits key differently and cannot merge into one over-trusted memory.

## Reproduction test
`tests/test_suggestion_fingerprint_shapes.py` — asserts non-empty fingerprints for both shapes and that two different method edits fingerprint differently. Verified **red (3 failing) on base → green (4 passing) with fix**.

---
_Provenance: surfaced by **parslee-morpheus** (post-merge review of `39d892b`, "Unrelated accepted fixes can be merged into one over-trusted memory" — i.e. this fix's under-promotion repair opened an over-promotion path); candidate fix authored by **parslee-trinity** and verified red→green locally. Review before merge._
