### PR TITLE
fix(memory): retraction teardown must not delete healthy globals or block re-learning

### DIFF
--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1457,6 +1457,12 @@ class FactStore:
                 existing_signature = existing.canonical_signature
                 if (
                     not existing.is_valid
+                    # PROJECT-scope tombstones only. A GLOBAL rollback is a
+                    # separate ownership domain (owned by cross-project
+                    # reconcile); letting one block a project's own local
+                    # promotion means one project's undo silently bars every
+                    # other, unrelated project from re-learning the pattern.
+                    and existing.scope == FactScope.PROJECT
                     and existing.invalidation_reason == "repeated_attributed_contradiction"
                     and existing_signature == target_signature
                 ):
@@ -1538,6 +1544,34 @@ class FactStore:
                     break
         episode_ids = list(dict.fromkeys(ep.episode_id for _, ep in supporting))
         return supporting, project_ids, episode_ids
+
+    def _clear_global_promotion_links(
+        self, target_signature: str, fact_id: str, episodes_root: "Path"
+    ) -> int:
+        """Clear ``promoted_global_fact_id`` on every candidate that links to a
+        torn-down global (``fact_id``) for ``target_signature``, writing the
+        episodes back. Without this the leftover link permanently reads as
+        'already promoted' — barring the signature from re-promotion even under
+        fresh strong evidence, and (because the link lives in the shared episode
+        store) blocking every project. Returns the number of candidates cleared."""
+        from neo.memory.episodes import LearningEpisodeStore
+
+        cleared = 0
+        for project_path in sorted(p for p in episodes_root.iterdir() if p.is_dir()):
+            episode_store = LearningEpisodeStore(project_path.name, base_dir=episodes_root)
+            for episode in episode_store.list():
+                changed = False
+                for candidate in episode.memory_candidates:
+                    if (
+                        candidate.promoted_global_fact_id == fact_id
+                        and self._global_signature(candidate.subject) == target_signature
+                    ):
+                        candidate.promoted_global_fact_id = ""
+                        changed = True
+                        cleared += 1
+                if changed:
+                    episode_store.save(episode)
+        return cleared
 
     def _mint_global_fact(
         self, target_signature: str, subject_src: str, body_src: str,
@@ -1723,6 +1757,12 @@ class FactStore:
             # representative candidate. Only signatures that already clear the
             # bar pay the expensive mint+rescan.
             reps: dict[str, dict[str, Any]] = {}
+            # Signatures with an ACTIVE retraction signal on disk — a candidate
+            # downgraded to 'contradicted' by a repeated attributed
+            # contradiction. Teardown fires only for these; a signature whose
+            # support merely dropped (episodes aged out of the bounded per-
+            # project ring buffer, no contradiction) is left intact.
+            contradicted_signatures: set[str] = set()
             for project_path in sorted(p for p in episodes_root.iterdir() if p.is_dir()):
                 episode_store = LearningEpisodeStore(project_path.name, base_dir=episodes_root)
                 for episode in episode_store.list():
@@ -1730,9 +1770,12 @@ class FactStore:
                     for candidate in episode.memory_candidates:
                         if candidate.kind != FactKind.PATTERN.value:
                             continue
+                        signature = self._global_signature(candidate.subject)
+                        if candidate.status == "contradicted":
+                            contradicted_signatures.add(signature)
+                            continue
                         if candidate.status not in {"supported_once", "durable"}:
                             continue
-                        signature = self._global_signature(candidate.subject)
                         entry = reps.setdefault(signature, {
                             "subject": candidate.subject, "body": candidate.body,
                             "cid": candidate.candidate_id,
@@ -1761,13 +1804,21 @@ class FactStore:
                     minted += 1
             if minted:
                 logger.info("Reconciled %d cross-project global promotion(s)", minted)
-            # Teardown: retract any existing global whose LIVE cross-project
-            # support has fallen below the bar — e.g. a contributing project
-            # rolled its pattern back (its candidates downgraded to
-            # 'contradicted', so absent from the reps tally). reconcile is
-            # otherwise additive-only; this is the only path that tears a global
-            # down, and it runs on the observer's fresh reload, so it sees the
-            # global a rolling-back project's stale store could not.
+            # Teardown: retract an existing global ONLY when a contributing
+            # project ACTIVELY rolled its pattern back — i.e. some candidate for
+            # this signature is now 'contradicted'. reconcile is otherwise
+            # additive-only; this is the only path that tears a global down, and
+            # it runs on the observer's fresh reload, so it sees the global a
+            # rolling-back project's stale store could not.
+            #
+            # Absence of support alone is NOT a retraction: supporting episodes
+            # scroll out of the bounded per-project ring buffer
+            # (LearningEpisodeStore._enforce_limit) in busy projects, dropping
+            # the live tally below the bar with nobody having retracted. Tearing
+            # down then silently deletes a healthy shared pattern that (because
+            # of the lingering promoted_global_fact_id links) could never be
+            # re-learned. Requiring a contradiction signal preserves the stated
+            # intent ("fire only when support was actively retracted").
             retracted = 0
             for fact in [
                 f for f in self._facts
@@ -1782,6 +1833,8 @@ class FactStore:
                 sig = fact.canonical_signature
                 if not sig:
                     continue
+                if sig not in contradicted_signatures:
+                    continue
                 entry = reps.get(sig)
                 projects = len(entry["projects"]) if entry else 0
                 episodes = len(entry["episodes"]) if entry else 0
@@ -1791,6 +1844,13 @@ class FactStore:
                 ):
                     fact.invalidation_reason = "repeated_attributed_contradiction"
                     self._invalidate(fact)
+                    # Clear the on-disk global link off every still-present
+                    # supporting candidate for this signature. The link is the
+                    # idempotency key both _mint_global_fact and the reps tally
+                    # read as "already promoted"; leaving it set would bar the
+                    # pattern from ever being re-minted even under fresh strong
+                    # evidence. Mirrors how the link is set at mint.
+                    self._clear_global_promotion_links(sig, fact.id, episodes_root)
                     retracted += 1
             if retracted:
                 self.save()

--- a/tests/test_reconcile_teardown_aging.py
+++ b/tests/test_reconcile_teardown_aging.py
@@ -1,0 +1,143 @@
+"""Reproduction tests for issue #9004.
+
+The reconcile teardown that retracts an under-supported GLOBAL episode-derived
+fact must fire ONLY on an active retraction (a candidate downgraded to
+'contradicted'), never merely because supporting episodes aged out of a busy
+project's bounded ring buffer. When it does fire, it must not permanently bar
+the same pattern from being re-learned, and it must never block an unrelated
+project from minting its own local project fact.
+
+Each test asserts the correct behavior and therefore FAILS on the buggy code.
+"""
+
+from unittest.mock import patch
+
+from neo.memory.models import FactScope
+from neo.memory.outcomes import Outcome, OutcomeType
+from neo.memory.store import FactStore
+
+# A subject with NO file-path bracket, so the path-bearing project
+# (_episode_signature) and path-agnostic global (_global_signature) identities
+# coincide — needed to exercise the cross-project block (finding 3).
+SUBJECT = "pattern: escape shell args"
+BODY = "escape shell arguments before exec"
+
+
+def _make_project(tmp_path, name, facts_dir, episodes_dir):
+    root = tmp_path / name
+    root.mkdir()
+    return FactStore(
+        codebase_root=str(root), eager_init=False,
+        facts_dir=facts_dir, episodes_dir=episodes_dir,
+    )
+
+
+def _feed(store, episodes_dir, prefix, n, otype):
+    from neo.memory.episodes import LearningEpisode, LearningEpisodeStore, MemoryCandidateEvidence
+
+    es = LearningEpisodeStore(store.project_id, base_dir=episodes_dir)
+    for i in range(n):
+        ep_id, cid, sid = f"{prefix}-{i}", f"{prefix}c{i}", f"{prefix}s{i}"
+        ep = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+        ep.memory_candidates.append(MemoryCandidateEvidence(
+            candidate_id=cid, suggestion_id=sid,
+            subject=SUBJECT, body=BODY, kind="pattern"))
+        es.save(ep)
+        outcome = Outcome(
+            outcome_type=otype, file_path="src/sh.py",
+            suggestion_id=sid, learning_episode_id=ep_id, candidate_id=cid,
+            candidate_subject=SUBJECT, candidate_body=BODY, candidate_kind="pattern")
+        with patch.object(store._outcome_tracker, "detect_outcomes",
+                          return_value=([outcome], {})):
+            store.detect_implicit_feedback({"prompt": "n"}, [])
+
+
+def _valid_globals(store):
+    return [
+        f for f in store.entries
+        if f.is_valid and f.scope == FactScope.GLOBAL and "episode-derived" in f.tags
+    ]
+
+
+def test_aged_out_support_does_not_tear_down_healthy_global(tmp_path):
+    """Finding 1: a healthy global must survive when a busy project's supporting
+    episodes simply age out of the bounded ring buffer (no retraction)."""
+    facts_dir = tmp_path / "facts"
+    episodes_dir = tmp_path / "episodes"
+
+    a = _make_project(tmp_path, "A", facts_dir, episodes_dir)
+    _feed(a, episodes_dir, "acc", 2, OutcomeType.ACCEPTED)
+    b = _make_project(tmp_path, "B", facts_dir, episodes_dir)
+    _feed(b, episodes_dir, "bacc", 2, OutcomeType.ACCEPTED)  # A+B mint the global
+    assert len(_valid_globals(b)) == 1
+
+    # Simulate A's supporting episodes aging out of the bounded per-project
+    # buffer (LearningEpisodeStore._enforce_limit unlinks the oldest). NO
+    # retraction has occurred.
+    from neo.memory.episodes import LearningEpisodeStore
+    a_episode_dir = LearningEpisodeStore(a.project_id, base_dir=episodes_dir).path
+    for stale in a_episode_dir.glob("*.json"):
+        stale.unlink()
+
+    # On the next reconcile the live tally shows only project B (below the bar),
+    # but nobody retracted anything — the global must NOT be torn down.
+    b.reconcile_cross_project_promotions()
+    assert len(_valid_globals(b)) == 1, "healthy global was deleted after episodes aged out"
+
+
+def test_torn_down_global_can_be_relearned_with_fresh_evidence(tmp_path):
+    """Finding 2: after a real contradiction tears a global down, fresh strong
+    cross-project evidence must be able to re-mint it."""
+    facts_dir = tmp_path / "facts"
+    episodes_dir = tmp_path / "episodes"
+
+    a = _make_project(tmp_path, "A", facts_dir, episodes_dir)
+    _feed(a, episodes_dir, "acc", 2, OutcomeType.ACCEPTED)
+    b = _make_project(tmp_path, "B", facts_dir, episodes_dir)
+    _feed(b, episodes_dir, "bacc", 2, OutcomeType.ACCEPTED)  # A+B mint the global
+    assert len(_valid_globals(b)) == 1
+
+    _feed(a, episodes_dir, "corr", 2, OutcomeType.MODIFIED)  # A actively retracts
+
+    # Real contradiction present -> reconcile tears the under-supported global down.
+    b.reconcile_cross_project_promotions()
+    assert _valid_globals(b) == []
+
+    # Fresh strong evidence: a brand-new project C accepts the same pattern twice,
+    # and B still holds its two supporting episodes -> 2 projects / 4 episodes.
+    c = _make_project(tmp_path, "C", facts_dir, episodes_dir)
+    _feed(c, episodes_dir, "cacc", 2, OutcomeType.ACCEPTED)
+
+    # The observer reconciles on a fresh reload each cycle (a stale store cannot
+    # see globals another process just minted). Re-mint must now succeed.
+    observer = _make_project(tmp_path, "observer", facts_dir, episodes_dir)
+    observer.reconcile_cross_project_promotions()
+    assert len(_valid_globals(observer)) == 1, "pattern permanently barred from re-promotion"
+
+
+def test_global_teardown_does_not_block_unrelated_project_local_fact(tmp_path):
+    """Finding 3: an unrelated project must still be able to mint its own local
+    PROJECT fact after a global for the same signature was torn down."""
+    facts_dir = tmp_path / "facts"
+    episodes_dir = tmp_path / "episodes"
+
+    a = _make_project(tmp_path, "A", facts_dir, episodes_dir)
+    _feed(a, episodes_dir, "acc", 2, OutcomeType.ACCEPTED)
+    b = _make_project(tmp_path, "B", facts_dir, episodes_dir)
+    _feed(b, episodes_dir, "bacc", 2, OutcomeType.ACCEPTED)  # A+B mint the global
+    assert len(_valid_globals(b)) == 1
+
+    _feed(a, episodes_dir, "corr", 2, OutcomeType.MODIFIED)  # A retracts
+    b.reconcile_cross_project_promotions()                   # global torn down
+    assert _valid_globals(b) == []
+
+    # Unrelated project C never had any contradiction; it independently accepts
+    # the same pattern twice and must get its own local project fact.
+    c = _make_project(tmp_path, "C", facts_dir, episodes_dir)
+    _feed(c, episodes_dir, "cacc", 2, OutcomeType.ACCEPTED)
+
+    local = [
+        f for f in c.entries
+        if f.is_valid and f.scope == FactScope.PROJECT and "episode-derived" in f.tags
+    ]
+    assert local, "unrelated project blocked from minting its own local fact by global teardown"


### PR DESCRIPTION
## Defect (three related over-reaches in cross-project retraction cleanup)
1. Older supporting evidence aging out of the buffer could tear down a **healthy** shared pattern.
2. A torn-down pattern could **never be re-learned**, even with fresh evidence.
3. One project's retraction **blocked all other projects** from learning that pattern.

## Fix
Scope teardown to genuine contradiction: healthy globals survive evidence aging, re-learning stays possible with fresh support, and unrelated project-local facts are unaffected.

## Reproduction test
`tests/test_reconcile_teardown_aging.py` — one test per defect (aged-out support doesn't tear down a healthy global; torn-down global can be re-learned; teardown doesn't block an unrelated project-local fact). Verified **red (3 failing) on base → green (3 passing) with fix**.

---
_Provenance: surfaced by **parslee-morpheus** (post-merge review of `a6eec5f`, 3 major findings); candidate fix authored by **parslee-trinity** and verified red→green locally. Review before merge._
