### PR TITLE
perf(memory): drop bulk text from tombstones at invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Tombstones no longer carry their bulk text.** An invalidated fact is retained up to 30 days for supersession and audit, and every byte of it was deserialized on each `FactStore` load — the single largest driver of observer RSS. Measured on a live store: 11,421 tombstones holding 24.7 MB, of which `body` alone was 15.8 MB. `_invalidate` now drops `body`, `context_text` and `retrieval_text` at the transition, mirroring the existing embedding strip at the same choke point, and the periodic sweep backfills tombstones created before this landed. Verified against a copy of a real 188 MB store: **zero valid facts lost or gained** at identity level, tombstone count unchanged, 15 MB reclaimed in one pass.
+
+  `subject` and `tags` are kept for audit, and `metadata` is kept because `purge_dead_facts` ages tombstones off `metadata.last_accessed` — dropping it would strand them forever. `episode_context` is deliberately not stripped: it is a structured object with its own `to_dict`, and blanking it breaks serialization outright.
+
+  The obvious bigger change — moving tombstones to a sidecar file so the hot path never parses them — was investigated and **rejected**: `_reconcile_fact` returns OURS when we hold a fact invalid, which is what makes an invalidation beat a concurrent writer's stale valid copy. Lazily-loaded tombstones would let merge-on-save silently resurrect invalidated facts. (`memory/store.py`)
+
 ## [0.40.0] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.40.1] - 2026-07-25
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,19 @@
   - Independent-outcome facts capped at 5/session (`MAX_INDEPENDENT_OUTCOMES` in
     `outcomes.py`) and 50/project (`MAX_INDEPENDENT_FACTS` in `store.py`).
   - Invalidation choke point: `_invalidate(fact, *, cascade=True)` is the single
-    path that sets `is_valid=False`. It **strips the 768-dim embedding at the
-    transition** — a tombstone is never retrieved/deduped/clustered (all such
+    path that sets `is_valid=False`. It **strips the 768-dim embedding AND the
+    bulk text (`body`, `context_text`, `retrieval_text`) at the transition**
+    (`_strip_tombstone_text`; measured 11,421 tombstones holding 24.7 MB, of
+    which `body` alone was 15.8 MB). `subject`/`tags` stay for audit and
+    `metadata` stays because `purge_dead_facts` ages tombstones off
+    `metadata.last_accessed` and reads `invalidation_reason` — dropping those
+    would strand tombstones forever. `episode_context` is deliberately NOT
+    stripped: it is a structured `EpisodeContext` with its own `to_dict`, and
+    blanking it to `""` breaks serialization (caught against a copy of a real
+    store). Safe because nothing reads a tombstone's text: dedup skips invalid
+    facts (`_exact_canonical_match`), merge-on-save returns early for them
+    (`_reconcile_fact`), retrieval and clustering pre-filter `is_valid`. The
+    older wording said only the embedding — a tombstone is never retrieved/deduped/clustered (all such
     paths pre-filter `is_valid`) but is retained up to 30 days for
     supersession/audit, so its embedding (~24 KB/fact) is immediate dead weight;
     stripping at the source keeps bloat from accumulating between sweeps. All six

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.40.0"
+version = "0.40.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.40.0"
+__version__ = "0.40.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -229,6 +229,42 @@ def build_resilient_embedder(
         return None
 
 
+#: Fields dropped from a fact when it becomes a tombstone. Nothing reads them
+#: after invalidation — dedup skips invalid facts (`_exact_canonical_match`),
+#: merge-on-save returns early for them (`_reconcile_fact`), and retrieval and
+#: clustering all pre-filter `is_valid`. Measured on a live store: 11,421
+#: tombstones held 24.7 MB, of which `body` alone was 15.8 MB, and every byte
+#: was deserialized into Python objects on every load.
+#:
+#: `subject` and `tags` are KEPT for audit, and `metadata` is KEPT because
+#: `purge_dead_facts` ages tombstones off `metadata.last_accessed` and reads
+#: `invalidation_reason`. Dropping those would strand tombstones forever.
+#: Only plain-text fields. `episode_context` is a structured `EpisodeContext`
+#: with its own `to_dict`, and blanking it to "" breaks serialization outright —
+#: caught by running this against a copy of a real store. It also contributed
+#: almost nothing to the measured bytes, so it is deliberately not stripped.
+_TOMBSTONE_DROPPED_FIELDS = ("body", "context_text", "retrieval_text")
+
+
+def _strip_tombstone_text(fact) -> bool:
+    """Blank the bulk text on an already-invalid fact. Returns True if changed.
+
+    Mirrors the embedding strip: same choke point, same rationale — a tombstone
+    is retained up to 30 days for supersession and audit, so its multi-KB body
+    is dead weight for that entire window.
+    """
+    changed = False
+    for field in _TOMBSTONE_DROPPED_FIELDS:
+        current = getattr(fact, field, None)
+        if not current or not isinstance(current, str):
+            continue  # already empty, or not the plain-text field we expect
+        # `body` is a plain `str` field; the other two are Optional[str]. Reset
+        # each to its own declared empty value rather than assuming one shape.
+        setattr(fact, field, "" if field == "body" else None)
+        changed = True
+    return changed
+
+
 class FactStore:
     """Scoped fact store with supersession-based knowledge management.
 
@@ -2657,13 +2693,23 @@ class FactStore:
         """
         stripped = 0
         for fact in self._facts:
-            if not fact.is_valid and fact.embedding is not None:
+            if fact.is_valid:
+                continue
+            changed = False
+            if fact.embedding is not None:
                 fact.embedding = None
+                changed = True
+            # Same sweep also backfills the bulk-text strip, so tombstones
+            # created before that landed (or by a peer process) are slimmed
+            # without a separate migration pass.
+            if _strip_tombstone_text(fact):
+                changed = True
+            if changed:
                 stripped += 1
         if stripped:
             if save:
                 self.save()
-            logger.info(f"Stripped embeddings from {stripped} tombstone(s)")
+            logger.info(f"Slimmed {stripped} tombstone(s)")
         return stripped
 
     def prune_stale_facts(self, save: bool = True) -> int:
@@ -3089,7 +3135,8 @@ class FactStore:
     def _invalidate(self, fact: Fact, *, cascade: bool = True) -> None:
         """Single choke point for marking a fact invalid.
 
-        Sets ``is_valid = False`` and drops the embedding at the transition: a
+        Sets ``is_valid = False``, drops the embedding, and drops the bulk text
+        at the transition: a
         tombstone is never retrieved, deduped, or clustered (all such paths
         pre-filter ``is_valid``), so its 768-dim vector is immediately dead
         weight. Stripping here keeps bloat from accumulating between the
@@ -3105,6 +3152,7 @@ class FactStore:
         """
         fact.is_valid = False
         fact.embedding = None
+        _strip_tombstone_text(fact)
         if cascade:
             self._cascade_needs_review(fact.id)
 

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -3071,3 +3071,69 @@ class TestSynthesisRemoved:
         """The git-verified learning path is untouched."""
         assert hasattr(FactStore, "_promote_repeatedly_supported_candidate")
         assert hasattr(FactStore, "reconcile_cross_project_promotions")
+
+
+class TestTombstoneTextStrip:
+    """Tombstones are retained up to 30 days for supersession and audit, so
+    their multi-KB bodies are dead weight for that whole window — and every
+    byte is deserialized on each load. Measured on a live store: 11,421
+    tombstones held 24.7 MB, `body` alone 15.8 MB.
+    """
+
+    def _fact(self, **kw):
+        f = Fact(subject="s", body="a long body " * 50, kind=FactKind.PATTERN,
+                 scope=FactScope.PROJECT, org_id="o", project_id="p",
+                 metadata=FactMetadata(confidence=0.5), **kw)
+        f.context_text = "ctx"
+        f.retrieval_text = "retr"
+        return f
+
+    def test_invalidate_drops_bulk_text(self, store):
+        f = self._fact()
+        store._facts.append(f)
+        store._invalidate(f)
+        assert f.is_valid is False
+        assert f.body == "" and f.context_text is None and f.retrieval_text is None
+
+    def test_audit_and_purge_fields_survive(self, store):
+        """subject/tags stay for audit; metadata stays because purge_dead_facts
+        ages tombstones off metadata.last_accessed."""
+        f = self._fact()
+        f.tags = ["outcome", "accepted"]
+        store._facts.append(f)
+        store._invalidate(f)
+        assert f.subject == "s"
+        assert f.tags == ["outcome", "accepted"]
+        assert f.metadata is not None and f.metadata.last_accessed is not None
+        assert f.id and f.kind is FactKind.PATTERN
+
+    def test_structured_episode_context_is_untouched(self):
+        """`episode_context` is an EpisodeContext with its own to_dict; blanking
+        it to "" broke serialization outright when first attempted."""
+        from neo.memory.store import _strip_tombstone_text
+        f = self._fact()
+        sentinel = object()
+        f.episode_context = sentinel
+        _strip_tombstone_text(f)
+        assert f.episode_context is sentinel
+
+    def test_strip_is_idempotent(self):
+        from neo.memory.store import _strip_tombstone_text
+        f = self._fact()
+        assert _strip_tombstone_text(f) is True
+        assert _strip_tombstone_text(f) is False
+
+    def test_valid_facts_are_never_stripped_by_the_backfill(self, store):
+        keep = self._fact()
+        store._facts.append(keep)
+        store.strip_tombstone_embeddings(save=False)
+        assert keep.is_valid and keep.body.startswith("a long body")
+
+    def test_backfill_slims_preexisting_tombstones(self, store):
+        """Tombstones created before this landed (or by a peer) get slimmed
+        without a separate migration pass."""
+        old = self._fact()
+        old.is_valid = False          # invalidated the old way: text intact
+        store._facts.append(old)
+        assert store.strip_tombstone_embeddings(save=False) == 1
+        assert old.body == ""


### PR DESCRIPTION
## Description

Tombstones no longer carry their bulk text. An invalidated fact is retained up to 30 days for supersession and audit, and every byte of it was deserialized into Python objects on each `FactStore` load — the single largest driver of observer RSS.

Measured on a live store: **11,421 tombstones holding 24.7 MB**, of which `body` alone was **15.8 MB**. `_invalidate` now drops `body`, `context_text` and `retrieval_text` at the transition, mirroring the embedding strip already at that choke point; the periodic sweep backfills tombstones created before this landed or by a peer process.

## Type of Change

- [x] Performance improvement

## Motivation and Context

This is the follow-on to #147. That change capped RSS *drift* by recycling the process; the floor was still one cycle's working set, and this attacks the working set itself.

**Kept deliberately:** `subject` and `tags` for audit, and `metadata` because `purge_dead_facts` ages tombstones off `metadata.last_accessed` and reads `invalidation_reason` — dropping those would strand every tombstone forever.

**Not stripped:** `episode_context`. It is a structured `EpisodeContext` with its own `to_dict`, and blanking it to `""` breaks serialization outright. I hit exactly that running the first version against a copy of a real store. It also contributed almost nothing to the measured bytes.

Safe because nothing reads a tombstone's text: dedup skips invalid facts (`_exact_canonical_match`), merge-on-save returns early for them (`_reconcile_fact`), and retrieval and clustering pre-filter `is_valid`.

## How Has This Been Tested?

- [x] Run against a **copy of the live 188 MB store**: zero valid facts lost or gained *at identity level* (diffed by fact id, not count), tombstone count unchanged, **15 MB reclaimed** in a single pass, zero save errors
- [x] Unit tests: strip at invalidation, audit/purge fields survive, structured `episode_context` untouched, idempotency, valid facts never stripped, backfill slims pre-existing tombstones
- [x] `make ci-local` — 1485 passed, lint clean
- [x] Committed through the pre-commit hook, no `--no-verify`

**Test Configuration**: Python 3.13 local, CI matrix 3.10–3.13; macOS local, ubuntu-latest CI; neo 0.40.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Rejected after investigation: the sidecar file.** The obvious bigger change is moving tombstones out of the hot file entirely so they are never parsed. I traced it and it is unsafe: `_reconcile_fact` returns OURS when we hold a fact invalid, and that is precisely what makes an invalidation beat a concurrent writer's stale valid copy. Lazily-loaded tombstones would let merge-on-save **silently resurrect invalidated facts** — a correctness bug considerably worse than the memory it saves.

One thing worth remembering before touching either: the pre-write dedup signature (`_canonical_signature`) is *recomputed* from `subject + body` rather than read from a stored field. It only ever runs over valid facts, which is what makes stripping tombstone bodies safe. It is a distinct function from the frozen `Fact.canonical_signature` used for promotion rollback — the "one keystroke apart" pair CLAUDE.md warns about.
