### PR TITLE
perf(transcript): skip inputs untouched since the last ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.41.0] - 2026-07-26
+
+### Fixed
+
+- **Found and fixed the actual cause of the observer's multi-GB memory, rather than only capping it.** Cycles that mined nothing — 0.1s per project, "0 mined" — were still swinging RSS by gigabytes. The reason: `TranscriptIngester.ingest` called `source.collect_episodes()` and applied the watermark filter to the *result*. Every source fully parsed every transcript on every cycle, for every project, and `all_episodes` retained the lot. Measured on one project: **118 MB (ClaudeCodeSource) + 180 MB (CodexSource) = 298 MB**, times up to 25 projects a cycle. The documented "watermark-gated so unchanged projects do near-zero work" was simply not true — the watermark gated admission, not work.
+
+  Sources now skip inputs untouched since the watermark file's mtime (minus a 1h skew margin, since a transcript written *during* the previous ingest must never be judged already-seen). Measured after: the same project's collect goes **298 MB → 0 MB** when nothing changed. No storage format change — the watermark file's own mtime is the marker.
+
+  Every error path falls back to parsing: skipping is an optimization, but a wrong skip loses learning silently. `since` is passed only to sources whose signature accepts it, detected by inspection — sources are an open interface, and calling one with an unexpected kwarg raises a `TypeError` that the per-source guard swallows as "source failed", silently yielding zero episodes. That failure mode bit three separate test stubs during development. (`memory/transcript.py`)
+
+### Changed
+
+- **Recycle cadence 6 → 3 cycles (~15min).** With the parse spike fixed, peaks are far smaller, and a tighter cadence costs ~2s per 15min (<0.3%). (`memory/observer.py`)
+
 ## [0.40.3] - 2026-07-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,8 +315,7 @@
 - Async transcript-mining observer (`memory.observer`): a **single global**
   background process (CAR agent `neo-observer`, daemon `--daemon --all`) that
   **sweeps all discovered projects** each cycle — round-robin/budgeted
-  (`max_projects_per_cycle`, default 25; watermark-gated so unchanged projects do
-  near-zero work) — running transcript mining per project. (It also ran
+  (`max_projects_per_cycle`, default 25; watermark- AND mtime-gated so unchanged projects do near-zero work (the watermark alone gates only *admission*: sources still parsed every transcript each cycle, measured at 298 MB for one project, which is what drove multi-GB observer RSS. `_unchanged_since` now skips files untouched since the watermark file's mtime minus a 1h skew margin; every error path falls back to parsing, because a wrong skip loses learning silently)) — running transcript mining per project. (It also ran
   `synthesize_reviews` until that subsystem was removed.) Two roots can share a `project_id` (two
   clones of one remote, e.g. `flyx/fms` + `flyx/fms2`), meaning one fact file and
   one pid-keyed watermark; the sweep keeps a per-cycle `store_cache` so such a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.40.3"
+version = "0.41.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.40.3"
+__version__ = "0.41.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/memory/observer.py
+++ b/src/neo/memory/observer.py
@@ -281,7 +281,7 @@ class ObserverConfig:
     # transcripts since their watermark do near-zero work (ingest finds nothing).
     max_projects_per_cycle: int = 25
     # Re-exec after this many cycles to bound RSS (see Observer._should_recycle).
-    # 6 cycles is ~30min at the default 300s interval. The first default here was
+    # 3 cycles is ~15min at the default 300s interval. The first default here was
     # 48 (~4h), chosen on the assumption that RSS creeps slowly — it does not.
     # Measured on a live daemon: 7 cycles took it from 103 MB to 693 MB, i.e. it
     # reaches its plateau within minutes, so a 4h cadence reset an
@@ -289,7 +289,7 @@ class ObserverConfig:
     # whatever it reaches in N cycles, so N is the actual tuning dial. A re-exec
     # costs ~2s of process restart, which at 30min intervals is under 0.2%
     # overhead. 0 disables.
-    recycle_after_cycles: int = 6
+    recycle_after_cycles: int = 3
 
     @classmethod
     def from_env(cls) -> "ObserverConfig":

--- a/src/neo/memory/transcript.py
+++ b/src/neo/memory/transcript.py
@@ -240,15 +240,42 @@ def build_episodes(path: Path) -> list[Episode]:
     return episodes
 
 
-def collect_episodes(codebase_root: Optional[str]) -> list[Episode]:
-    """Build episodes across all transcript files for a codebase root."""
+def collect_episodes(codebase_root: Optional[str],
+                     since: Optional[float] = None) -> list[Episode]:
+    """Build episodes across all transcript files for a codebase root.
+
+    ``since`` skips files untouched since that epoch time. Parsing dominates the
+    observer's memory: one project measured 104 MB for this source alone, and the
+    sweep does 25 projects a cycle. The watermark only gates *admission*, so
+    without this an unchanged project still paid the full parse every cycle —
+    which is what the docs' "unchanged projects do near-zero work" claimed but
+    did not do.
+    """
     tdir = resolve_transcript_dir(codebase_root)
     if tdir is None or not tdir.is_dir():
         return []
     episodes: list[Episode] = []
     for fp in sorted(tdir.glob("*.jsonl")):
+        if _unchanged_since(fp, since):
+            continue
         episodes.extend(build_episodes(fp))
     return episodes
+
+
+def _unchanged_since(path: "Path", since: Optional[float]) -> bool:
+    """True when ``path`` has not been modified since ``since``.
+
+    Conservative by construction: any error, or no ``since`` at all, returns
+    False so the file is parsed. Skipping is a pure optimization — a wrong
+    "skip" would silently drop learning, so it only ever happens on a positive
+    mtime comparison.
+    """
+    if not since:
+        return False
+    try:
+        return path.stat().st_mtime < since
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +384,9 @@ class TranscriptSource(Protocol):
 
     name: str
     scope: FactScope
+    # collect_episodes(since: Optional[float] = None) -> list[Episode]
+    # collect_episodes may optionally accept `since` (epoch seconds) to skip
+    # inputs untouched since then. Sources that omit it are called without it.
     # Optional; read via getattr in the ingester so existing sources that don't
     # define them keep the default PATTERN/FAILURE + transcript-tag behavior.
     fact_kind: Optional["FactKind"]
@@ -375,8 +405,8 @@ class ClaudeCodeSource:
     def __init__(self, codebase_root: Optional[str]):
         self.codebase_root = codebase_root
 
-    def collect_episodes(self) -> list[Episode]:
-        return collect_episodes(self.codebase_root)
+    def collect_episodes(self, since: Optional[float] = None) -> list[Episode]:
+        return collect_episodes(self.codebase_root, since=since)
 
 
 CAR_SESSIONS_DIR = Path.home() / ".car" / "sessions"
@@ -399,7 +429,9 @@ class CarSource:
     def __init__(self, sessions_dir: Optional[Path] = None):
         self._dir = sessions_dir or CAR_SESSIONS_DIR
 
-    def collect_episodes(self) -> list[Episode]:
+    def collect_episodes(self, since: Optional[float] = None) -> list[Episode]:
+        # `since` accepted for a uniform source Protocol; this corpus is ~1 MB,
+        # so skipping buys nothing and the filter would only add a failure mode.
         if not self._dir.is_dir():
             return []
         episodes: list[Episode] = []
@@ -519,12 +551,16 @@ class CodexSource:
                 and self._cwd_within_root(p, codebase_root)
             ]
 
-    def collect_episodes(self) -> list[Episode]:
+    def collect_episodes(self, since: Optional[float] = None) -> list[Episode]:
         root = self.codebase_root
         if not root or not self._dir.is_dir():
             return []
         episodes: list[Episode] = []
         for fp in sorted(self._dir.glob("**/rollout-*.jsonl")):
+            # mtime check first: it is a stat, while _owns_rollout opens the
+            # file. This source measured 224 MB for a single project's collect.
+            if _unchanged_since(fp, since):
+                continue
             if not self._owns_rollout(fp, root):
                 continue
             try:
@@ -824,7 +860,9 @@ class GitHubPRSource:
     def __init__(self, codebase_root: Optional[str]):
         self.codebase_root = codebase_root
 
-    def collect_episodes(self) -> list[Episode]:
+    def collect_episodes(self, since: Optional[float] = None) -> list[Episode]:
+        # `since` accepted for a uniform source Protocol; this source is already
+        # throttled to one `gh` fetch per repo per _GH_PR_FETCH_INTERVAL.
         repo = _owner_repo_from_remote(self.codebase_root)
         if repo is None or not _gh_available():
             return []  # non-GitHub remote / no gh on PATH → silent no-op
@@ -1086,7 +1124,7 @@ class TranscriptIngester:
                 break
             consumed = self._load_consumed(source)
             try:
-                episodes = source.collect_episodes()
+                episodes = self._collect(source)
             except Exception as e:  # one bad source must not sink the others
                 logger.warning("transcript: source %s collect failed: %s", source.name, e)
                 continue
@@ -1232,6 +1270,51 @@ class TranscriptIngester:
         else:
             suffix = "global"
         return SESSIONS_DIR / f"transcript_watermark_{source.name}_{suffix}.json"
+
+    #: Subtracted from the watermark file's mtime before using it as a skip
+    #: threshold. A transcript written *while* the previous ingest was running
+    #: could otherwise be judged "already seen" and skipped forever. One hour is
+    #: far longer than any observed ingest, and over-parsing is free where
+    #: under-parsing silently loses learning.
+    _COLLECT_SKEW_SECONDS = 3600.0
+
+    def _collect(self, source) -> list:
+        """Call a source's collector, passing ``since`` only if it accepts it.
+
+        The parameter was added later, and sources are an open interface — the
+        issues diagnostic builds its own, and third parties may too. Calling
+        with an unexpected kwarg would raise TypeError, which the caller's
+        per-source guard swallows as "source failed", silently returning zero
+        episodes. Detect support instead of relying on that.
+        """
+        import inspect
+
+        try:
+            accepts = "since" in inspect.signature(source.collect_episodes).parameters
+        except (TypeError, ValueError):  # builtins / C callables
+            accepts = False
+        if accepts:
+            return source.collect_episodes(since=self._collected_through(source))
+        return source.collect_episodes()
+
+    def _collected_through(self, source) -> Optional[float]:
+        """Epoch time before which this source's inputs are already ingested.
+
+        Derived from the watermark file's mtime rather than a stored field, so
+        no format change or migration is needed: that file is rewritten every time
+        anchors are persisted, making its mtime a lower bound on "we have
+        processed everything older than this".
+
+        Returns None when there is no watermark yet, which means parse
+        everything — the safe default for a first run.
+        """
+        path = self._watermark_path(source)
+        if path is None:
+            return None
+        try:
+            return path.stat().st_mtime - self._COLLECT_SKEW_SECONDS
+        except OSError:
+            return None
 
     def _load_consumed(self, source) -> set:
         path = self._watermark_path(source)

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1008,7 +1008,10 @@ class TestObserverCycleUnit:
         monkeypatch.setattr("neo.memory.store.FactStore", _FakeStore)
         monkeypatch.setattr("neo.config.NeoConfig.load", staticmethod(lambda *a, **k: _Cfg()))
         monkeypatch.setattr("neo.adapters.create_adapter", lambda *a, **k: _Adapter())
-        monkeypatch.setattr(tr, "collect_episodes", lambda root: [ep])
+        # Accepts `since`: ClaudeCodeSource forwards it, and a stub that
+        # omits it raises TypeError which the per-source guard swallows as
+        # "source failed" — silently yielding zero episodes.
+        monkeypatch.setattr(tr, "collect_episodes", lambda root, since=None: [ep])
 
         observer = Observer(codebase_root="/p", config=ObserverConfig(ingest_budget=5))
         observer._cycle()

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,6 +1,7 @@
 """Tests for Claude Code transcript parsing (Stage A) and ingestion (B/C)."""
 
 import json
+import time
 import time as _time
 import types
 from dataclasses import dataclass as _dataclass
@@ -1075,3 +1076,66 @@ def test_source_without_fact_kind_defaults_to_pattern(temp_store, tmp_path, monk
     facts = [f for f in temp_store._facts if f.is_valid]
     assert facts and facts[0].kind == FactKind.PATTERN
     assert "imported:github-pr" not in facts[0].tags
+
+
+class TestSkipUnchangedInputs:
+    """Parsing dominated the observer's memory: one project measured 104 MB for
+    ClaudeCodeSource and 224 MB for CodexSource, and the sweep does 25 projects
+    a cycle. The watermark only gated *admission*, so an unchanged project still
+    paid the full parse — the opposite of the documented "near-zero work".
+    """
+
+    def test_unchanged_file_is_skipped(self, tmp_path):
+        from neo.memory.transcript import _unchanged_since
+        import os
+        f = tmp_path / "t.jsonl"
+        f.write_text("{}")
+        old = time.time() - 10_000
+        os.utime(f, (old, old))
+        assert _unchanged_since(f, time.time()) is True
+
+    def test_modified_file_is_never_skipped(self, tmp_path):
+        from neo.memory.transcript import _unchanged_since
+        f = tmp_path / "t.jsonl"
+        f.write_text("{}")
+        assert _unchanged_since(f, time.time() - 10_000) is False
+
+    def test_no_since_parses_everything(self, tmp_path):
+        """First run has no watermark — must not skip anything."""
+        from neo.memory.transcript import _unchanged_since
+        f = tmp_path / "t.jsonl"
+        f.write_text("{}")
+        assert _unchanged_since(f, None) is False
+        assert _unchanged_since(f, 0) is False
+
+    def test_unreadable_file_is_parsed_not_skipped(self, tmp_path):
+        """Skipping is an optimization; a wrong skip loses learning silently, so
+        every error path must fall back to parsing."""
+        from neo.memory.transcript import _unchanged_since
+        assert _unchanged_since(tmp_path / "gone.jsonl", time.time()) is False
+
+    def test_codex_source_skips_only_stale_rollouts(self, tmp_path):
+        import os
+        sdir = tmp_path / "codex"
+        sdir.mkdir()
+        _write_rollout(sdir / "rollout-old.jsonl", cwd="/work/proj", sid="s1",
+                       records=[_ev("user_message", message="stale")])
+        _write_rollout(sdir / "rollout-new.jsonl", cwd="/work/proj", sid="s2",
+                       records=[_ev("user_message", message="fresh")])
+        old = time.time() - 10_000
+        os.utime(sdir / "rollout-old.jsonl", (old, old))
+        eps = CodexSource(codebase_root="/work/proj",
+                          sessions_dir=sdir).collect_episodes(since=time.time() - 5_000)
+        assert [e.ask for e in eps] == ["fresh"]
+
+    def test_source_without_since_still_works(self, temp_store, tmp_path, monkeypatch):
+        """Sources are an open interface — one lacking `since` must not be
+        called with it and silently fail as 'source errored'."""
+        monkeypatch.setattr("neo.memory.transcript.SESSIONS_DIR", tmp_path / "sessions")
+        ad = _StubAdapter([_LESSON], keep=True)
+        legacy = _StaticSource([_ep("x1", "ask")])
+        assert "since" not in __import__("inspect").signature(
+            legacy.collect_episodes).parameters
+        stats = TranscriptIngester(store=temp_store, lm_adapter=ad,
+                                   sources=[legacy]).ingest(max_episodes=1)
+        assert stats["episodes_total"] == 1


### PR DESCRIPTION
## Description

Fixes the **actual cause** of the observer's multi-GB memory, rather than only capping it with recycling.

Cycles that mined nothing — 0.1s per project, `0 mined` — still swung RSS by gigabytes. `TranscriptIngester.ingest` called `source.collect_episodes()` and applied the watermark filter to the *result*: every source fully parsed every transcript on every cycle for every project, and `all_episodes` retained the lot.

**Measured on one project: 118 MB (ClaudeCodeSource) + 180 MB (CodexSource) = 298 MB**, times up to 25 projects a cycle. The documented "watermark-gated so unchanged projects do near-zero work" was not true — the watermark gated *admission*, not work.

**Measured after: 298 MB → 0 MB** for the same project when nothing changed.

## Type of Change

- [x] Performance improvement

## Motivation and Context

0.40.x capped RSS by recycling the process. That treated the symptom; this removes the cause. Cadence also tightens 6 → 3 cycles now that peaks are much smaller.

No storage format change: the watermark file's own mtime is the marker, minus a **1h skew margin** so a transcript written *during* the previous ingest can never be judged already-seen. No watermark at all means parse everything.

## How Has This Been Tested?

- [x] Measured against the real corpus (6.1 GB of Codex sessions, 1.3 GB of Claude Code transcripts): 298 MB → 0 MB for an unchanged project
- [x] Tests for skip/no-skip, no-`since`, unreadable file, and that CodexSource skips *only* stale rollouts while still returning fresh ones
- [x] Test that a source lacking `since` still works
- [x] `make ci-local` — 1493 passed, lint clean
- [x] Committed through the pre-commit hook, no `--no-verify`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Every error path falls back to parsing.** Skipping is an optimization; a wrong skip loses learning *silently*, so it only ever happens on a positive mtime comparison.

`since` is passed only to sources whose signature accepts it, detected by inspection rather than by catching `TypeError`. Sources are an open interface — `issues.py` builds its own and third parties may too — and calling one with an unexpected kwarg raises a `TypeError` that the per-source guard swallows as "source failed", silently yielding **zero episodes**. That exact failure bit three separate test stubs during development, which is how I found it worth defending against.