### PR TITLE
docs: record the release prerequisites and the TestPyPI gap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,12 @@ jobs:
           name: dist
           path: dist/
 
+  # NOTE: requires a Trusted Publisher configured on TestPyPI for this repo +
+  # workflow. It is NOT configured today, so a manual dispatch fails at the
+  # publish step with an OIDC "missing publisher" error — the build and the
+  # artifact round-trip still run and are still worth dispatching to smoke-test
+  # a workflow change. Configure at https://test.pypi.org/manage/account/publishing/
+  # (owner Parslee-ai, repo neo, workflow publish.yml) to make dry-runs work.
   publish-testpypi:
     needs: build
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,23 @@ local linter and CI's disagree — which is exactly how a green local tree turne
 `main` red during 0.39.0. Bump the pin deliberately, in its own commit, with the
 lint delta reviewed.
 
+### Releasing
+
+Publishing is automated: creating a GitHub **Release** triggers `publish.yml`,
+which builds and uploads to PyPI via Trusted Publishers (OIDC — no token lives
+in the repo). The sequence is push → tag → release; do not run `twine` locally.
+
+Two things to know before you rely on it:
+
+- **TestPyPI is not configured.** `publish-testpypi` only runs on a manual
+  `workflow_dispatch`, and it currently fails at the publish step because no
+  Trusted Publisher exists for this repo on TestPyPI. The `build` job and the
+  artifact upload/download round-trip still execute, so dispatching is a valid
+  smoke test for a workflow change — just expect the final step to fail until
+  someone configures it at <https://test.pypi.org/manage/account/publishing/>.
+- **A version can never be replaced on PyPI**, only yanked. Verify CI is green
+  on the exact commit you are tagging, not merely on the branch.
+
 ### 3a. Enable the pre-commit hook
 
 ```bash


### PR DESCRIPTION
## Description

Documents two release-path facts that were only discoverable by tripping over them.

**TestPyPI has no Trusted Publisher for this repo.** Dispatching `publish.yml` manually fails at the publish step with an OIDC "missing publisher" error. It was invisible because `publish-testpypi` only runs on `workflow_dispatch`, and the job showed `skipped` on every real release — so nobody had ever exercised it.

Nothing about releasing is broken: `publish-pypi` is release-gated, has a working publisher, and has shipped 0.39.0 / 0.39.1 / 0.40.0 / 0.40.1 cleanly.

## Type of Change

- [x] Documentation update

## Motivation and Context

Found while verifying #74 and #73, which bumped `upload-artifact` 6→7 and `download-artifact` 7→8 — leaving a mismatched pair in the **release path**. Dispatching the workflow confirmed `download-artifact@v8` reads what `upload@v7` writes, so the bumps are safe. The dispatch also surfaced the TestPyPI gap, which is worth writing down rather than rediscovering.

CONTRIBUTING now also records that a PyPI version can only be yanked, never replaced — so CI must be green on the exact commit being tagged, not merely on the branch.

## How Has This Been Tested?

- [x] Documentation and a YAML comment only; no code paths change
- [x] `make ci-local` — lint clean, suite green
- [x] The claims are from an actual dispatch run (30180615076): `ci-check` ✅, `build` ✅, `download-artifact@v8` ✅, `Publish to TestPyPI` ❌ on missing publisher

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Configuring the publisher is an account-level action on test.pypi.org and cannot be done from the repo, so this records what is needed rather than fixing it.
