### PR TITLE
build: make local checks actually predict CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,22 @@
 #!/bin/sh
-# Pre-commit hook: lint and test before every commit
-# Install: git config core.hooksPath .githooks
+# Pre-commit hook: run the SAME checks CI runs, before the commit exists.
+#
+# Install:  make hooks     (or: git config core.hooksPath .githooks)
+#
+# This is a parity gate, not a general test run. Every command below must stay
+# identical to .github/workflows/ci.yml, and the toolchain must be pinned in
+# pyproject's [dev] extra — otherwise "passes locally" means nothing. That is not
+# hypothetical: during 0.39.0 a green local tree turned main red, because local
+# ruff was 0.15 while CI resolved 0.16 and the two disagreed about which rules
+# are on by default.
+#
+# It still cannot catch everything. CI runs Linux across Python 3.10-3.13; this
+# runs your machine on one interpreter. A test that assumes macOS paths passes
+# here and fails there — that happened too. Treat green as necessary, not
+# sufficient.
+#
+# Bypassing with --no-verify is a decision, not a shortcut. If you do it, say why
+# in the commit message.
 
 set -e
 
@@ -10,10 +26,20 @@ if [ -x ".venv/bin/python" ]; then
 fi
 export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src"
 
-echo "Running ruff lint..."
+# Fail loudly on a linter version mismatch rather than linting clean against the
+# wrong rule set and handing CI a red build.
+PINNED_RUFF=$(sed -n 's/^ *"ruff==\([0-9.]*\)",/\1/p' pyproject.toml | head -1)
+LOCAL_RUFF=$("$PYTHON_BIN" -m ruff --version 2>/dev/null | awk '{print $2}')
+if [ -n "$PINNED_RUFF" ] && [ "$PINNED_RUFF" != "$LOCAL_RUFF" ]; then
+  echo "pre-commit: ruff version mismatch — pinned ${PINNED_RUFF}, local ${LOCAL_RUFF:-none}." >&2
+  echo "            CI lints with ${PINNED_RUFF}. Run: pip install -e '.[dev]'" >&2
+  exit 1
+fi
+
+echo "Running ruff lint (same command as CI)..."
 "$PYTHON_BIN" -m ruff check src/ tests/
 
-echo "Running tests..."
-"$PYTHON_BIN" -m pytest tests/ -q --tb=line -x
+echo "Running tests (same command as CI)..."
+"$PYTHON_BIN" -m pytest tests/ -q --tb=line
 
 echo "All checks passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.39.1] - 2026-07-25
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Local checks now actually predict CI.** `ruff` is pinned to an exact version instead of a range: it is pre-1.0 and changes both its default rule set and rule behavior in minor bumps, so a range let a contributor's linter and CI's disagree — which is how a green local tree turned `main` red twice during the 0.39.0 release. The `Makefile` now runs tools through the project venv rather than whatever `ruff`/`pytest` sit on `PATH` (a system ruff 0.15.1 was shadowing the pinned 0.16.0, so `make lint` was linting against the wrong rules). The repo's `.githooks/pre-commit` runs the same commands as CI and refuses to run at all on a linter version mismatch, and `make hooks` installs it so it is versioned with the code instead of drifting untracked in `.git/hooks/`. `make ci-local` runs the gate without committing. Documented in CONTRIBUTING, including the limit: CI is Linux across Python 3.10–3.13 while the hook is one machine and one interpreter, so green locally is necessary but not sufficient. (`pyproject.toml`, `Makefile`, `.githooks/pre-commit`, `CONTRIBUTING.md`)
+
 ## [0.39.0] - 2026-07-25
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,36 @@ pip install -e ".[dev]"
 
 This installs Neo in editable mode with all development tools (pytest, black, ruff, mypy).
 
+`ruff` is pinned to an **exact** version, not a range. It is pre-1.0 and changes
+both its default rule set and rule behavior in minor bumps, so a range lets your
+local linter and CI's disagree — which is exactly how a green local tree turned
+`main` red during 0.39.0. Bump the pin deliberately, in its own commit, with the
+lint delta reviewed.
+
+### 3a. Enable the pre-commit hook
+
+```bash
+make hooks
+```
+
+Run this once per clone. It points `core.hooksPath` at the repo's `.githooks/`,
+so the hook is versioned with the code rather than living untracked in
+`.git/hooks/` where it silently drifts.
+
+The hook runs the **same** lint and test commands as CI, and refuses to run at
+all if your `ruff` differs from the pinned version. It is a parity gate, not a
+general test run — if you change it, change `.github/workflows/ci.yml` to match.
+
+It cannot catch everything: CI runs Linux across Python 3.10–3.13, the hook runs
+your machine on one interpreter. A test that assumes macOS paths passes locally
+and fails in CI. Green locally is necessary, not sufficient.
+
+To run the same checks without committing:
+
+```bash
+make ci-local
+```
+
 ### 4. Configure API Keys
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: help install install-dev test format lint clean
+.PHONY: help install install-dev test format lint hooks ci-local clean
+
+# Prefer the project venv over whatever happens to be on PATH. A system-wide
+# `ruff` is routinely a different version from the pinned one, and linting with
+# the wrong version is precisely how a green local tree turned main red.
+PYTHON := $(shell test -x .venv/bin/python && echo .venv/bin/python || echo python3)
 
 help:
 	@echo "Neo Makefile Commands:"
@@ -8,6 +13,8 @@ help:
 	@echo "  make test          - Run all tests"
 	@echo "  make format        - Format code with black"
 	@echo "  make lint          - Lint code with ruff"
+	@echo "  make hooks         - Enable the pre-commit hook (run once per clone)"
+	@echo "  make ci-local      - Run exactly what CI runs, before pushing"
 	@echo "  make clean         - Clean up generated files"
 
 install:
@@ -17,13 +24,21 @@ install-dev:
 	pip install -e ".[dev]"
 
 test:
-	pytest
+	$(PYTHON) -m pytest
 
 format:
-	black src/ tests/
+	$(PYTHON) -m black src/ tests/
 
 lint:
-	ruff check src/ tests/
+	$(PYTHON) -m ruff check src/ tests/
+
+hooks:
+	git config core.hooksPath .githooks
+	@echo "pre-commit hook enabled (.githooks). It runs the same lint + tests as CI."
+
+ci-local:
+	$(PYTHON) -m ruff check src/ tests/
+	$(PYTHON) -m pytest -q
 
 clean:
 	rm -rf __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,11 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "black>=23.0.0",
-    # Upper bound: ruff is pre-1.0 and changes rule behavior in minor bumps.
-    "ruff>=0.15.0,<1.0",
+    # Pinned EXACTLY, not a range. ruff is pre-1.0 and changes both its default
+    # rule set and rule behavior in minor bumps, so a range means a contributor's
+    # local ruff and CI's can disagree — which is how a green local tree pushed a
+    # red main in 0.39.0. Bump this deliberately, with the lint delta reviewed.
+    "ruff==0.16.0",
     "mypy>=1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.39.0"
+version = "0.39.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.39.0"
+__version__ = "0.39.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Makes local checks actually predict CI. The 0.39.0 release turned `main` red twice; neither failure was catchable locally, because "passes locally" did not mean anything.

Three concrete gaps, all now closed:

- **`ruff` was pinned as a range** (`>=0.15.0,<1.0`). It is pre-1.0 and changes both its default rule set and rule behavior in minor bumps, so local resolved 0.15 while CI resolved 0.16. A clean local lint handed CI **1050 errors** — on code the release never touched. Verified by running ruff 0.16 against the *previous* release commit: 1050 errors there too. The linter moved, not the code. Now pinned exactly.
- **`make lint` ran a bare `ruff` from `PATH`** — a system 0.15.1, shadowing the pinned version. The one command a contributor would reach for to pre-check was linting against the wrong rules. Every Makefile target now runs through the project venv.
- **The tracked `.githooks/pre-commit` was never active.** `core.hooksPath` was unset and undocumented, so a stale untracked copy in `.git/hooks/` ran instead. Its header claimed it "ensures we never push broken code to CI" — a promise it could not keep. It now runs the same commands as CI, refuses to run at all on a linter version mismatch, and `make hooks` installs it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

`main` was red for roughly ten minutes across two pushes during the 0.39.0 release, and the release bypassed this repo's own PR requirement on an admin override. This PR is both the fix for the underlying tooling gap and the demonstration of the workflow that should have been used: branch → hook-verified commit → PR → CI → merge.

The hook's docstring now states what it *cannot* do rather than overpromising. CI is Linux across Python 3.10–3.13; the hook is one machine and one interpreter. A test asserting macOS-only paths passed locally and failed CI during 0.39.0. Green locally is necessary, not sufficient.

## How Has This Been Tested?

- [x] `make ci-local` — full suite, 1473 passed / 3 skipped, lint clean
- [x] Committed through the hook with **no** `--no-verify`; hook ran lint + tests and passed
- [x] Version guard verified in both directions: downgraded ruff to 0.15.0 → hook exits **1** and blocks; restored 0.16.0 → hook proceeds
- [x] Confirmed `make lint` now resolves `.venv/bin/python -m ruff` (0.16.0) rather than `/opt/homebrew/bin/ruff` (0.15.1)
- [x] Confirmed the pinned rule set is clean under both ruff 0.15.0 and 0.16.0, on this branch and on the prior release commit

**Test Configuration**:
- Python version: 3.13 local; CI matrix 3.10–3.13
- OS: macOS local; ubuntu-latest CI
- Neo version: 0.39.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — build/tooling change; verified by executing the gate in both pass and fail states rather than by unit test
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Deliberately **not** included: a bulk fix of the ~1050 findings the newer ruff default set reports. That is a thousand-line diff across unrelated code, and widening the enforced rule set is a decision to take on its own terms — not something to smuggle into a tooling fix. The `select` list added in 0.39.0 records what the project actually enforces today.

Bumping the ruff pin should be its own commit, with the lint delta reviewed.
