### PR TITLE
docs: audit the documentation for correctness, and close the two CLI gaps it found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,13 @@
     (vs 7/14); promoted automatically on access_count ≥2 or success_count >0.
   - Independent-outcome facts capped at 5/session (`MAX_INDEPENDENT_OUTCOMES` in
     `outcomes.py`) and 50/project (`MAX_INDEPENDENT_FACTS` in `store.py`).
-  - `prune_stale_facts` → `demote_unhelpful_facts` → `purge_dead_facts` run on every
-    cold start (`store.py:190-192`). For on-demand compaction of tombstone bloat in a
-    specific project's fact file, use `neo memory prune [--all] [--dry-run]`
-    (`subcommands.py:_compact_fact_file`).
+  - `prune_stale_facts` → `demote_unhelpful_facts` → `purge_dead_facts` →
+    `strip_tombstone_embeddings` run on every cold start, each with `save=False` so
+    the chain flushes one merge-on-save instead of four. `_invalidate` already strips
+    a tombstone's embedding and bulk text at the transition, so the final step is a
+    backfill for tombstones minted off that path. For on-demand compaction of
+    tombstone bloat in a specific project's fact file, use
+    `neo memory prune [--all] [--dry-run]` (`subcommands.py:_compact_fact_file`).
   - Diagnostics (read-only, flag-and-propose): `neo memory issues [--since 14d]
     [--min-cluster 3] [--suggest-rules] [--json]` surfaces recurring frictions mined from
     transcript history (Claude Code / Codex / CAR) as ranked, evidence-cited issues
@@ -67,7 +70,7 @@
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the
   suggested vocabulary, but any string is valid. `retrieve_relevant(..., domain=...)`
   filters by exact match; `domain=None` returns all facts including unset ones.
-- Outcomes (`memory.outcomes` + `store.detect_implicit_feedback`, ~`store.py:806-900`):
+- Outcomes (`memory.outcomes` + `store.detect_implicit_feedback`):
   ACCEPTED/MODIFIED act on a linked legacy fact with confidence +0.2 / −0.2
   (±arch_mod); ACCEPTED bumps `success_count`. New suggestions remain episode-local
   candidates until independently accepted twice; deterministic verification failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,13 @@
   - Per-scope valid-fact caps (`SCOPE_LIMITS` in `store.py`): global=200, org=100,
     project=500, session=50. Enforced per loaded scope set (project+org+global);
     invalidated facts persist as tombstones until `purge_dead_facts` runs.
-  - Supersession at cosine ≥ 0.85 (`SUPERSESSION_THRESHOLD`, `store.py:3017`);
+  - Supersession at cosine ≥ 0.85 (`SUPERSESSION_THRESHOLD`, `store.py:59`);
     pre-write dedup is canonical-signature **equality**, not cosine
-    (`memory.generalize`). `SYNTHESIS_SIMILARITY` is a *separate* constant that
-    happens to equal 0.85 and is used only by REVIEW clustering
-    (`store.py:3381`) — the two can be tuned independently.
+    (`memory.generalize`). `SYNTHESIS_SIMILARITY` was a *separate* constant that
+    happened to equal 0.85 and gated REVIEW clustering; it went away with
+    `synthesize_reviews` (see below). The only 0.85 left in `store.py` is
+    supersession. `memory.issues` keeps its own `CLUSTER_SIMILARITY = 0.85`,
+    tunable independently.
   - Episode-derived promotion correlation (`store._episode_signature` /
     `_global_signature`): a candidate promotes to a durable fact only when ≥2
     independent verified-accepted episodes share a **correlation signature**. That
@@ -181,7 +183,7 @@
     (`--regenerate-embeddings` targets the legacy ReasoningMemory cache), so the
     strip is one-way in practice.
   - `prune_stale_facts` → `demote_unhelpful_facts` → `purge_dead_facts` →
-    `strip_tombstone_embeddings` run on every cold start (`store.py:190-192`),
+    `strip_tombstone_embeddings` run on every cold start (in `FactStore.initialize`),
     each taking `save=False` so the chain flushes **one** merge-on-save instead
     of four. `strip_tombstone_embeddings` is now a **backfill** — it only catches
     tombstones minted off the `_invalidate` path (an ingester superseding a fact;
@@ -236,7 +238,7 @@
       touches the `transcript_watermark_*` watermark — decoupled from fact admission and
       idempotent (`find_issues`). Gate mirrors the old synthesis discipline (≥`min_cluster`
       members, ≥2 sessions, ≥2 frictional, verbatim evidence); clusters at
-      `SYNTHESIS_SIMILARITY` via the shared `math_utils.cluster_by_similarity`. See
+      `issues.CLUSTER_SIMILARITY` via the shared `math_utils.cluster_by_similarity`. See
       `docs/solutions/conversation-mined-issues.md` and `docs/solutions/rule-file-sync.md`.
 - Transcript sources (`memory.transcript`, the `TranscriptSource` Protocol): the
   `TranscriptIngester` mines lessons from four sources by default —
@@ -264,13 +266,18 @@
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the
   suggested vocabulary, but any string is valid. `retrieve_relevant(..., domain=...)`
   filters by exact match; `domain=None` returns all facts including unset ones.
-- Outcomes (`memory.outcomes` + `store.detect_implicit_feedback`, ~`store.py:806-900`):
-  ACCEPTED/MODIFIED/UNVERIFIED act on the linked original fact when present —
-  confidence +0.2 / −0.2 / +0.1 (all ±arch_mod), and bump `success_count` (except
-  MODIFIED). MODIFIED also writes a REVIEW at confidence 0.4; ACCEPTED falls back to a
-  REVIEW (`suggestion_confidence + 0.1`) when no link is found; UNVERIFIED never creates
-  a REVIEW. INDEPENDENT writes a REVIEW at confidence 0.2. **Footgun**: if you add a new
-  `OutcomeType`, update both `outcomes.py` and `store.detect_implicit_feedback`.
+- Outcomes (`memory.outcomes` + `store.detect_implicit_feedback`):
+  ACCEPTED/MODIFIED act on the linked original fact when present — confidence
+  +0.2 / −0.2 (both ±arch_mod); ACCEPTED also bumps `success_count` and sets
+  effectiveness "better", MODIFIED sets "worse". **UNVERIFIED mutates nothing**:
+  absence of verification is not success, so the evidence is preserved in the
+  learning episode (candidate status → `unverified`) and neither confidence nor
+  `success_count` moves — the live path and `replay_linked_feedback` share that
+  invariant (`store.py:2148`, `store.py:2301`). MODIFIED also writes a REVIEW at
+  confidence 0.4; ACCEPTED falls back to a REVIEW (`suggestion_confidence + 0.1`)
+  when no link is found; UNVERIFIED never creates a REVIEW. INDEPENDENT writes a
+  REVIEW at confidence 0.2. **Footgun**: if you add a new `OutcomeType`, update
+  both `outcomes.py` and `store.detect_implicit_feedback`.
 - Retrieval: `rank_score = recall_decay(sim)·confidence + success_bonus·effectiveness_f
   + provenance_bonus`. `memory.models.rank_score` is the single source of truth — if you
   change the formula, audit `ContextAssembler._score_facts` too. Cosine is batched via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,23 +34,6 @@ local linter and CI's disagree — which is exactly how a green local tree turne
 `main` red during 0.39.0. Bump the pin deliberately, in its own commit, with the
 lint delta reviewed.
 
-### Releasing
-
-Publishing is automated: creating a GitHub **Release** triggers `publish.yml`,
-which builds and uploads to PyPI via Trusted Publishers (OIDC — no token lives
-in the repo). The sequence is push → tag → release; do not run `twine` locally.
-
-Two things to know before you rely on it:
-
-- **TestPyPI is not configured.** `publish-testpypi` only runs on a manual
-  `workflow_dispatch`, and it currently fails at the publish step because no
-  Trusted Publisher exists for this repo on TestPyPI. The `build` job and the
-  artifact upload/download round-trip still execute, so dispatching is a valid
-  smoke test for a workflow change — just expect the final step to fail until
-  someone configures it at <https://test.pypi.org/manage/account/publishing/>.
-- **A version can never be replaced on PyPI**, only yanked. Verify CI is green
-  on the exact commit you are tagging, not merely on the branch.
-
 ### 3a. Enable the pre-commit hook
 
 ```bash
@@ -118,6 +101,23 @@ ruff check src/ tests/
 mypy src/
 ```
 
+## Releasing
+
+Publishing is automated: creating a GitHub **Release** triggers `publish.yml`,
+which builds and uploads to PyPI via Trusted Publishers (OIDC — no token lives
+in the repo). The sequence is push → tag → release; do not run `twine` locally.
+
+Two things to know before you rely on it:
+
+- **TestPyPI is not configured.** `publish-testpypi` only runs on a manual
+  `workflow_dispatch`, and it currently fails at the publish step because no
+  Trusted Publisher exists for this repo on TestPyPI. The `build` job and the
+  artifact upload/download round-trip still execute, so dispatching is a valid
+  smoke test for a workflow change — just expect the final step to fail until
+  someone configures it at <https://test.pypi.org/manage/account/publishing/>.
+- **A version can never be replaced on PyPI**, only yanked. Verify CI is green
+  on the exact commit you are tagging, not merely on the branch.
+
 ## Project Structure
 
 ```
@@ -131,7 +131,7 @@ neo/
 │       ├── engine.py               # MapCoder/CodeSim orchestration
 │       ├── memory/                 # Fact-based memory system
 │       │   ├── models.py           #   Fact, FactKind, FactScope, rank_score
-│       │   ├── store.py            #   FactStore + supersession + synthesis
+│       │   ├── store.py            #   FactStore + supersession + evidence promotion
 │       │   ├── context.py          #   Four-layer context assembly (memgine-ported)
 │       │   ├── outcomes.py         #   Feedback-loop classification
 │       │   ├── bm25.py             #   Sparse channel for hybrid retrieval
@@ -263,8 +263,9 @@ No framework-specific code, focus on generic approach.
 #### Contribution Process
 
 1. **Choose a Domain**:
-   - Existing: `rate-limiting`, `caching`, `resilience`, `observability`
-   - Propose new domain via GitHub issue
+   - Existing (have patterns today): `rate-limiting`, `caching`
+   - Approved but still empty: `resilience`, `observability` — first pattern welcome
+   - Propose a new domain via GitHub issue
 
 2. **Write the Pattern**:
    - Use template above
@@ -352,7 +353,7 @@ See existing patterns for reference:
 - Update `README.md` for user-facing changes
 - Update `QUICKSTART.md` if the 5-minute setup flow changes
 - Update `INSTALL.md` for setup changes (extras, dependencies, integration surfaces)
-- Update `CLAUDE.md` and `AGENTS.md` together — they are kept identical so Claude Code and AGENTS.md-spec tools (Codex, etc.) see the same project rules
+- Update `CLAUDE.md` and `AGENTS.md` together. `CLAUDE.md` is the long-form source of truth; `AGENTS.md` is a **condensed** mirror for AGENTS.md-spec tools (Codex, etc.). They are not byte-identical, but they must never contradict each other — `neo memory rules` flags exactly that kind of drift
 - When touching plugin sources, update the relevant plugin manifest and keep the **Claude Code** (`.claude-plugin/`) and **Codex** (`plugins/neo/`) surfaces in sync — the same six commands are exposed on both
 - When touching CAR (`src/neo/car_*.py`), document any schema or behavior change in the README's "Run as an Agent (CAR / A2A)" section
 - Add docstrings to new functions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,40 @@
 
 ## Quick Install
 
-### Recommended: Development Mode
+### Recommended: From PyPI
+
+```bash
+# Isolated install (recommended for end users)
+pipx install neo-reasoner
+
+# Or into the current environment
+pip install neo-reasoner
+
+# Verify installation
+neo --version
+```
+
+The base install is runnable as soon as you set `OPENAI_API_KEY` — OpenAI is the
+default provider and its SDK is a core dependency. To add another provider up
+front:
+
+```bash
+pip install neo-reasoner[anthropic]  # Claude
+pip install neo-reasoner[google]     # Gemini
+pip install neo-reasoner[ollama]     # Ollama HTTP client
+pip install neo-reasoner[all]        # All LM providers
+pip install neo-reasoner[car]        # Common Agent Runtime (neo serve, observer)
+```
+
+Updating:
+
+```bash
+neo update                  # built-in updater
+pip install --upgrade neo-reasoner
+pipx upgrade neo-reasoner
+```
+
+### Development Mode (From Source)
 
 ```bash
 # Clone repository
@@ -20,7 +53,7 @@ This automatically installs:
 - Core dependencies (numpy, scikit-learn, datasketch, fastembed, faiss-cpu, jsonschema, pyyaml, tree-sitter)
 - Neo CLI command (`neo`)
 
-### Alternative: Using pyproject.toml
+### Extras (From Source)
 
 ```bash
 # Install with specific extras
@@ -151,11 +184,16 @@ neo --version
 # Should output something like:
 # "What is real? How do you define 'real'?"
 #
-# neo 0.18.1
+# neo 0.41.0
 # Provider: openai | Model: gpt-5.6
+# Storage: FactStore (path: /Users/you/.neo/facts)
+# CAR: not found
 # Stage: Sleeper | Memory: 0.0%
-# 0 facts | 0.00 avg confidence
+# 0 patterns | 0.00 avg confidence
 ```
+
+The `CAR:` line reports whatever local CAR runtime is detected — `not found` is
+the expected value unless you installed the `[car]` extra.
 
 ### Test Core Functionality
 
@@ -258,12 +296,14 @@ export PATH="${PATH}:$(pwd)"
 ### API Key Not Found
 
 ```bash
-# Verify environment variable is set
-echo $ANTHROPIC_API_KEY
+# Verify environment variable is set (OPENAI_API_KEY is the default provider's)
+echo $OPENAI_API_KEY
 
 # Or set it now
-export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
 ```
+
+Use `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` instead if you switched `provider`.
 
 ### sklearn/numpy Issues
 
@@ -331,12 +371,12 @@ If you previously installed Neo using requirements.txt:
 # Uninstall old version
 pip uninstall neo-reasoner
 
-# Remove old dependencies (optional)
-pip freeze | grep -v "^-e" | xargs pip uninstall -y
-
-# Install fresh using new method
+# Install fresh using the current method
 pip install -e .
 ```
+
+To be sure no stale dependency pins linger, do this in a fresh virtualenv rather
+than mass-uninstalling packages from a shared environment.
 
 ## Upgrading
 
@@ -360,8 +400,8 @@ pip uninstall neo-reasoner
 
 # Remove environment variables
 # Edit ~/.bashrc or ~/.zshrc and remove:
-# - ANTHROPIC_API_KEY
-# - etc.
+# - OPENAI_API_KEY (or ANTHROPIC_API_KEY / GOOGLE_API_KEY)
+# - any NEO_* overrides
 
 # Optional: Remove local data (facts, config, indexes)
 rm -rf ~/.neo
@@ -386,7 +426,7 @@ CMD ["neo", "--version"]
 docker build -t neo .
 
 # Run Neo
-docker run -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY neo "your prompt"
+docker run -e OPENAI_API_KEY=$OPENAI_API_KEY neo "your prompt"
 ```
 
 ## Next Steps
@@ -402,7 +442,7 @@ After installation:
 ## Getting Help
 
 - **Installation Issues**: Check this guide's Troubleshooting section
-- **API Key Problems**: Verify environment variables with `echo $ANTHROPIC_API_KEY`
+- **API Key Problems**: Verify environment variables with `echo $OPENAI_API_KEY`
 - **Dependencies**: Run `pip list | grep neo` to see installed packages
 - **GitHub Issues**: Report bugs at https://github.com/Parslee-ai/neo/issues
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,16 +27,23 @@ Add to `~/.bashrc` or `~/.zshrc` for persistence.
 neo --version
 ```
 
-Expected output:
+Expected output on a fresh install (the version number tracks the release you
+installed):
 ```
 "What is real? How do you define 'real'?"
 
-neo 0.18.1
+neo 0.41.0
 Provider: openai | Model: gpt-5.6
+Storage: FactStore (path: /Users/you/.neo/facts)
+CAR: not found
 Stage: Sleeper | Memory: 0.0%
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-0 facts | 0.00 avg confidence
+0 patterns | 0.00 avg confidence
 ```
+
+The first run downloads the Jina embedding model (~400 MB) into
+`~/.cache/neo/fastembed`, so expect it to take a minute. Subsequent runs reuse
+the cache.
 
 ## 4. Try a Simple Query
 
@@ -157,10 +164,13 @@ neo --config set --config-key model --config-value gemini-2.0-flash
 
 ### Local (Ollama)
 ```bash
-pip install neo-reasoner
+pip install neo-reasoner[ollama]
 ollama serve
 neo --config set --config-key provider --config-value ollama
 neo --config set --config-key base_url --config-value http://localhost:11434
+neo --config set --config-key model --config-value llama3   # default is llama2
 ```
+
+No API key needed — Ollama is reached over HTTP on the `base_url` above.
 
 That's it! You're ready to use Neo.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Neo is **_the missing context layer_** for AI Code Assistants. It retrieves rele
 
 - [Design Philosophy](#design-philosophy)
 - [How It Works](#how-it-works)
+- [The Construct](#the-construct)
 - [Quick Start](#quick-start)
 - [Run as an Agent (CAR / A2A)](#run-as-an-agent-car--a2a)
 - [Claude Code Plugin](#claude-code-plugin)
@@ -39,21 +40,35 @@ Neo is **_the missing context layer_** for AI Code Assistants. It retrieves rele
 - [Works Alongside Your AI Tools](#works-alongside-your-ai-tools)
 - [Installation](#installation)
   - [From PyPI (Recommended)](#from-pypi-recommended)
+  - [Updating Neo](#updating-neo)
   - [From Source (Development)](#from-source-development)
   - [Dependencies](#dependencies)
-  - [Optional: LM Provider](#optional-lm-provider)
+  - [Optional: Additional LM Providers](#optional-additional-lm-providers)
 - [Usage](#usage)
   - [CLI Interface](#cli-interface)
+  - [Command Reference](#command-reference)
+  - [Operating Modes](#operating-modes)
+  - [Goal-aware agent-loop envelope](#goal-aware-agent-loop-envelope)
+  - [Memory Maintenance](#memory-maintenance)
+  - [Background Observer](#background-observer)
+  - [Memory Diagnostics](#memory-diagnostics)
   - [Timeout Requirements](#timeout-requirements)
   - [Output Format](#output-format)
   - [Personality System](#personality-system)
+  - [Load Program — Training Neo's Memory](#load-program---training-neos-memory)
 - [Architecture](#architecture)
   - [Fact-Based Memory](#fact-based-memory)
   - [Output Schemas](#output-schemas)
+  - [Code Smell Detection in Context Assembly](#code-smell-detection-in-context-assembly)
+  - [Smart File Selection](#smart-file-selection)
+  - [Learning Feedback Loop](#learning-feedback-loop)
   - [Storage Architecture](#storage-architecture)
 - [Performance](#performance)
+  - [Memory-Driven Reasoning Effort](#memory-driven-reasoning-effort-gpt-5-models)
+  - [Architectural Quality Feedback Loop](#architectural-quality-feedback-loop)
 - [Configuration](#configuration)
   - [CLI Configuration Management](#cli-configuration-management)
+  - [Secure API Key Storage](#secure-api-key-storage)
   - [Environment Variables](#environment-variables)
 - [LM Adapters](#lm-adapters)
   - [OpenAI (Default)](#openai-default)
@@ -104,6 +119,44 @@ applies learned patterns, generates solutions, and stores new facts for continuo
     This model runs locally on your machine to generate vector embeddings.
 
 
+
+2. When you ask Neo for help:
+    - Your query is embedded locally using the Jina model
+    - Neo searches the fact store for relevant knowledge (using cosine similarity)
+    - Retrieved facts are organized into layers: constraints, relevant knowledge, recent changes, known unknowns
+    - This combined context is sent to your chosen LLM API (OpenAI/Anthropic/Google)
+    - The LLM generates a solution informed by both your query and past facts
+    - The result is stored back as a new fact in local memory for future use
+
+Local storage:
+  ~/.neo/facts/facts_global.json       ← Global-scoped facts
+  ~/.neo/facts/facts_org_{id}.json     ← Organization-scoped facts
+  ~/.neo/facts/facts_project_{id}.json ← Project-scoped facts
+
+Privacy:
+  - Your code never leaves your machine during embedding/search
+  - Only your prompt + retrieved facts are sent to the LLM API
+  - This is the same as using the LLM directly, but with added context from something akin to memory.
+
+ ```
+   Your Prompt
+      ↓
+  Local Jina Embedding (768-dim vector)
+      ↓
+  Cosine Similarity Search (finds relevant facts)
+      ↓
+  Retrieve Facts from ~/.neo/facts/
+      ↓
+  Assemble Context: Constraints → Knowledge → Recent Changes → Known Unknowns
+      ↓
+  →→→ NETWORK CALL →→→ LLM API (OpenAI/Anthropic/etc.)
+      ↓
+  Solution Generated
+      ↓
+  Store as New Fact in Local Memory
+ ```
+
+
 ## The Construct
 
 Neo includes **The Construct** - a curated library of architecture and design patterns with semantic search capabilities. Think of it as your personal reference library for common engineering patterns, indexed and searchable using the same embedding technology that powers Neo's reasoning memory.
@@ -151,41 +204,7 @@ All patterns must:
 
 See `/construct/README.md` for contribution guidelines.
 
-2. When you ask Neo for help:
-    - Your query is embedded locally using the Jina model
-    - Neo searches the fact store for relevant knowledge (using cosine similarity)
-    - Retrieved facts are organized into layers: constraints, relevant knowledge, recent changes, known unknowns
-    - This combined context is sent to your chosen LLM API (OpenAI/Anthropic/Google)
-    - The LLM generates a solution informed by both your query and past facts
-    - The result is stored back as a new fact in local memory for future use
 
-Local storage:
-  ~/.neo/facts/facts_global.json       ← Global-scoped facts
-  ~/.neo/facts/facts_org_{id}.json     ← Organization-scoped facts
-  ~/.neo/facts/facts_project_{id}.json ← Project-scoped facts
-
-Privacy:
-  - Your code never leaves your machine during embedding/search
-  - Only your prompt + retrieved facts are sent to the LLM API
-  - This is the same as using the LLM directly, but with added context from something akin to memory.
-
- ```
-   Your Prompt
-      ↓
-  Local Jina Embedding (768-dim vector)
-      ↓
-  Cosine Similarity Search (finds relevant facts)
-      ↓
-  Retrieve Facts from ~/.neo/facts/
-      ↓
-  Assemble Context: Constraints → Knowledge → Recent Changes → Known Unknowns
-      ↓
-  →→→ NETWORK CALL →→→ LLM API (OpenAI/Anthropic/etc.)
-      ↓
-  Solution Generated
-      ↓
-  Store as New Fact in Local Memory
- ```
 
 ## Quick Start
 
@@ -243,17 +262,43 @@ neo serve
 
 ### Outbound: use CAR as Neo's inference layer
 
+Outbound routing is controlled by the `inference_mode` config field, **not** by
+`provider`:
+
+| `inference_mode` | Behavior |
+|------------------|----------|
+| `static` (default) | Always use the configured `provider` / `model`. CAR is never called. |
+| `auto`             | Use CAR's adaptive router when `car-runtime` is importable **and** the daemon is reachable; fall back to the static provider on absence or runtime failure. |
+
+The default is `static` until a CAR release verifies the router's quality
+behavior (see the known limitation below). Opt in persistently or per-shell:
+
 ```bash
-# Switch Neo's default provider
+# Persistently: prefer CAR's router, fall back to the static provider
+neo --config set --config-key inference_mode --config-value auto
+
+# Or per-invocation / per-shell
+export NEO_INFERENCE_MODE=auto
+```
+
+To pin CAR as the **only** backend (no static fallback), set the provider
+itself. Clear `model` so CAR's router chooses per call, or set it to pin one
+backend:
+
+```bash
 neo --config set --config-key provider --config-value car
 
-# Let CAR's adaptive router pick the backend per call (recommended)
+# Let the router pick per call (an empty value clears the field)
 neo --config set --config-key model --config-value ""
 
-# Or pin a specific model — local or remote
+# Or pin a specific backend — local or remote
 neo --config set --config-key model --config-value qwen3-32b
-neo --config set --config-key model --config-value gpt-5
 ```
+
+Environment overrides work the same way: `NEO_PROVIDER=car`, `NEO_MODEL=...`.
+Note that with `provider=car`, whatever `model` holds is passed straight to CAR
+as a pin — leaving it at the default `gpt-5.6` pins that model rather than
+letting the router choose, which is why clearing it matters.
 
 The CAR daemon must be running (`car-server` / `python -m car_runtime.server`). From Python:
 
@@ -455,10 +500,10 @@ When enabled, Neo will:
 ```bash
 $ neo "your query"
 
-⚡ Auto-installing neo update: 0.18.0 → 0.18.1
+⚡ Auto-installing neo update: 0.40.0 → 0.41.0
    This happens in the background. Please wait...
 
-✓ Auto-update completed: 0.18.1
+✓ Auto-update completed: 0.41.0
    Restart neo to use the new version.
 
 [Neo] Processing your query...
@@ -545,6 +590,49 @@ neo --version
 # Inspect detected local CAR runtime surfaces
 neo car status
 ```
+
+### Command Reference
+
+Neo is one binary with a plain-text prompt plus a handful of subcommands. Run
+`neo --help` for the flag list.
+
+**Subcommands**
+
+| Command | Purpose |
+|---------|---------|
+| `neo "<prompt>"` | Reason about a prompt in the current repo (the default path) |
+| `neo memory <action>` | Memory maintenance, diagnostics, and the background observer — see [Memory Maintenance](#memory-maintenance) |
+| `neo construct <action>` | The Construct pattern library: `list`, `show`, `search`, `index` |
+| `neo car status` | Report detected CAR CLI / server / Python bindings / daemon |
+| `neo serve` | Host Neo as an A2A endpoint (`--a2a-bind`, `--public-url`, `--agent-name`) |
+| `neo prompt <action>` | Prompt-effectiveness tooling: `analyze`, `enhance`, `patterns`, `suggest`, `history`, `stats` |
+| `neo contribute` | Export high-confidence patterns for community contribution |
+| `neo update` | Update the installed `neo` package in place |
+
+**Global flags**
+
+| Flag | Purpose |
+|------|---------|
+| `--cwd PATH` | Working-directory override (which repo Neo reasons about) |
+| `--mode {advise,patch,verify,learn,agent}` | Operating mode; default `learn` — see [Operating Modes](#operating-modes) |
+| `--fast` / `--deep` | Force the single-call path / force multi-agent deliberation (default is `auto`, which gates on novelty + CAR availability) |
+| `--dry-run` | Assemble and print the full context, then exit without an LLM call |
+| `--json` | Emit JSONL progress events plus a final JSON object (also the JSON *input* path) |
+| `--output-schema NAME_OR_PATH` | Constrain the shape of the final JSON response |
+| `--index` / `--update` / `--languages CSV` | Build, incrementally refresh, and scope the per-project semantic index |
+| `--semantic` | Use the semantic index for file selection (requires `.neo/index.json`) |
+| `--max-bytes N` | Hard cap on total context bytes (default 300000) |
+| `--max-files N` | Cap on files: context gathering (default 30), or the index build when passed with `--index` (default 100) |
+| `--include GLOB` / `--exclude GLOB` | Allow/block file patterns; both repeatable |
+| `--exts CSV` | Restrict context to these file extensions |
+| `--diff-since REV` | Prioritize files changed since a git rev or duration |
+| `--no-git` / `--no-scan` | Skip git heuristics / skip the directory scan entirely |
+| `--stdin-json` / `--stdin-text` | Force the stdin input mode instead of auto-detecting |
+| `--verbose` / `--debug` | INFO / DEBUG logging to stderr |
+| `--allow-write-path GLOB` / `--allow-command CMD` | `agent`-mode authority grants (repeatable) |
+| `--config {list,get,set,reset}` | Configuration management — see [Configuration](#configuration) |
+| `--load-program DATASET_ID` | Import a HuggingFace dataset into memory — see [Load Program](#load-program---training-neos-memory) |
+| `--regenerate-embeddings` | Rebuild legacy `ReasoningMemory` embeddings with the current model (automatic backup) |
 
 ### Operating Modes
 
@@ -640,6 +728,92 @@ quality, harmful-memory, unsupported-promotion, repeat-error, isolation, latency
 model-call, and token metrics, and exits nonzero if any safety scenario or threshold
 fails. See [the evaluation contract](docs/solutions/evidence-learning-evaluation.md).
 
+**Is it actually learning?** Two read-only commands answer that without an LM
+call — one for the retrieve side, one for the promote side:
+
+```bash
+# Retrieval side: were retrieved facts actually used, and which detector earned the credit?
+neo memory citation-stats --since 7d
+
+# Promotion side: episodes, outcomes, candidate statuses, promotions/rollbacks
+neo memory learning-stats --since 7d
+```
+
+`citation-stats` summarizes the `citation_survival` metric from
+`~/.neo/metrics.jsonl` (retrieved / included / used, split by
+`by_marker` / `by_self_report` / `by_overlap`). `learning-stats` reads the
+episode ledger in `~/.neo/episodes`. Both take `--json`. Note that
+`learning-stats` covers only the **interactive, attributed** path: an `IDLE`
+reading means suggestions aren't being accepted downstream, not that Neo has
+stopped learning — the background observer mints facts with no episode
+footprint.
+
+```bash
+# Re-run implicit-feedback processing over linked session outcomes
+neo memory replay-feedback              # current project
+neo memory replay-feedback --all        # every local project Neo has touched
+neo memory replay-feedback --dry-run    # report what would change, mutate nothing
+```
+
+Use `replay-feedback` after a memory-loop fix, to re-apply confidence and
+`success_count` updates from already-recorded ACCEPTED / MODIFIED / UNVERIFIED
+outcomes. It only touches linked, non-independent outcomes.
+`--include-legacy-fallback` also inspects legacy `session_*.json` files (which
+may re-replay already-processed sessions); `--limit N` bounds `--all`.
+
+### Background Observer
+
+Transcript mining runs out-of-band in a single global background process
+supervised by CAR, so it never sits on the request path. It sweeps every
+discovered project each cycle, mining lessons from Claude Code, Codex, and CAR
+transcripts plus merged GitHub PRs.
+
+```bash
+neo memory observer status   # CAR-reported state + orphaned-process check
+neo memory observer start
+neo memory observer stop
+neo memory observer kick     # force a cycle now (maps to CAR agents_restart)
+```
+
+It **autostarts** whenever `car-server` is reachable — opt out with
+`NEO_OBSERVER_AUTOSTART=0`. With no CAR present it prints a one-time hint and
+stays silent. Requires the `[car]` extra and a running `car-server`
+(car-runtime ≥ 0.18.0). Logs land in
+`~/.car/logs/neo-observer.{stdout,stderr}.log`. Tunables:
+`NEO_OBSERVER_INTERVAL_SECONDS` (default 300), `NEO_OBSERVER_COOLDOWN`
+(default 60), `NEO_OBSERVER_RECYCLE_CYCLES` (default 48 — the daemon re-execs
+itself to bound RSS drift; 0 disables). See
+[the observer design note](docs/solutions/async-observer.md).
+
+### Memory Diagnostics
+
+Read-only, flag-and-propose commands that inspect your rules and your other
+tools' memory rather than Neo's own facts:
+
+```bash
+# Recurring frictions mined from transcript history, as ranked evidence-cited issues
+neo memory issues --since 14d --min-cluster 3
+neo memory issues --suggest-rules          # adds a bounded LM call per issue
+
+# Drift between AGENTS.md / CLAUDE.md / GEMINI.md (gaps + LM-judged conflicts)
+neo memory rules
+neo memory rules --no-conflicts            # skip the LM conflict pass
+
+# Malformed entries, near-duplicates, conflicts, and index drift in Claude Code's memory/*.md
+neo memory audit
+
+# Ingest a peer tool's memory files into Neo as REVIEW facts on probation
+neo memory import --dry-run
+```
+
+All four take `--json` (except `import`, which takes `--dry-run` and
+`--confidence`). `issues` reuses the ingester's transcript episodes but never
+admits facts or moves the ingest watermark, so it is idempotent and decoupled
+from fact admission. See
+[conversation-mined issues](docs/solutions/conversation-mined-issues.md),
+[rule-file sync](docs/solutions/rule-file-sync.md), and
+[memory audit](docs/solutions/memory-audit.md).
+
 
 ### Timeout Requirements
 
@@ -671,15 +845,38 @@ def solution():
 
 Neo responds with personality _(Matrix-inspired quotes)_ when displaying version info:
 
+On a fresh install:
+
 ```bash
 $ neo --version
 "What is real? How do you define 'real'?"
 
-neo 0.18.1
+neo 0.41.0
 Provider: openai | Model: gpt-5.6
+Storage: FactStore (path: /Users/you/.neo/facts)
+CAR: not found
 Stage: Sleeper | Memory: 0.0%
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-0 facts | 0.00 avg confidence
+0 patterns | 0.00 avg confidence
+```
+
+Once memory has built up, the quote, the stage (`Sleeper` → `Glitch` →
+`Unplugged` → `Training` → `The One`), and the bar all move, and a line about
+patterns approaching community contribution appears:
+
+```bash
+$ neo --version
+"I can see it now. The code is showing me."
+
+neo 0.41.0
+Provider: openai | Model: gpt-5.6
+Storage: FactStore (path: /Users/you/.neo/facts)
+CAR: python binding car_runtime | daemon running
+Stage: Unplugged | Memory: 49.7%
+███████████████████░░░░░░░░░░░░░░░░░░░░░
+521 patterns | 0.64 avg confidence
+
+⚡ 6 pattern(s) approaching contribution (need 0.8 confidence + 3 successes)
 ```
 
 ### Load Program - Training Neo's Memory
@@ -746,9 +943,9 @@ Neo uses a **scoped, supersession-based fact store** with **Jina Code v2** embed
 1. **Typed Facts**: Eight kinds — CONSTRAINT, ARCHITECTURE, DECISION, PATTERN, REVIEW, FAILURE, KNOWN_UNKNOWN, and EPISODE (instance-specific events with `{when, where, why, with_whom}` context).
 2. **Scoped Organization**: Facts are scoped to global, organization, or project level, with per-scope valid-fact caps (200 / 100 / 500 / 50). Org and project are auto-detected from git remotes.
 3. **Supersession & Pre-Write Dedup**: New facts with cosine similarity ≥ 0.85 to an existing fact short-circuit (bump the existing fact's access count) or supersede it. The pre-write canonical-signature check uses entity abstraction + verb-synonym folding to catch near-duplicates before they hit the store.
-4. **Confidence + Effectiveness Ranking**: `rank_score = recall_decay(sim)·confidence + success_bonus·effectiveness_f + provenance_bonus`. The Ebbinghaus recall-probability transform gives frequently-recalled facts slower decay; LessonL-style effectiveness (`c/n` over reuse outcomes) multiplies the success bonus. Curated facts (CONSTRAINT/ARCHITECTURE/DECISION and `seed`/`community`/`synthesized`-tagged facts) bypass decay.
+4. **Confidence + Effectiveness Ranking**: `rank_score = recall_decay(sim)·confidence + success_bonus·effectiveness_f + provenance_bonus`. The Ebbinghaus recall-probability transform gives frequently-recalled facts slower decay; LessonL-style effectiveness (`c/n` over reuse outcomes) multiplies the success bonus. Curated facts (CONSTRAINT/ARCHITECTURE/DECISION and `seed`/`community`/`synthesized`-tagged facts) bypass decay. (Nothing mints the `synthesized` tag anymore — facts carrying it predate the removal of REVIEW→PATTERN synthesis and keep their immunity.)
 5. **Hybrid Retrieval**: 0.7·dense (Jina) + 0.3·BM25. Half the result slots ranked by full `rank_score`, half by raw cosine — novel-but-relevant facts aren't crowded out by validated winners.
-6. **Triple-Trigger Consolidation**: REVIEW facts cluster into PATTERN / FAILURE archetypes when ANY of count-delta ≥10, elapsed ≥1h, or confidence-decile entropy >0.9 fires. Clusters of ≥3 get an NREM-style Hebbian confidence bump; non-curated facts decay 3% globally after each pass.
+6. **Evidence-Gated Promotion**: a suggestion is recorded as a *candidate*, not a fact. It only becomes a durable PATTERN after **two independent, git-verified acceptances** whose task prompt and diff shape agree (`_episode_signature` for project scope, the path-agnostic `_global_signature` for cross-repo lessons), and only when its kind is promotable — `algorithm` / `bugfix` classify to `pattern`; `feature`, `refactor`, and `explanation` deliberately do not. Unverifiable suggestions (no path a diff could ever name) are downgraded to non-promotable `review` at mint. There is **no** similarity-clustered promotion path: the older REVIEW→PATTERN synthesis (`synthesize_reviews`, with its triple-trigger gate, Hebbian bump, and global decay) was removed after four months in which it minted 114 facts and not one PATTERN. See [evidence-learning episodes](docs/solutions/evidence-learning-episodes.md).
 7. **Dual-Buffer Probation**: New non-curated facts enter with a `probation` tag and a 3-day stale window (vs 7/14 normal); promoted automatically on `access_count ≥ 2` or `success_count > 0` — quietly evicts noise while keeping real signal.
 8. **Four-Layer Context**: Retrieved facts are organized into constraints, relevant knowledge, recent changes, and known unknowns. The four-layer state model is from *Beyond Conversation: A State-Based Context Architecture for Enterprise AI Agents* (Liotta, 2025) — see [`papers/state-based-context-architecture.pdf`](papers/state-based-context-architecture.pdf). The token-budget enforcement in `memory/context.py` is ported from the engine described in *Memgine: A Deterministic Memory Engine for Stateful AI Agents* (Liotta, 2026) — see [`papers/memgine-deterministic-memory-engine.pdf`](papers/memgine-deterministic-memory-engine.pdf). Both are evaluated by [StateBench](https://github.com/parslee-ai/statebench); the 95.8% decision-accuracy result on the v1.0 development split is what drove Neo's move from a separate "Recently Changed" section to inline `(changed from: X)` annotations.
 
@@ -913,16 +1110,25 @@ neo --config set --config-key api_key --config-value sk-ant-...
 neo --config reset
 ```
 
-**Exposed Configuration Fields:**
-- `provider` - LM provider (openai, anthropic, google, azure, ollama, local)
-- `model` - Model name (e.g., gpt-5.6, claude-sonnet-4-5-20250929)
+**Exposed Configuration Fields** (the only keys `--config get/set` accepts):
+- `provider` - LM provider: `openai` (default), `anthropic`, `google`, `azure`, `ollama`, `local`, `claude-code`, `car`
+- `model` - Model name (default `gpt-5.6`; e.g. `claude-sonnet-4-5-20250929`). Pass an empty value (`--config-value ""`) to clear it and let the provider or CAR's router choose
 - `api_key` - API key for the chosen provider
-- `base_url` - Base URL for local/Ollama endpoints
-- `memory_backend` - Memory backend: "fact_store" (default) or "legacy"
+- `base_url` - Base URL for local/Ollama endpoints (also clearable with an empty value)
+- `inference_mode` - `static` (default) or `auto` — see [Outbound: use CAR as Neo's inference layer](#outbound-use-car-as-neos-inference-layer)
+- `memory_backend` - Memory backend: `fact_store` (default) or `legacy`
 - `auto_install_updates` - Automatically install updates in background (true/false)
 - `constraint_auto_scan` - Auto-scan CLAUDE.md for constraints (true/false, default: true)
 - `log_level` - Logging level: DEBUG, INFO, WARNING, or ERROR
 - `reasoning_effort_cap` - Optional cap for OpenAI gpt-5 reasoning effort
+
+**Other fields in `~/.neo/config.json`** — real settings, but not reachable
+through `--config set`; edit the file or use the environment variable:
+- `reasoning_mode` - `auto` (default), `fast`, or `deep`. Per-run equivalents: `--fast` / `--deep`
+- `default_temperature` / `default_max_tokens` - Env: `NEO_TEMPERATURE` / `NEO_MAX_TOKENS`
+- `exemplar_dir` - Env: `NEO_EXEMPLAR_DIR`
+- `enable_ruff` / `enable_pyright` / `enable_mypy` / `enable_eslint` - static-analysis toggles
+- `safe_read_patterns` / `forbidden_paths` - file allowlist and blocklist
 
 Configuration is stored in `~/.neo/config.json`. Environment variables override
 stored config values for the current process.
@@ -961,12 +1167,27 @@ export NEO_BASE_URL=http://localhost:11434       # for Ollama/local endpoints
 **Behavior**
 
 ```bash
+export NEO_INFERENCE_MODE=auto                    # prefer CAR's router, fall back to the static provider
 export NEO_REASONING_EFFORT=high                  # cap auto-effort selection
 export NEO_AUTO_INSTALL_UPDATES=1                 # auto-install background updates
 export NEO_SKIP_UPDATE_CHECK=1                    # disable update checks entirely
 export NEO_LOG_LEVEL=INFO                         # DEBUG/INFO/WARNING/ERROR
 export NEO_TEMPERATURE=0.7                        # generation temperature
 export NEO_MAX_TOKENS=4096                        # per-call max output tokens
+export NEO_EXEMPLAR_DIR=/path/to/exemplars        # override the exemplar store location
+export NEO_FASTEMBED_CACHE_DIR=/path/to/cache     # Jina model cache (default ~/.cache/neo/fastembed)
+export NEO_STDIN_TIMEOUT_SECONDS=5                # wait for stdin to be readable (default 1.0)
+export NEO_CAR_TIMEOUT_SECONDS=300                # per-call CAR watchdog deadline (default 240)
+export NEO_ALLOW_PLAINTEXT_API_KEY=1              # permit storing api_key in config.json (see above)
+```
+
+**Background observer**
+
+```bash
+export NEO_OBSERVER_AUTOSTART=0                   # do not autostart the observer
+export NEO_OBSERVER_INTERVAL_SECONDS=300          # sweep interval
+export NEO_OBSERVER_COOLDOWN=60                   # per-process cooldown between cycles
+export NEO_OBSERVER_RECYCLE_CYCLES=48             # re-exec after N cycles to bound RSS (0 disables)
 ```
 
 ### Install Sanity
@@ -983,10 +1204,21 @@ python3 -c "import neo; print(neo.__file__)"
 **Observability**
 
 ```bash
-export NEO_METRICS=off                            # disable ~/.neo/metrics.jsonl writes
+export NEO_PROFILE=standard                       # off | minimal | standard (default) | strict
+export NEO_METRICS=off                            # hard kill-switch; overrides NEO_PROFILE
 ```
 
 Neo writes structured per-operation events (retrieve / add_fact / lm_call / overseer_tick) to `~/.neo/metrics.jsonl` and per-session manifests + JSONL outcome logs to `~/.neo/sessions/`.
+
+`NEO_PROFILE` selects which events are emitted: `off` emits nothing, `minimal`
+emits only `lm_call`, `standard` emits everything, and `strict` is reserved for
+future verbose events (identical to `standard` today). `NEO_METRICS=off` (or
+`0`/`false`/`no`) is the legacy hard kill-switch and wins over `NEO_PROFILE`.
+
+The log rotates to `metrics.jsonl.1` at 32 MB with one generation retained. The
+readers (`memory citation-stats`, `memory learning-stats`) window by `--since`
+and read only the active file — a `--since` older than the last rotation
+silently sees less history.
 
 ## LM Adapters
 
@@ -997,7 +1229,11 @@ from neo.adapters import OpenAIAdapter
 adapter = OpenAIAdapter(model="gpt-5.6", api_key="sk-...")
 ```
 
-Default model: `gpt-5.6`. GPT-5/Codex models use the `/v1/responses` endpoint automatically.
+Neo's configured default model is `gpt-5.6` (`NeoConfig.model`), which is what
+the CLI uses. Constructing an adapter directly without a `model` falls back to
+the adapter's own default of `gpt-4`, so pass the model explicitly when you
+bypass `NeoConfig`. GPT-5/Codex models use the `/v1/responses` endpoint
+automatically.
 
 ### Anthropic
 
@@ -1108,12 +1344,12 @@ The 0.18 memory architecture lands deterministic techniques from a focused readi
 2. **Memory Systems Survey (1)**
    *Paper [2603.07670](https://arxiv.org/abs/2603.07670)*
    - Provenance taxonomy (`STRUCTURAL > OBSERVED > INFERRED`); dual-buffer / probation consolidation; Layer-1/2/3 observability split.
-   - **Implementation**: `src/neo/memory/models.py:42`, `store.py` (probation tag), `memory/metrics.py`.
+   - **Implementation**: `Provenance` in `src/neo/memory/models.py`, `store.py` (probation tag), `memory/metrics.py`.
 
 3. **Memory Survey 2 — Zep / AriGraph bi-temporal pattern**
    *Paper [2512.13564](https://arxiv.org/abs/2512.13564) §5.2.2*
    - Bi-temporal stamps (`event_time` / `event_time_end` / `ingest_time`); supersession via soft-delete.
-   - **Implementation**: `src/neo/memory/models.py:241`.
+   - **Implementation**: the `event_time` / `event_time_end` / `ingest_time` fields on `FactMetadata` in `src/neo/memory/models.py`.
 
 4. **Trajectory Memory — Canonical-signature dedup**
    *Paper [2603.10600](https://arxiv.org/abs/2603.10600) §7*
@@ -1133,22 +1369,22 @@ The 0.18 memory architecture lands deterministic techniques from a focused readi
 7. **LessonL — Effectiveness multiplier on reuse outcomes**
    *Paper [2505.23946](https://arxiv.org/abs/2505.23946)*
    - Per-fact `c/n` effectiveness as a success-bonus multiplier; half-by-rank / half-by-cosine slot allocation (Algorithm 1).
-   - **Implementation**: `src/neo/memory/models.py:130, 233`; `store.retrieve_relevant`.
+   - **Implementation**: `EFFECTIVENESS_EPSILON` and `FactMetadata.effectiveness_f` in `src/neo/memory/models.py`; `store.retrieve_relevant`.
 
 8. **Ebbinghaus Recall — Spaced-repetition decay for retrieval**
    *Hou et al., paper [2404.00573](https://arxiv.org/abs/2404.00573)*
    - Recall-probability transform `p_n(t) = (1 − exp(−r·exp(−t/g_n))) / (1 − e⁻¹)` applied to similarity scores for fluid facts.
-   - **Implementation**: `src/neo/math_utils.py:40`, `models.rank_score`.
+   - **Implementation**: `math_utils.recall_probability`, `models.rank_score`.
 
 9. **Episodic Memory — Five-property episodic context**
    *Paper [2502.06975](https://arxiv.org/abs/2502.06975) Table 1*
    - `{when, where, why, with_whom}` instance-specific event context.
-   - **Implementation**: `src/neo/memory/models.py:320` `EpisodeContext`.
+   - **Implementation**: `EpisodeContext` in `src/neo/memory/models.py`.
 
 10. **Multiple Memory Systems — Retrieval / context unit split**
     *Paper [2508.15294](https://arxiv.org/abs/2508.15294) §3*
     - Embed concise keywords (`retrieval_text`); inject full narrative (`context_text`) — same fact, two surfaces.
-    - **Implementation**: `src/neo/memory/models.py:373`.
+    - **Implementation**: the `retrieval_text` / `context_text` split on `Fact` in `src/neo/memory/models.py`.
 
 **Engine & multi-agent reasoning**
 
@@ -1160,12 +1396,12 @@ The 0.18 memory architecture lands deterministic techniques from a focused readi
 12. **CodeSim — MODIFY / NO_MODIFY decision token**
     *Hou et al., paper [2502.05664](https://arxiv.org/abs/2502.05664)*
     - Simulator emits an explicit "no modification needed" token; planner uses it as an override on the agreement-of-outputs heuristic. (Distinct from the 2023 ACM CodeSim paper of the same name.)
-    - **Implementation**: `src/neo/engine.py:427`.
+    - **Implementation**: `NeoEngine._simulation_consensus` / `_extract_plan_decision` in `src/neo/engine.py`.
 
 13. **SICA — Asynchronous structured-output watchdog & cache-hit observability**
     *Paper [2504.15228](https://arxiv.org/abs/2504.15228) §A.2, Table 1*
     - Daemon-thread tick loop emitting `overseer_tick` events; loop detection via 5-identical-actions-in-a-row; LM-call cache-hit-rate tracking.
-    - **Implementation**: `src/neo/overseer.py`, `src/neo/adapters.py:237`.
+    - **Implementation**: `src/neo/overseer.py`; cache-hit-rate tracking in `src/neo/adapters.py`.
 
 **In-house papers (Parslee)** — the foundational research behind Neo's context architecture
 

--- a/docs/solutions/async-observer.md
+++ b/docs/solutions/async-observer.md
@@ -4,20 +4,40 @@ Proposal for moving REVIEW→PATTERN/FAILURE synthesis off the hot path, modeled
 after ECC's `continuous-learning-v2` observer
 (`affaan-m/ECC:skills/continuous-learning-v2/`).
 
-> **As-built note (post-v0.19):** the first cut of this proposal rolled its own
-> daemon (`subprocess.Popen` + PID file + SIGUSR1 kick + idle-exit). That
-> implementation was replaced before any release with a port to CAR's
-> `agents_*` lifecycle API (the API landed in car-runtime 0.16.1; the
-> hard dep is ≥ 0.18.0 — see car-releases#54). The motivation, ECC
-> reference points, and design rationale below remain accurate; the
-> "Process model" section's plumbing is **superseded** — CAR's supervisor
-> owns spawn, restart-on-failure, log redirection, and clean shutdown.
-> `~/.car/agents.json` is the persisted spec; `~/.car/logs/neo-observer-<id8>.{stdout,stderr}.log`
-> is where output lands. `kick` maps to `agents_restart` since CAR has no
-> signal-passthrough primitive. See `src/neo/memory/observer.py` for the
-> current shape.
+> **As-built note — read this before the design below.** Two things have changed
+> since this was written, and the "Status quo" and "Process model" sections are
+> **superseded**:
+>
+> 1. **The workload is no longer synthesis.** `synthesize_reviews` — the
+>    triple-trigger gate, the ≥3-member clustering, the Hebbian bump, and the
+>    global 3% decay described throughout this document — was **removed**. In
+>    four months of production it minted 114 facts and not one PATTERN, and a
+>    live census found zero ≥3-member clusters at cosine 0.85 across all 1152
+>    valid REVIEWs. What the observer actually runs today is **transcript
+>    mining** (Claude Code / Codex / CAR sessions + merged GitHub PRs) via
+>    `TranscriptIngester`. Durable PATTERNs now come only from the git-verified
+>    episode ledger — see `docs/solutions/evidence-learning-episodes.md`.
+>
+> 2. **The process model is CAR's, and there is one process, not one per
+>    project.** The first cut rolled its own daemon (`subprocess.Popen` + PID
+>    file + SIGUSR1 kick + idle-exit); that was replaced before any release with
+>    a port to CAR's `agents_*` lifecycle API (the API landed in car-runtime
+>    0.16.1; the hard dep is ≥ 0.18.0 — see car-releases#54). CAR's supervisor
+>    owns spawn, restart-on-failure, log redirection, and clean shutdown.
+>    A **single global** agent (`neo-observer`, run as `--daemon --all`) sweeps
+>    every discovered project each cycle, budgeted by `max_projects_per_cycle`
+>    (default 25) and gated on both the watermark and file mtimes.
+>    `~/.car/agents.json` is the persisted spec; output lands in
+>    `~/.car/logs/neo-observer.{stdout,stderr}.log`. `kick` maps to
+>    `agents_restart` since CAR has no signal-passthrough primitive. The daemon
+>    also holds a cross-process single-instance lock and re-execs itself every
+>    `NEO_OBSERVER_RECYCLE_CYCLES` cycles (default 48) to bound RSS drift.
+>
+> The motivation and ECC reference points below remain the useful part. See
+> `src/neo/memory/observer.py` for the current shape, and `CLAUDE.md` for the
+> maintained description.
 
-## Status quo
+## Status quo (historical — describes the since-removed synthesis path)
 
 Synthesis runs inline in `memory/store.py:1722-1765` under a triple-trigger gate
 (any of: `count_delta ≥ 10`, `elapsed ≥ 1h`, `entropy > 0.9`). It fires on the

--- a/docs/solutions/conversation-mined-issues.md
+++ b/docs/solutions/conversation-mined-issues.md
@@ -34,7 +34,7 @@ A pull command. Pipeline (`neo/memory/issues.py`), all LM-free in v1:
 3. **Cluster** (`detect_issues`) — embed each ask (sharpened with its first
    error line when present) via the store's `_embed_text` (Jina — same vectors
    as fact retrieval, no extra model, no LM) and complete-linkage cluster at
-   `CLUSTER_SIMILARITY = 0.85` (== `store.SYNTHESIS_SIMILARITY`), reusing
+   `CLUSTER_SIMILARITY = 0.85` (the threshold the removed `store.SYNTHESIS_SIMILARITY` used; the two are no longer coupled), reusing
    `math_utils.cluster_by_similarity`.
 4. **Gate** — a cluster becomes an `Issue` only if it has **≥ `min_cluster`
    members**, spans **≥ 2 distinct sessions**, has **≥ 2 frictional members**,

--- a/docs/tree-sitter-setup.md
+++ b/docs/tree-sitter-setup.md
@@ -44,7 +44,7 @@ The resulting index lives at `.neo/index.json` inside the target repo and powers
 
 ### Supported Languages
 
-The canonical map lives in `src/neo/languages.py:30-54`.
+The canonical map is `EXTENSION_TO_LANGUAGE` in `src/neo/languages.py`.
 
 | Language   | Extensions                  |
 |------------|-----------------------------|
@@ -91,7 +91,7 @@ Per-subsystem coverage isn't uniform. For example, `code_smells` empty-catch det
 ## Operational Notes
 
 - Use `neo --update` instead of `--index` after the first build — it re-embeds only changed files.
-- `neo --index --max-files N` caps the walk when you only care about the active subtree.
+- The index build caps at **100 files** per run by default. Override it with `neo --index --max-files N`; the same flag caps *context gathering* at 30 by default when used without `--index`, so each subsystem keeps its own floor.
 - Neo honors `.gitignore` by default; double-check large generated dirs aren't tracked.
 - `MAX_CHUNK_LENGTH` is set to **2000 characters** (defined in both `language_parser.py` and `project_index.py` — keep them in sync if you change one).
 - Malformed code returns empty chunks by design (better than half-parsed garbage propagating into embeddings).

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -240,12 +240,16 @@ def parse_args():
 
         observer_p = subparsers.add_parser(
             'observer',
-            help='Run REVIEW→PATTERN/FAILURE synthesis in a background process',
+            help='Manage the background transcript-mining observer (CAR-supervised)',
         )
         observer_p.add_argument(
             'observer_action',
             choices=('start', 'stop', 'status', 'kick'),
-            help='start: spawn; stop: SIGTERM; status: show PID/last cycle; kick: SIGUSR1 force cycle',
+            help=(
+                'start: register+start the CAR agent; stop: stop it; '
+                'status: CAR state, last cycle, orphan check; '
+                'kick: force a cycle now (agents_restart)'
+            ),
         )
         observer_p.add_argument('--cwd', help='Codebase root (defaults to current directory)')
 
@@ -400,18 +404,38 @@ def parse_args():
         return args
 
     # Default argument parser (for reasoning mode)
+    # Subcommands are dispatched by the sys.argv[1] checks above, so argparse
+    # never sees them and cannot list them. Spell them out here or they are
+    # undiscoverable from `neo --help`.
     p = argparse.ArgumentParser(
         prog="neo",
         description="Neo - Reasoning helper for coding tasks",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        parents=[global_parser]
+        parents=[global_parser],
+        epilog="""subcommands (run `neo <subcommand> --help` for details):
+  neo memory <action>     replay-feedback | prune | observer | issues | rules |
+                          audit | import | explain | evaluate-learning |
+                          citation-stats | learning-stats
+  neo construct <action>  list | show | search | index
+  neo car status          report detected CAR runtime surfaces
+  neo serve               host Neo as an Agent2Agent v1.0 endpoint (needs [car])
+  neo prompt <action>     analyze | enhance | patterns | suggest | history | stats
+  neo contribute          export high-confidence patterns for the community
+  neo update              update the installed neo package
+""",
     )
 
     p.add_argument("prompt", nargs="?", help="Plain text prompt (or use stdin)")
     p.add_argument("--json", action="store_true", help="Print JSONL events and final JSON")
     p.add_argument("--output-schema", metavar="NAME_OR_PATH", help="Control final response shape")
     p.add_argument("--max-bytes", type=int, default=300_000, help="Hard cap for total context bytes")
-    p.add_argument("--max-files", type=int, default=30, help="Soft cap for number of context files")
+    # Default is None, not a number, because this flag feeds two different
+    # subsystems with different natural caps: context gathering (30) and the
+    # index build (100). A shared numeric default would silently shrink one of
+    # them; `None` lets each call site keep its own floor while an explicit
+    # value overrides both.
+    p.add_argument("--max-files", type=int, default=None,
+                   help="Cap on files: context gathering (default 30) or, with --index, the index build (default 100)")
     p.add_argument("--include", action="append", default=[], help="Allowlist glob patterns (repeatable)")
     p.add_argument("--exclude", action="append", default=[], help="Blocklist glob patterns (repeatable)")
     p.add_argument("--exts", metavar="CSV", help="Restrict to file extensions (comma-separated)")
@@ -652,7 +676,11 @@ def main():
             languages = [lang.strip() for lang in args.languages.split(',')]
             print(f"[Neo] Indexing languages: {', '.join(languages)}")
 
-        max_files = 100  # Configurable later
+        # `--max-files` is defined on the reasoning parser, so a subcommand
+        # parser that also inherits `--index` won't carry the attribute.
+        max_files = getattr(args, 'max_files', None) or 100
+        if max_files != 100:
+            print(f"[Neo] Indexing at most {max_files} files")
 
         try:
             index.build_index(languages=languages, max_files=max_files)
@@ -890,7 +918,7 @@ def main():
                 includes=args.include,
                 excludes=args.exclude,
                 max_bytes=args.max_bytes,
-                max_files=args.max_files,
+                max_files=args.max_files or 30,
                 diff_since=args.diff_since,
                 use_git=not args.no_git,
             )

--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -312,12 +312,18 @@ class NeoConfig:
         path = Path(config_path).expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Only save exposed fields (not internal settings)
+        # Only save exposed fields (not internal settings).
+        # `from_file` accepts any NeoConfig field, so anything readable but
+        # missing here is silently erased the next time a config is saved —
+        # which is exactly what happened to `inference_mode` and
+        # `reasoning_mode`. Keep this list in sync with what users can set.
         exposed_fields = {
             'provider': self.provider,
             'model': self.model,
             'api_key': self.api_key if os.environ.get("NEO_ALLOW_PLAINTEXT_API_KEY") else None,
             'base_url': self.base_url,
+            'inference_mode': self.inference_mode,
+            'reasoning_mode': self.reasoning_mode,
             'auto_install_updates': self.auto_install_updates,
             'memory_backend': self.memory_backend,
             'constraint_auto_scan': self.constraint_auto_scan,

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -1964,13 +1964,24 @@ def handle_config(args):
     """Handle --config flag operations."""
     from neo.config import NeoConfig, store_api_key_in_keychain
 
-    VALID_PROVIDERS = ['openai', 'anthropic', 'google', 'azure', 'ollama', 'local', 'claude-code']
+    # Mirrors the providers `adapters.create_adapter` can actually build. 'car'
+    # belongs here: it is a real static provider (CAR's router owns model
+    # selection), distinct from inference_mode='auto', which prefers CAR but
+    # falls back to the static provider when the daemon is unreachable.
+    VALID_PROVIDERS = [
+        'openai', 'anthropic', 'google', 'azure', 'ollama', 'local',
+        'claude-code', 'car',
+    ]
     VALID_MEMORY_BACKENDS = ['fact_store', 'legacy']
+    VALID_INFERENCE_MODES = ['static', 'auto']
     EXPOSED_FIELDS = [
-        'provider', 'model', 'api_key', 'base_url',
+        'provider', 'model', 'api_key', 'base_url', 'inference_mode',
         'memory_backend', 'auto_install_updates', 'constraint_auto_scan',
         'log_level', 'reasoning_effort_cap',
     ]
+    # Optional string fields an empty --config-value clears back to unset. For
+    # `model` that is the only way to say "let the provider/router choose".
+    NULLABLE_FIELDS = {'model', 'base_url'}
 
     def mask_secret(value: str) -> str:
         """Mask API keys and secrets for display."""
@@ -2029,6 +2040,12 @@ def handle_config(args):
         if args.config_key == 'memory_backend' and args.config_value not in VALID_MEMORY_BACKENDS:
             print(f"Error: Invalid memory backend. Valid values: {', '.join(VALID_MEMORY_BACKENDS)}", file=sys.stderr)
             sys.exit(1)
+        if args.config_key == 'inference_mode' and args.config_value not in VALID_INFERENCE_MODES:
+            print(
+                f"Error: Invalid inference mode. Valid values: {', '.join(VALID_INFERENCE_MODES)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if args.config_key == 'log_level':
             value_upper = str(args.config_value).upper() if args.config_value else ""
             if value_upper not in ("DEBUG", "INFO", "WARNING", "ERROR"):
@@ -2041,6 +2058,10 @@ def handle_config(args):
             if not value:
                 print("Error: API key cannot be empty", file=sys.stderr)
                 sys.exit(1)
+        elif args.config_value == "" and args.config_key in NULLABLE_FIELDS:
+            # An explicitly empty value clears the field. `--config-value ""` is
+            # distinguishable from an omitted flag (which argparse leaves None).
+            value = None
         elif not args.config_value:
             print("Error: --config-value required for this config key", file=sys.stderr)
             sys.exit(1)
@@ -2085,6 +2106,8 @@ def handle_config(args):
         config.save()
         if args.config_key == 'api_key':
             print(f"\u2713 Stored api_key in Keychain for provider {config.provider}")
+        elif value is None and args.config_key in NULLABLE_FIELDS:
+            print(f"\u2713 Cleared {args.config_key} (provider default applies)")
         else:
             print(f"\u2713 Set {args.config_key} = {value}")
 

--- a/tests/test_config_car_provider.py
+++ b/tests/test_config_car_provider.py
@@ -1,0 +1,132 @@
+"""CLI reachability of the CAR inference surface.
+
+`adapters.create_adapter` has always been able to build a CAR adapter, and
+`resolve_adapter` has always honored `inference_mode`. Neither was reachable
+from `neo --config set`: the provider allowlist omitted 'car' and
+`EXPOSED_FIELDS` omitted `inference_mode`. Worse, `NeoConfig.save()` did not
+serialize `inference_mode` at all, so a hand-edited value was erased by the
+next save. These pin all three.
+"""
+
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from neo.cli import parse_args
+from neo.config import NeoConfig
+from neo.subcommands import handle_config
+
+
+def _set(key, value):
+    return SimpleNamespace(config="set", config_key=key, config_value=value)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / ".neo").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(h))
+    monkeypatch.setattr("pathlib.Path.home", lambda: h)
+    for var in ("NEO_API_KEY", "OPENAI_API_KEY", "NEO_PROVIDER", "NEO_INFERENCE_MODE"):
+        monkeypatch.delenv(var, raising=False)
+    return h
+
+
+def _config_json(home):
+    return json.loads((home / ".neo" / "config.json").read_text())
+
+
+def test_car_is_a_settable_provider(home, capsys):
+    handle_config(_set("provider", "car"))
+
+    assert _config_json(home)["provider"] == "car"
+    assert "Set provider = car" in capsys.readouterr().out
+
+
+def test_invalid_provider_still_rejected(home):
+    with pytest.raises(SystemExit) as exc:
+        handle_config(_set("provider", "not-a-provider"))
+    assert exc.value.code == 1
+
+
+def test_inference_mode_is_settable_and_persists(home):
+    handle_config(_set("inference_mode", "auto"))
+
+    # Both on disk and after a round-trip through load(): `save()` used to drop
+    # this field, so the value survived in memory but never on disk.
+    assert _config_json(home)["inference_mode"] == "auto"
+    assert NeoConfig.load().inference_mode == "auto"
+
+
+def test_inference_mode_rejects_unknown_value(home):
+    with pytest.raises(SystemExit) as exc:
+        handle_config(_set("inference_mode", "turbo"))
+    assert exc.value.code == 1
+
+
+def test_save_does_not_erase_a_hand_edited_inference_mode(home):
+    (home / ".neo" / "config.json").write_text(json.dumps({
+        "provider": "openai",
+        "inference_mode": "auto",
+        "reasoning_mode": "deep",
+    }))
+
+    # Any unrelated set triggers a full rewrite of config.json.
+    handle_config(_set("log_level", "INFO"))
+
+    data = _config_json(home)
+    assert data["inference_mode"] == "auto"
+    assert data["reasoning_mode"] == "deep"
+
+
+def test_empty_value_clears_model_so_the_router_can_choose(home, capsys):
+    handle_config(_set("model", "gpt-5.6"))
+    handle_config(_set("model", ""))
+
+    assert _config_json(home)["model"] is None
+    assert NeoConfig.load().model is None
+    assert "Cleared model" in capsys.readouterr().out
+
+
+def test_empty_value_still_rejected_for_non_nullable_fields(home):
+    with pytest.raises(SystemExit) as exc:
+        handle_config(_set("memory_backend", ""))
+    assert exc.value.code == 1
+
+
+def test_omitted_value_is_not_treated_as_a_clear(home):
+    """`--config-key model` with no `--config-value` is a mistake, not a clear."""
+    with pytest.raises(SystemExit) as exc:
+        handle_config(_set("model", None))
+    assert exc.value.code == 1
+
+
+def test_car_provider_passes_no_api_key_kwargs(home):
+    from neo.adapters import _adapter_kwargs_for_config
+
+    handle_config(_set("provider", "car"))
+    handle_config(_set("model", ""))
+
+    config = NeoConfig.load()
+    assert config.provider == "car"
+    # CAR's router owns backend selection; api_key/base_url are meaningless.
+    assert _adapter_kwargs_for_config(config) == {}
+
+
+def test_max_files_defaults_differ_per_subsystem():
+    """One flag feeds two caps: context gathering (30) and indexing (100)."""
+    with patch.object(sys, "argv", ["neo", "--index"]):
+        assert parse_args().max_files is None
+    with patch.object(sys, "argv", ["neo", "a prompt"]):
+        assert parse_args().max_files is None
+    with patch.object(sys, "argv", ["neo", "--index", "--max-files", "500"]):
+        assert parse_args().max_files == 500
+
+
+def test_subcommand_parsers_have_no_max_files_attribute():
+    """The --index branch must use getattr, not args.max_files."""
+    with patch.object(sys, "argv", ["neo", "memory", "prune", "--dry-run"]):
+        assert not hasattr(parse_args(), "max_files")


### PR DESCRIPTION
## Description

An audit of README / QUICKSTART / INSTALL / CONTRIBUTING / `docs/` against the code, plus fixes for the two CLI gaps that audit surfaced.

**Documentation** — commands that error as written, claims that outlive the code they describe, and gaps in the command surface. Highlights:

- The CAR-outbound setup told you to run `--config set --config-key provider --config-value car` and `--config-value ""`. Both exit 1.
- `tree-sitter-setup.md` claimed `neo --index --max-files N` caps the walk; the index build hardcoded 100 and ignored the flag.
- INSTALL's migration steps included `pip freeze | grep -v "^-e" | xargs pip uninstall -y`, which uninstalls every package in the environment.
- README described "Triple-Trigger Consolidation" as live architecture; `synthesize_reviews` was removed. Same staleness in `docs/solutions/async-observer.md` (which also still described a per-project daemon and the wrong log path) and CONTRIBUTING's file map.
- CLAUDE.md said UNVERIFIED outcomes give +0.1 confidence and bump `success_count`; the code mutates nothing (`store.py:2148`, `store.py:2301`). README and AGENTS.md were right — CLAUDE.md was the outlier.
- CONTRIBUTING said CLAUDE.md and AGENTS.md "are kept identical"; they are 168 vs 449 lines.
- Six of nine `file.py:NNN` anchors in Research pointed at unrelated lines (`engine.py:427` was ~660 off). Swapped all to symbol names.
- Version samples showed `0.18.1` and a `--version` layout missing the `Storage:`/`CAR:` lines, with "facts" where the code prints "patterns".
- README now documents all 11 `neo memory` actions (was 3), the ~20 undocumented global flags, and the missing env vars. INSTALL had no PyPI install path at all.

**Code** — two capabilities existed but were unreachable from the CLI, which is what made their documentation wrong:

- `handle_config` now accepts `provider=car` and `inference_mode` (validated `static`/`auto`). An empty `--config-value ""` clears `model`/`base_url`; with `provider=car` that is the only way to let CAR's router choose, since `model` is passed through as a pin. An omitted `--config-value` still errors.
- Exposing the field was not enough: `NeoConfig.save()` serializes a hardcoded list that omitted `inference_mode` and `reasoning_mode`, while `from_file` accepts any dataclass field — both were readable but erased by the next save. Added to the save list.
- `neo --index --max-files N` is honored. The flag feeds two subsystems with different natural caps (gathering 30, indexing 100), so the default became `None` and each call site keeps its own floor.
- Two stale help strings: `neo --help` listed no subcommands at all (they are dispatched by `sys.argv[1]` before argparse sees them), and `neo memory observer --help` still described REVIEW→PATTERN synthesis and a SIGUSR1 kick.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None — found by auditing the docs against the code.

## Motivation and Context

Documentation that instructs a user to run a command which exits 1 is worse than absent documentation. Three such commands were published. Behind two of them sat real capabilities (`create_adapter` has always built a CAR adapter; `resolve_adapter` has always honored `inference_mode`) that no CLI path could reach, so the fix belonged in the code rather than in a rewording.

The `NeoConfig.save()` omission is the sharpest one: `from_file` reads any dataclass field, so `inference_mode` and `reasoning_mode` could be hand-edited into `config.json`, read back correctly, and then silently erased by the next unrelated `--config set`.

## How Has This Been Tested?

- [x] New `tests/test_config_car_provider.py` (11 tests): `car` accepted and invalid providers still rejected; `inference_mode` settable, validated, and persisted through `load()`; an unrelated `--config set` no longer erases a hand-edited `inference_mode`/`reasoning_mode`; empty value clears `model` but is still rejected for non-nullable fields; omitted value is not treated as a clear; `--max-files` defaults resolve per subsystem; subcommand parsers carry no `max_files` attribute.
- [x] Full suite: 1504 passed, 3 skipped. `ruff check src/ tests/` clean. Both commits went through the `.githooks` pre-commit parity gate.
- [x] Manual end-to-end against an isolated `HOME`: `provider=car` → `model=""` → `inference_mode=auto` round-trips through `config.json` and `NeoConfig.load()`; `_adapter_kwargs_for_config` returns `{}` for CAR.
- [x] Manual index build on an 8-file repo: `--max-files 3` indexed 3 files, plain `--index` indexed all 8 (default preserved).
- [x] Docs: every relative link and every README internal anchor resolves.

**Test Configuration**:
- Python version: 3.13.13
- OS: macOS (Darwin 25.5.0)
- Neo version: 0.41.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

`reasoning_mode` is deliberately still not settable via `--config set` — it has per-run `--fast` / `--deep` equivalents. It does now persist correctly if hand-edited.
