### PR TITLE
fix(observer): tighten the recycle cadence to one that actually bounds RSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.40.2] - 2026-07-25
+
+### Fixed
+
+- **The observer's recycle cadence was too lax to do its job.** 0.40.0 shipped a default of 48 cycles (~4h) on the assumption that RSS creeps slowly. It does not: a live daemon went from 103 MB to **693 MB in 7 cycles**, reaching its plateau within minutes. A 4-hour cadence therefore reset an already-plateaued process and bought essentially nothing. Recycling caps RSS at roughly whatever it reaches in `recycle_after_cycles`, which makes that number the actual tuning dial rather than a formality. Default is now **6 cycles (~30min)**; a re-exec costs ~2s of process restart, under 0.2% overhead at that interval. (`memory/observer.py`)
+
 ## [0.40.1] - 2026-07-25
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.40.1"
+version = "0.40.2"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.40.1"
+__version__ = "0.40.2"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -36,7 +36,7 @@ Tunables (env, read by the daemon child):
                                      the rate at which restarts re-
                                      trigger mining.
     NEO_OBSERVER_RECYCLE_CYCLES    — re-exec after this many cycles to
-                                     bound RSS (default 48, ~4h). 0
+                                     bound RSS (default 6, ~30min). 0
                                      disables recycling.
 """
 
@@ -281,9 +281,15 @@ class ObserverConfig:
     # transcripts since their watermark do near-zero work (ingest finds nothing).
     max_projects_per_cycle: int = 25
     # Re-exec after this many cycles to bound RSS (see Observer._should_recycle).
-    # 48 cycles is ~4h at the default 300s interval — long enough that the swap
-    # is invisible, short enough that fragmentation never compounds. 0 disables.
-    recycle_after_cycles: int = 48
+    # 6 cycles is ~30min at the default 300s interval. The first default here was
+    # 48 (~4h), chosen on the assumption that RSS creeps slowly — it does not.
+    # Measured on a live daemon: 7 cycles took it from 103 MB to 693 MB, i.e. it
+    # reaches its plateau within minutes, so a 4h cadence reset an
+    # already-plateaued process and bought nothing. Recycling caps RSS at roughly
+    # whatever it reaches in N cycles, so N is the actual tuning dial. A re-exec
+    # costs ~2s of process restart, which at 30min intervals is under 0.2%
+    # overhead. 0 disables.
+    recycle_after_cycles: int = 6
 
     @classmethod
     def from_env(cls) -> "ObserverConfig":
@@ -414,8 +420,10 @@ class Observer:
         each project sweep deserializes a multi-MB fact file (79% of whose rows
         are tombstones retained by policy), and the allocator never returns
         those arenas to the OS. Nothing leaks — RSS drifts up to the high-water
-        mark and stays there, measured at 0.5-0.7 GB. Re-exec'ing on a cadence
-        bounds it for the cost of one process image swap.
+        mark and stays there, measured at 0.5-0.7 GB — and it gets there fast:
+        a live daemon went 103 MB -> 693 MB in 7 cycles. Recycling caps RSS at
+        roughly whatever it reaches in ``recycle_after_cycles``, which is why
+        that number is the real tuning dial rather than a formality.
         """
         limit = self.config.recycle_after_cycles
         return limit > 0 and self._cycles_total >= limit

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1161,6 +1161,13 @@ class TestRecycleToBoundRSS:
         assert self._observer(48, 48)._should_recycle() is True
         assert self._observer(49, 48)._should_recycle() is True
 
+    def test_default_cadence_is_tight_enough_to_matter(self):
+        """RSS plateaus within minutes (measured 103 MB -> 693 MB over 7 cycles),
+        so recycling caps it at whatever N cycles reach. A cadence far above that
+        resets an already-plateaued process and buys nothing."""
+        from neo.memory.observer import ObserverConfig
+        assert ObserverConfig().recycle_after_cycles <= 12
+
     def test_does_not_recycle_early(self):
         assert self._observer(47, 48)._should_recycle() is False
         assert self._observer(0, 48)._should_recycle() is False


### PR DESCRIPTION
## Description

0.40.0 shipped `recycle_after_cycles=48` (~4h). That default was wrong, and I caught it by measuring the running daemon after shipping.

**Measured: 7 cycles took the observer from 103 MB to 693 MB.** RSS reaches its plateau within minutes, so a 4-hour cadence reset an already-plateaued process and bounded nothing. Recycling caps RSS at roughly whatever it reaches in N cycles — N is the actual tuning dial, not a formality.

Default is now **6 cycles (~30min)**. A re-exec costs ~2s of process restart, which is under 0.2% overhead at that interval.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The mechanism from #147 works — a controlled test with `RECYCLE_CYCLES=1` held RSS oscillating between 179–381 MB. The default was simply set far above the point where it does any good, so in practice the shipped feature did nothing for the problem it was written to solve.

## How Has This Been Tested?

- [x] `make ci-local` — 1486 passed, lint clean
- [x] Added a guard test asserting the default stays ≤ 12 cycles, so this cannot silently drift back to a number that looks reasonable and bounds nothing
- [x] Existing recycle tests (budget predicate, `0` disables, env knob, exec args, non-fatal exec failure) still pass
- [x] Committed through the pre-commit hook, no `--no-verify`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Worth stating plainly: the floor is still one cycle's working set. Recycling bounds drift; it does not lower the baseline. Getting under that needs the fact files themselves to shrink further, and the tombstone slim in 0.40.1 was the safe portion of that — the sidecar variant was investigated and rejected because it would let merge-on-save silently resurrect invalidated facts.
