### PR TITLE
fix(observer): make the recycle default single-sourced, not restated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.40.3] - 2026-07-25
+
+### Fixed
+
+- **0.40.2's cadence fix was a no-op; this makes it real.** `ObserverConfig` declared the recycle default in two places — the dataclass field and a restated literal inside `from_env`. 0.40.2 moved the field 48 → 6 and left `from_env` saying 48, and the daemon only ever reads `from_env`, so the shipped default never changed. The guard test added alongside it checked `ObserverConfig()` rather than `ObserverConfig.from_env()`, so it passed against the broken path and gave false assurance. `from_env` now derives every fallback from the dataclass defaults instead of restating them, and the test asserts both construction paths plus their equality when no env is set. (`memory/observer.py`)
+
 ## [0.40.2] - 2026-07-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.40.2"
+version = "0.40.3"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.40.2"
+__version__ = "0.40.3"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -303,10 +303,17 @@ class ObserverConfig:
             except ValueError:
                 return default
 
+        defaults = cls()
         return cls(
-            interval_seconds=_read("NEO_OBSERVER_INTERVAL_SECONDS", 300.0),
-            cooldown_seconds=_read("NEO_OBSERVER_COOLDOWN", 60.0),
-            recycle_after_cycles=int(_read("NEO_OBSERVER_RECYCLE_CYCLES", 48.0)),
+            # Fall back to the dataclass defaults rather than restating them.
+            # A second literal here is how 0.40.2 shipped a no-op: the field
+            # default moved 48 -> 6 while this line kept saying 48, and the
+            # daemon only ever reads from_env().
+            interval_seconds=_read("NEO_OBSERVER_INTERVAL_SECONDS", defaults.interval_seconds),
+            cooldown_seconds=_read("NEO_OBSERVER_COOLDOWN", defaults.cooldown_seconds),
+            recycle_after_cycles=int(
+                _read("NEO_OBSERVER_RECYCLE_CYCLES", defaults.recycle_after_cycles)
+            ),
         )
 
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1164,9 +1164,30 @@ class TestRecycleToBoundRSS:
     def test_default_cadence_is_tight_enough_to_matter(self):
         """RSS plateaus within minutes (measured 103 MB -> 693 MB over 7 cycles),
         so recycling caps it at whatever N cycles reach. A cadence far above that
-        resets an already-plateaued process and buys nothing."""
+        resets an already-plateaued process and buys nothing.
+
+        Asserts BOTH construction paths. The first version of this test checked
+        only `ObserverConfig()` while the daemon reads `from_env()`, which kept
+        its own hardcoded 48 — so 0.40.2 shipped a no-op behind a green test.
+        """
         from neo.memory.observer import ObserverConfig
         assert ObserverConfig().recycle_after_cycles <= 12
+        assert ObserverConfig.from_env().recycle_after_cycles <= 12
+
+    def test_from_env_defaults_match_the_dataclass(self, monkeypatch):
+        """No env set => from_env must equal the field defaults exactly.
+
+        Guards the duplication class directly: any default restated as a literal
+        inside from_env can drift from the field it mirrors.
+        """
+        from neo.memory.observer import ObserverConfig
+        for var in ("NEO_OBSERVER_INTERVAL_SECONDS", "NEO_OBSERVER_COOLDOWN",
+                    "NEO_OBSERVER_RECYCLE_CYCLES"):
+            monkeypatch.delenv(var, raising=False)
+        plain, from_env = ObserverConfig(), ObserverConfig.from_env()
+        assert from_env.interval_seconds == plain.interval_seconds
+        assert from_env.cooldown_seconds == plain.cooldown_seconds
+        assert from_env.recycle_after_cycles == plain.recycle_after_cycles
 
     def test_does_not_recycle_early(self):
         assert self._observer(47, 48)._should_recycle() is False


### PR DESCRIPTION
## Description

**0.40.2 shipped a no-op, behind a green test.** This makes the fix real.

`ObserverConfig` declared the recycle default twice: once as the dataclass field, once as a literal inside `from_env`. 0.40.2 moved the field 48 → 6 and left `from_env` saying 48 — and the daemon only ever reads `from_env`, so the shipped default never changed. I confirmed it by querying the installed 0.40.2 build after release: still 48 cycles.

Worse, the guard test added in the same change asserted `ObserverConfig()` rather than `ObserverConfig.from_env()`. It exercised the path nobody uses and passed against the broken one.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`from_env` now derives every fallback from the dataclass defaults instead of restating them, so the same class cannot recur for `interval_seconds` or `cooldown_seconds` either.

## How Has This Been Tested?

- [x] `ObserverConfig.from_env().recycle_after_cycles` is now 6, verified directly
- [x] Env override still wins (`NEO_OBSERVER_RECYCLE_CYCLES=3` → 3)
- [x] Guard test now asserts **both** construction paths
- [x] New test asserts `from_env()` equals the field defaults exactly with no env set — guarding the duplication class itself, not just this one field
- [x] `make ci-local` — 1487 passed, lint clean
- [x] Committed through the pre-commit hook, no `--no-verify`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The lesson worth keeping: a test that constructs an object differently from the way production constructs it can pass while production is broken. The new test pins the production path explicitly.