### PR TITLE
fix(config): derive the save() field list from the dataclass

### DIFF
--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -8,13 +8,18 @@ import os
 import platform
 import subprocess
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from pathlib import Path
 from typing import Optional
 
 
 KEYCHAIN_SERVICE_PREFIX = "neo-reasoner"
 logger = logging.getLogger(__name__)
+
+#: Fields the generic save path must never write. `save` handles `api_key`
+#: explicitly, gated on NEO_ALLOW_PLAINTEXT_API_KEY. Anything added here needs
+#: the same treatment or it will simply stop being persisted.
+_SECRET_FIELDS = frozenset({"api_key"})
 
 
 def _keychain_service(provider: str) -> str:
@@ -302,8 +307,45 @@ class NeoConfig:
 
         return config
 
+    def _changed_from_defaults(self) -> dict:
+        """Fields whose value differs from the dataclass default.
+
+        Derived from the dataclass rather than a hand-maintained allow-list.
+        The old list-based approach silently erased any field it omitted,
+        because ``from_file`` accepts *every* field the class defines: a value
+        could be hand-edited into config.json, read back correctly, then
+        dropped by the next unrelated ``--config set``. That happened to
+        ``inference_mode`` and ``reasoning_mode``, and would have happened to
+        the six other fields nothing writes yet.
+
+        Fields still at their default are omitted rather than written out.
+        Persisting defaults would freeze today's values into every user's file,
+        so a future change to a default would never reach anyone who had ever
+        run ``--config set`` — the exact failure the ``auto_install_updates``
+        migration in ``from_file`` exists to undo.
+
+        ``api_key`` is excluded here and handled explicitly by ``save``: it is
+        the one secret, and ``load()`` populates it from the environment or
+        Keychain, so a generic diff-from-default pass would spill it to disk.
+        """
+        changed = {}
+        for f in fields(self):
+            if f.name in _SECRET_FIELDS:
+                continue
+            if f.default is not MISSING:
+                default = f.default
+            elif f.default_factory is not MISSING:
+                default = f.default_factory()
+            else:
+                changed[f.name] = getattr(self, f.name)
+                continue
+            value = getattr(self, f.name)
+            if value != default:
+                changed[f.name] = value
+        return changed
+
     def save(self, config_path: Optional[str] = None):
-        """Save configuration to file (only exposed fields)."""
+        """Save configuration to file (user-set fields only)."""
         if not config_path:
             config_dir = Path.home() / ".neo"
             config_dir.mkdir(exist_ok=True)
@@ -312,24 +354,14 @@ class NeoConfig:
         path = Path(config_path).expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Only save exposed fields (not internal settings).
-        # `from_file` accepts any NeoConfig field, so anything readable but
-        # missing here is silently erased the next time a config is saved —
-        # which is exactly what happened to `inference_mode` and
-        # `reasoning_mode`. Keep this list in sync with what users can set.
-        exposed_fields = {
-            'provider': self.provider,
-            'model': self.model,
-            'api_key': self.api_key if os.environ.get("NEO_ALLOW_PLAINTEXT_API_KEY") else None,
-            'base_url': self.base_url,
-            'inference_mode': self.inference_mode,
-            'reasoning_mode': self.reasoning_mode,
-            'auto_install_updates': self.auto_install_updates,
-            'memory_backend': self.memory_backend,
-            'constraint_auto_scan': self.constraint_auto_scan,
-            'log_level': self.log_level,
-            'reasoning_effort_cap': self.reasoning_effort_cap,
-        }
+        exposed_fields = self._changed_from_defaults()
+
+        # The secret. Written unconditionally — as an explicit null when
+        # plaintext storage is not enabled — so that a stale plaintext key
+        # left in the file is actively cleared rather than merely omitted.
+        exposed_fields['api_key'] = (
+            self.api_key if os.environ.get("NEO_ALLOW_PLAINTEXT_API_KEY") else None
+        )
 
         # Mark explicit opt-out so migration doesn't override it
         if self.auto_install_updates is False:

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -1,0 +1,149 @@
+"""`NeoConfig.save()` must persist every field a user can set.
+
+`from_file` accepts every field the dataclass defines, but `save` used to write
+a hand-maintained allow-list. Anything missing from that list could be written
+into config.json, read back correctly, and then silently erased by the next
+unrelated save. `inference_mode` and `reasoning_mode` were live instances of
+that bug; six more fields were latent.
+
+These tests pin the two properties that keep the class of bug closed:
+every non-secret field round-trips, and `api_key` never reaches disk unless
+plaintext storage is explicitly enabled.
+"""
+
+import dataclasses
+import json
+
+import pytest
+
+from neo import config as config_module
+from neo.config import NeoConfig
+
+
+# One non-default value per field. Deliberately exhaustive: the assertion below
+# fails if a field is added to NeoConfig without being covered here, which is
+# the only way this test keeps working as the config grows.
+NON_DEFAULT_VALUES = {
+    "provider": "car",
+    "model": None,
+    "base_url": "http://localhost:1234",
+    "inference_mode": "auto",
+    "reasoning_mode": "deep",
+    "default_temperature": 0.1,
+    "default_max_tokens": 999,
+    "reasoning_effort_cap": "high",
+    "safe_read_patterns": ["*.rs"],
+    "forbidden_paths": ["*.pem"],
+    "exemplar_dir": "/tmp/exemplars",
+    "enable_ruff": False,
+    "enable_pyright": False,
+    "enable_mypy": True,
+    "enable_eslint": False,
+    "auto_install_updates": False,
+    "memory_backend": "legacy",
+    "constraint_auto_scan": False,
+    "log_level": "DEBUG",
+}
+
+
+def test_every_field_is_covered_by_this_test():
+    """A new NeoConfig field must be added to NON_DEFAULT_VALUES."""
+    declared = {f.name for f in dataclasses.fields(NeoConfig)}
+    # api_key is the one secret; it is asserted separately below.
+    assert declared - set(NON_DEFAULT_VALUES) == {"api_key"}
+
+
+@pytest.mark.parametrize("field_name", sorted(NON_DEFAULT_VALUES))
+def test_field_survives_a_save_load_round_trip(field_name, tmp_path):
+    value = NON_DEFAULT_VALUES[field_name]
+    path = tmp_path / "config.json"
+
+    NeoConfig(**{field_name: value}).save(str(path))
+
+    assert field_name in json.loads(path.read_text()), (
+        f"{field_name} was not persisted; the next save would erase it"
+    )
+    assert getattr(NeoConfig.from_file(str(path)), field_name) == value
+
+
+def test_all_fields_persist_together(tmp_path):
+    path = tmp_path / "config.json"
+    NeoConfig(**NON_DEFAULT_VALUES).save(str(path))
+
+    loaded = NeoConfig.from_file(str(path))
+    for name, value in NON_DEFAULT_VALUES.items():
+        assert getattr(loaded, name) == value, name
+
+
+def test_defaults_are_not_frozen_into_the_file(tmp_path):
+    """Only user-set fields are written.
+
+    Persisting defaults would pin today's values for every user who ever ran
+    `--config set`, so a future change to a default would never reach them —
+    the failure the auto_install_updates migration exists to undo.
+    """
+    path = tmp_path / "config.json"
+    NeoConfig(log_level="DEBUG").save(str(path))
+
+    saved = json.loads(path.read_text())
+    assert sorted(saved) == ["api_key", "log_level"]
+
+
+def test_all_default_config_writes_no_settings(tmp_path):
+    path = tmp_path / "config.json"
+    NeoConfig().save(str(path))
+
+    # Only the explicit secret null; every setting is left to the defaults.
+    assert json.loads(path.read_text()) == {"api_key": None}
+
+
+def test_api_key_from_environment_is_not_written_to_disk(tmp_path, monkeypatch):
+    """load() fills api_key from env/Keychain; save() must not spill it."""
+    home = tmp_path / "home"
+    (home / ".neo").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-from-env")
+    monkeypatch.delenv("NEO_API_KEY", raising=False)
+    monkeypatch.delenv("NEO_ALLOW_PLAINTEXT_API_KEY", raising=False)
+    monkeypatch.setattr(config_module, "load_api_key_from_keychain", lambda provider: None)
+
+    config = NeoConfig.load()
+    assert config.api_key == "sk-secret-from-env"
+
+    path = tmp_path / "config.json"
+    config.save(str(path))
+
+    saved = json.loads(path.read_text())
+    assert saved["api_key"] is None
+    assert "sk-secret-from-env" not in path.read_text()
+
+
+def test_plaintext_api_key_written_only_when_explicitly_allowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEO_ALLOW_PLAINTEXT_API_KEY", "1")
+    path = tmp_path / "config.json"
+
+    NeoConfig(api_key="sk-plain").save(str(path))
+
+    assert json.loads(path.read_text())["api_key"] == "sk-plain"
+
+
+def test_auto_update_opt_out_survives_the_migration(tmp_path, monkeypatch):
+    """False + the explicit marker must not be flipped back to True on load."""
+    monkeypatch.delenv("NEO_AUTO_INSTALL_UPDATES", raising=False)
+    path = tmp_path / "config.json"
+
+    NeoConfig(auto_install_updates=False).save(str(path))
+
+    saved = json.loads(path.read_text())
+    assert saved["auto_install_updates"] is False
+    assert saved["_auto_update_explicit"] is True
+    assert NeoConfig.from_file(str(path)).auto_install_updates is False
+
+
+def test_unknown_keys_in_the_file_are_ignored(tmp_path):
+    """Fields removed from the dataclass must not break loading."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"provider": "anthropic", "retired_setting": 1}))
+
+    assert NeoConfig.from_file(str(path)).provider == "anthropic"


### PR DESCRIPTION
## Description

`NeoConfig.save()` wrote a hand-maintained allow-list of fields, but `from_file` accepts *every* field the dataclass defines. Any field missing from that list could be written into `config.json`, read back correctly, and then silently erased by the next unrelated `--config set`.

`inference_mode` and `reasoning_mode` were live instances (fixed in #156). Nine more were latent: `enable_ruff`, `enable_pyright`, `enable_mypy`, `enable_eslint`, `default_temperature`, `default_max_tokens`, `exemplar_dir`, `safe_read_patterns`, `forbidden_paths`.

`_changed_from_defaults()` now derives the write set from `dataclasses.fields()`, so adding a field to `NeoConfig` can no longer leave it unpersisted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Follow-up to #156, which fixed the two live instances of this bug but left the mechanism — the hand-maintained list — in place.

## Motivation and Context

Two design points worth review:

**It writes only fields that differ from their default, not every field.** Persisting defaults would close the erasure bug but open a worse one: today's values would be frozen into every user's `config.json`, so a future change to a default would never reach anyone who had ever run `--config set`. That is the exact failure the `auto_install_updates` migration in `from_file` exists to undo. The tradeoff: a value deliberately pinned to the *current* default is not recorded as a pin, so a later default change would move that user.

**`api_key` is excluded from the generic pass and handled explicitly.** `load()` populates it from the environment or Keychain, so a naive diff-from-default pass would have written a live secret to disk. It is still emitted as an explicit `null` when `NEO_ALLOW_PLAINTEXT_API_KEY` is unset, which actively clears a stale plaintext key rather than merely omitting it — and preserves the existing keychain test that asserts the key is present-and-null.

## How Has This Been Tested?

- [x] New `tests/test_config_persistence.py` (27 tests): every non-secret field round-trips through `save` → `from_file` (parametrized per field); defaults are not frozen into the file; an env-supplied `api_key` never reaches disk; plaintext is written only when explicitly allowed; the `auto_install_updates` opt-out marker survives; unknown keys in the file are ignored.
- [x] **Verified the tests fail against the previous implementation.** Restoring `git show HEAD:src/neo/config.py` in place produces 12 failures — the 9 latent fields plus the two defaults properties. Without that check the tests would not be proven to guard anything.
- [x] `test_every_field_is_covered_by_this_test` fails if a field is added to `NeoConfig` without a non-default value in the fixture, so coverage cannot rot the way the allow-list did.
- [x] Legacy upgrade path, manually, against a real old-format `config.json`: hand-edited `enable_mypy` / `default_max_tokens` / `exemplar_dir` now survive an unrelated `--config set` that previously erased all three; redundant default keys are dropped from the file.
- [x] Full suite: 1531 passed, 3 skipped. `ruff check src/ tests/` clean. Commit went through the `.githooks` pre-commit parity gate.

**Test Configuration**:
- Python version: 3.13.13
- OS: macOS (Darwin 25.5.0)
- Neo version: 0.41.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Visible side effect for existing users: on the next save, keys whose value equals the default are dropped from `config.json`. Functionally identical on load — `from_file` fills them from the dataclass — but the file gets noticeably shorter. `--config reset` now produces `{"api_key": null}`.
