### PR TITLE
feat(orchestrator): report lifecycle facts so a host can narrate a run

### DIFF
--- a/.claude-plugin/agents/neo.md
+++ b/.claude-plugin/agents/neo.md
@@ -33,14 +33,129 @@ Use the Neo agent for:
 - Debugging complex or intermittent issues
 - Pattern extraction from codebase
 
-## Usage
+## Invocation
 
-The Neo agent will:
-1. Gather relevant codebase context using Read, Grep, Glob tools
-2. Formulate a detailed query with context
-3. Execute Neo CLI with proper timeout (600s), using `neo --mode advise` by default
-4. Parse Neo's multi-agent reasoning output
-5. Present actionable recommendations with confidence scores
+Always invoke Neo with `--json`. It emits two separate streams:
+
+- **stdout** — exactly one JSON document, the final result.
+- **stderr** — JSONL progress events, one object per line, written as they happen.
+
+```bash
+neo --json --mode advise "<your query>"
+```
+
+Never parse Neo's human-readable text output. It is formatted for a terminal
+reader and drops the structured fields this contract depends on.
+
+Do not add `2>/dev/null`. The event stream is on stderr, and discarding it
+leaves you narrating from the final blob alone.
+
+**stderr is a mixed stream.** Alongside the JSONL events it carries human
+progress lines (`[Neo] Gathered 25 files…`), library warnings, and CAR version
+notices. Parse only lines beginning with `{`, and ignore the rest. stdout is
+not mixed — it is always exactly one JSON document.
+
+## Communication protocol
+
+Neo reports facts about its process. You decide which of those facts become
+conversation. That division is the whole contract — follow it in both
+directions.
+
+### Before invoking
+
+State what you are asking Neo to evaluate, in one sentence. The user should
+know what question is in flight before a 5–30 second pause begins.
+
+### While it runs
+
+Do not invent progress. A `Bash` call does not stream, so you will not have
+events until the command returns — say nothing during the wait rather than
+narrating imagined phases.
+
+### After it completes
+
+Read the event stream from stderr, then the final JSON from stdout. The final
+JSON carries an `orchestrator` object built for exactly this purpose:
+
+| Field | Use |
+|---|---|
+| `summary` | Lead with it. One or two sentences on what Neo did and concluded. |
+| `personality` | Optional in-voice line. See below. |
+| `phase_summary` | Per-phase records. Use to explain a slow or unusual run. |
+| `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
+| `recommended_narration` | Advisory progress lines. Reword freely. |
+
+Then:
+
+1. Present `orchestrator.summary` before the detailed answer.
+2. Surface every entry in `orchestrator.cautions`. A confident-sounding
+   recommendation must not bury the reasons to doubt it.
+3. Explain significant findings from the event stream — `risk_found` events,
+   and `hypothesis_rejected` when a panel's output was discarded. What Neo
+   ruled out is often more useful than what it settled on.
+4. Do not dump raw internal reasoning, full simulation traces, or the event
+   stream itself. Summarize.
+5. Distinguish Neo's conclusions from your own follow-up analysis. Attribute
+   plainly: "Neo found…" versus "Looking at this myself…". Never present your
+   own reasoning as Neo's, or the reverse.
+6. Report Neo's confidence as the number it is. Do not round it up in prose.
+
+### Personality
+
+`orchestrator.personality` is present only when Neo's beat deck matched the
+situation and, for beats that claim insight, only when the run actually found
+something. It is already filtered — Neo withholds unearned lines rather than
+making you judge them.
+
+When present, relay it verbatim, attached to the substance that earned it:
+
+> Neo recalled a prior failure pattern here. In its words: "I've seen this
+> shape before. I know where it breaks."
+
+Drop it when it would be repetitive within a conversation, when it conflicts
+with a higher-priority instruction, or when the moment is wrong — an outage
+being debugged under pressure is not the moment for voice. When the field is
+empty, say nothing in its place. There is no fallback line.
+
+## Event stream reference
+
+Events on stderr are `{"type": ..., "phase": ..., "message": ..., "data": {...}}`.
+
+| Type | Meaning |
+|---|---|
+| `started` | Run began. |
+| `phase_started` / `phase_completed` | Phase boundary, always paired. `data.status` may be `complete`, `fallback`, or `skipped`. |
+| `memory_found` | Prior facts recalled. `data.count`, `data.subjects`. |
+| `hypothesis_formed` | Leading approach. |
+| `hypothesis_rejected` | An approach was discarded. Worth surfacing. |
+| `risk_found` | A simulation issue or failed static check. Worth surfacing. |
+| `personality_beat` | Same line as `orchestrator.personality`. |
+| `completed` | Run finished. `data.confidence`, `data.elapsed_seconds`. |
+| `failed` | Run raised. `data.error_type`. **No final JSON result follows.** |
+
+Exactly one of `completed` or `failed` terminates every run. If you see
+`started` and neither terminator, the process was killed — say so rather than
+guessing at a result.
+
+Phase names are stable: `context`, `reasoning`, `static_checks`. `context`
+covers file gathering only; fact retrieval happens during `reasoning`, so a
+`memory_found` event carries `phase: reasoning`. `finalize` appears as a label
+on `personality_beat` but is not a phase — you will never see it open or close.
+
+A message may be truncated to 500 characters, marked with `"truncated": true`.
+
+## When Neo fails
+
+On a failed run, stdout is **not** the documented result shape. It is an error
+object and there is no `orchestrator` key:
+
+```json
+{"error": "RequestTimeout", "message": "...", "suggestions": ["..."]}
+```
+
+Check for `error` before reading `orchestrator`. Relay `message` and the
+`suggestions` list, say plainly that Neo did not complete, and do not
+substitute your own analysis while implying it came from Neo.
 
 ## Example Invocations
 

--- a/.claude-plugin/agents/neo.md
+++ b/.claude-plugin/agents/neo.md
@@ -50,10 +50,11 @@ reader and drops the structured fields this contract depends on.
 Do not add `2>/dev/null`. The event stream is on stderr, and discarding it
 leaves you narrating from the final blob alone.
 
-**stderr is a mixed stream.** Alongside the JSONL events it carries human
-progress lines (`[Neo] Gathered 25 files…`), library warnings, and CAR version
-notices. Parse only lines beginning with `{`, and ignore the rest. stdout is
-not mixed — it is always exactly one JSON document.
+`--json` implies `--quiet`, so Neo's human progress lines are suppressed and
+stderr is essentially pure JSONL. It is not *guaranteed* pure: Python logging
+warnings and CAR version notices can still appear there. Parse only lines
+beginning with `{` and ignore the rest. stdout is never mixed — always exactly
+one JSON document.
 
 ## Communication protocol
 
@@ -79,8 +80,8 @@ JSON carries an `orchestrator` object built for exactly this purpose:
 
 | Field | Use |
 |---|---|
-| `summary` | Lead with it. One or two sentences on what Neo did and concluded. |
-| `personality` | Optional in-voice line. See below. |
+| `summary` | Lead with it. Neo's own account of what he did and concluded. |
+| `personality` | Optional extra beat. See below. |
 | `phase_summary` | Per-phase records. Use to explain a slow or unusual run. |
 | `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
 | `recommended_narration` | Advisory progress lines. Reword freely. |
@@ -100,22 +101,52 @@ Then:
    own reasoning as Neo's, or the reverse.
 6. Report Neo's confidence as the number it is. Do not round it up in prose.
 
-### Personality
+### Voice
 
-`orchestrator.personality` is present only when Neo's beat deck matched the
+Neo speaks in the first person, clipped and direct. Every string he emits —
+`orchestrator.summary`, each caution, each phase message, each event message —
+is already written in that voice.
+
+**The register shifts with how much Neo remembers about the project.** The same
+facts read differently at each of the five memory stages:
+
+| Stage | Summary |
+|---|---|
+| 1 Sleeper | `Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe. Confidence 0.88.` |
+| 3 Unplugged | `I read it. I'd change 1 thing(s) in src/parser.py. Confidence 0.88.` |
+| 5 The One | `src/parser.py. 1 change(s). 0.88.` |
+
+Do not normalize that away. A hedge at stage 1 is information — it tells the
+user Neo has no history with this codebase. Terseness at stage 5 is the same
+signal inverted. Cautions deliberately do **not** vary by stage.
+
+**Relay Neo's wording; do not translate it into your own register.** Rewriting
+"I'd change one thing" into "Neo has produced a suggestion" strips the
+character and, worse, blurs whose claim it is. Quote or pass through his lines,
+and keep your own analysis in your own voice so the two never merge.
+
+Two limits on this. Neo's voice is not a licence to soften facts: a caution
+stays a caution however tersely it is phrased. And when the moment is wrong —
+a production outage, a user under pressure — lead with the substance and let
+the styling fall away. Terse is Neo; performative is not.
+
+### Personality beats
+
+`orchestrator.personality` is an *additional* line, above and beyond the voice
+of everything else. It is present only when Neo's beat deck matched the
 situation and, for beats that claim insight, only when the run actually found
 something. It is already filtered — Neo withholds unearned lines rather than
 making you judge them.
 
 When present, relay it verbatim, attached to the substance that earned it:
 
-> Neo recalled a prior failure pattern here. In its words: "I've seen this
-> shape before. I know where it breaks."
+> Neo recalled a prior pattern here — "I've seen this shape before. Let me use
+> what I remember."
 
-Drop it when it would be repetitive within a conversation, when it conflicts
-with a higher-priority instruction, or when the moment is wrong — an outage
-being debugged under pressure is not the moment for voice. When the field is
-empty, say nothing in its place. There is no fallback line.
+Drop it when it would be repetitive within a conversation or when it conflicts
+with a higher-priority instruction. When the field is empty, say nothing in its
+place. There is no fallback line — and the rest of Neo's output is already in
+his voice, so nothing is lost.
 
 ## Event stream reference
 

--- a/.claude-plugin/commands/neo-architect.md
+++ b/.claude-plugin/commands/neo-architect.md
@@ -32,6 +32,22 @@ Neo will:
 3. Search memory for similar architectural decisions
 4. Provide recommendations with confidence scores and risk analysis
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`). For architecture specifically:
+
+- Lead with `orchestrator.summary`, then the recommendation.
+- Name the **alternatives considered and why each lost**. An architectural
+  recommendation without its rejected options is an opinion, not guidance.
+  `hypothesis_rejected` events and the plan's rationale fields carry this.
+- State the tradeoff Neo accepted, in the user's terms: what gets harder if
+  they follow this advice.
+- Surface `orchestrator.cautions` in full. Architecture mistakes are the
+  expensive kind to reverse.
+- Be explicit that this is advice, not a decision. Architectural context Neo
+  cannot see — team, timeline, politics — routinely dominates.
+
 ## Parameters
 
 This command uses `advise` mode. Architecture guidance is not automatically

--- a/.claude-plugin/commands/neo-debug.md
+++ b/.claude-plugin/commands/neo-debug.md
@@ -32,6 +32,21 @@ Neo will:
 3. Search memory for similar debugging scenarios
 4. Suggest debugging strategies and fixes with confidence scores
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`). For debugging specifically:
+
+- Lead with `orchestrator.summary`, then the leading hypothesis.
+- Report what was **ruled out**, not just what was concluded. Every
+  `hypothesis_rejected` event and every simulation issue in `risk_found`
+  narrows the search for the user — that is the substance of a debugging
+  session.
+- Say what evidence supports the leading hypothesis and what would falsify it.
+- If `memory_found` fired, say so: a prior occurrence of this failure is the
+  single most useful thing Neo can contribute.
+- Never present a hypothesis as a diagnosis. Neo does not run the code.
+
 ## Parameters
 
 This command uses read-only `advise` mode. It does not apply fixes, execute

--- a/.claude-plugin/commands/neo-optimize.md
+++ b/.claude-plugin/commands/neo-optimize.md
@@ -32,6 +32,22 @@ Neo will:
 3. Search memory for similar optimization patterns
 4. Suggest improvements with confidence scores
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`). For optimization specifically:
+
+- Lead with `orchestrator.summary`, then the identified bottleneck.
+- Show the **evidence** for the bottleneck — the complexity argument or the
+  code path Neo pointed at. An optimization claim with no evidence is a guess
+  wearing a confidence score.
+- State the expected impact and its basis. If Neo estimated rather than
+  measured, say "estimated". Neo does not execute or benchmark anything.
+- Recommend the user measure before and after. Any suggested benchmark
+  commands are advisory and are never run by Neo.
+- Surface `orchestrator.cautions`, especially correctness risks — a faster
+  wrong answer is a regression.
+
 ## Parameters
 
 This command uses read-only `advise` mode. Suggested benchmarks and commands are

--- a/.claude-plugin/commands/neo-pattern.md
+++ b/.claude-plugin/commands/neo-pattern.md
@@ -35,6 +35,20 @@ Neo will:
 This command uses explicit `learn` mode. The result is recorded only as an
 episode candidate and requires independent verified support before promotion.
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`). For pattern extraction specifically:
+
+- Lead with `orchestrator.summary`, then the pattern Neo identified.
+- Cite the instances the pattern was drawn from. A "pattern" with one example
+  is an anecdote — say how many occurrences Neo actually saw.
+- Report `memory_found` when the pattern matched something Neo already knew.
+  Recurrence across sessions is the strongest signal available here.
+- Be accurate about learning: this run records an episode **candidate**. It
+  does not mint a durable fact. Promotion needs two independent
+  git-verified acceptances. Do not tell the user Neo "learned" this.
+
 ## Parameters
 
 - `<target>` - Code area or pattern type (required)

--- a/.claude-plugin/commands/neo-review.md
+++ b/.claude-plugin/commands/neo-review.md
@@ -35,6 +35,22 @@ Neo will:
 This command uses read-only `advise` mode and performs no repository writes or
 durable learning updates.
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`). For a review specifically:
+
+- Lead with `orchestrator.summary`, then the findings themselves.
+- Group findings by severity, not by file. A security issue and a naming nit
+  are not peers.
+- Surface `risk_found` events and every entry in `orchestrator.cautions` —
+  a review that reads as clean because the caveats were trimmed is worse than
+  no review.
+- State which assumptions Neo challenged. "Neo disagreed with the existing
+  retry logic" is the useful half of a review.
+- Give the confidence number. A 0.55 review is a starting point for your own
+  reading, not a verdict — say so.
+
 ## Parameters
 
 - `<target>` - File path, module name, or code description (required)

--- a/.claude-plugin/commands/neo.md
+++ b/.claude-plugin/commands/neo.md
@@ -35,6 +35,20 @@ Neo will:
 This command uses `advise` mode. It reads and retrieves memory but does not create
 learning candidates, modify repository files, or execute commands.
 
+## Presentation
+
+Invoke with `--json` and follow the agent's communication protocol
+(`agents/neo.md`):
+
+- Say what you are asking Neo before invoking it.
+- Lead with `orchestrator.summary`, then the answer.
+- Surface every entry in `orchestrator.cautions`.
+- Relay `orchestrator.personality` verbatim when present, attached to the
+  finding that earned it. Say nothing in its place when it is absent.
+- Attribute clearly. "Neo found…" and "Looking at this myself…" are different
+  claims with different reliability, and the user needs to be able to tell
+  them apart.
+
 ## Parameters
 
 - `<question>` - Your question or task description (required)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ wheels/
 *.egg
 
 # Virtual environments
+# `.venv/` needs its own entry: `venv/` does not match it, and the Makefile and
+# pre-commit hook both look for `.venv/bin/python` — so the project's own
+# convention was one `git add -A` away from committing an entire interpreter.
+.venv/
 venv/
 env/
 ENV/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,10 +428,15 @@
   `--json` writes **two streams**: stdout is exactly ONE JSON document (now with
   an `orchestrator` key), stderr is JSONL events. They are deliberately NOT
   interleaved — the old `--json` help text promised events on one stream, and
-  honoring that literally would break every `neo --json | jq` consumer. stderr
-  is **mixed** (also `[Neo]` progress lines, library + CAR warnings), so hosts
-  parse lines starting with `{` and skip the rest; `--quiet` is defined in
-  `cli.py` but never read, so those lines can't currently be suppressed.
+  honoring that literally would break every `neo --json | jq` consumer.
+  `--json` implies `--quiet`, so stderr is *essentially* pure JSONL; logging
+  warnings and CAR notices can still land there, so hosts parse lines starting
+  with `{` and skip the rest. `--quiet` had been declared and never read — the
+  `[Neo]` notices now route through `neo.progress` (`note()`/`set_quiet()`)
+  instead of bare `print(file=sys.stderr)` calls scattered through
+  `context_gatherer`. The flag is process-global on purpose (a display setting
+  fixed once from argv, read five layers down); index-command **errors** stay
+  unsuppressed, because `--quiet` silences progress, not failures.
   `safe_emit` swallows sink exceptions — an observer must never take down the
   run it observes — logging the FIRST at WARNING and the rest at DEBUG so a
   broken sink stays findable; `NullSink` is the default, so an unobserved run
@@ -463,6 +468,23 @@
   remedies) and is CAPPED — a host is told never to drop one, so the list must
   stay relayable; anything dropped is reported as a count. `phase_summary`
   copies each record, not just the list (live engine state, foreign consumer).
+  **Voice is staged and lives in the deck, NOT in code.** Every user-facing
+  string comes from `orchestrator_voice.lines` in `neo_matrix.yaml` via
+  `engine._voice(key, **fmt)`; `_voice_stage()` picks opener/hedge/terseness
+  from `orchestrator_voice.stages` keyed on `_memory_level_to_stage()`, so the
+  same facts read `Don't know this code. … , maybe. Confidence 0.88.` at stage 1
+  and `src/parser.py. 1 change(s). 0.88.` at stage 5. A single fixed register
+  throws away a signal the system already computes.
+  `test_engine_holds_no_prose_of_its_own` pins the no-literals rule — a string
+  in `engine.py` is a personality change hidden in a code diff. `_voice`
+  degrades to `""` on a missing key/bad placeholder (a YAML slip must not kill a
+  run) and `_cap_cautions` drops blanks so a failed template isn't relayed as an
+  empty bullet. **Deliberate asymmetry**: cautions and progress messages do NOT
+  vary by stage — a host is told never to drop a caution, so a warning must read
+  the same at every stage; voice is not licence to soften a fact. LM-voiced
+  summaries were considered and rejected (a call per run + fabrication risk);
+  the system prompts already inject personality, so LM-authored prose is voiced
+  by inference and only the derived scaffolding is templated.
   Beat surface metadata (`surface`/`importance`/`requires_finding`/
   `orchestrator_line` in `neo_matrix.yaml`) gates personality: `requires_finding`
   beats stay silent unless the run actually found something, and there is NO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,66 @@
   fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
   the LM, then exits without making the LLM call. Faster iteration on context-gatherer
   and retrieval changes than waiting for an inference round trip.
+- Host communication (`neo.events` + `models.OrchestratorMessage`): the engine
+  reports lifecycle facts so a host (Claude Code, MCP, an IDE) doesn't have to
+  reverse-engineer presentation from raw plans. **Governing rule: Neo reports
+  facts about its process; the host decides how and when they become
+  conversation** — never put host-specific wording in `engine.py`.
+  `--json` writes **two streams**: stdout is exactly ONE JSON document (now with
+  an `orchestrator` key), stderr is JSONL events. They are deliberately NOT
+  interleaved — the old `--json` help text promised events on one stream, and
+  honoring that literally would break every `neo --json | jq` consumer. stderr
+  is **mixed** (also `[Neo]` progress lines, library + CAR warnings), so hosts
+  parse lines starting with `{` and skip the rest; `--quiet` is defined in
+  `cli.py` but never read, so those lines can't currently be suppressed.
+  `safe_emit` swallows sink exceptions — an observer must never take down the
+  run it observes — logging the FIRST at WARNING and the rest at DEBUG so a
+  broken sink stays findable; `NullSink` is the default, so an unobserved run
+  costs what it always did. Four **invariants**, all test-pinned: (1) findings
+  (`hypothesis_formed`/`risk_found`) are emitted BEFORE their phase closes;
+  (2) no event may claim a closed phase — `MEMORY_FOUND` fires from
+  `_capture_retrieval_context` (the funnel all fact-retrieval paths pass
+  through) which runs while REASONING is open, so it labels itself via
+  `_current_phase()`; (3) every `phase_completed` has a `phase_started` —
+  the budget-skip branch OPENS the phase before closing it `skipped`, and
+  `_end_phase`'s synthesize-on-missing fallback logs a WARNING so the next
+  caller bug is findable; (4) every run terminates with `completed` or
+  `FAILED` — `process()` emits `FAILED` from its except branch and marks
+  still-`running` records `failed`, because STARTED-then-silence is worse than
+  no events (a host can't tell a crash from a hang). The first phase is
+  `context` (file gathering), deliberately NOT `retrieval` — fact retrieval
+  happens during REASONING, and the old name forced every emitter inside it to
+  work around the overstatement. `_end_phase` reverse-searches for the newest
+  open record because a failed panel closes `reasoning` as `fallback` and the
+  fast path opens a second one.
+  `_build_orchestrator_message` is **pure derivation** — no LM call, no new
+  analysis; every claim must be defensible from the rest of the `NeoOutput`.
+  **VERIFY mode gets its own sentence**: it makes no LM call and its
+  `code_suggestions` are the CALLER's `proposed_changes` echoed back, so the
+  generic "Neo reasoned … and proposes N change(s)" credited Neo with the
+  caller's work; it also suppresses the low-confidence caution (VERIFY
+  confidence is a pass/fail verdict, so "verify before acting" is circular).
+  `cautions` distinguishes no-tools from skipped-for-budget (different
+  remedies) and is CAPPED — a host is told never to drop one, so the list must
+  stay relayable; anything dropped is reported as a count. `phase_summary`
+  copies each record, not just the list (live engine state, foreign consumer).
+  Beat surface metadata (`surface`/`importance`/`requires_finding`/
+  `orchestrator_line` in `neo_matrix.yaml`) gates personality: `requires_finding`
+  beats stay silent unless the run actually found something, and there is NO
+  fallback line — silence is the default. **One beat per run** (`_run_beat`
+  selects once and caches): `_generate_notes` and `_orchestrator_beat` both read
+  it, and `--json` carries both, so independent selection let one character
+  speak with two voices. `_select_beat` derives `memory_hit`/`no_memory_match`
+  from real recall state — without them `unfamiliar_codebase` was configured,
+  surfaceable and **unreachable**, i.e. dead text that a "declares its wording"
+  test can't catch; `test_every_declared_beat_can_actually_fire` pins
+  reachability itself. Beat lines must not outrun their trigger (a single
+  traceback is not "multiple failures"; the keyword *fix* does not establish
+  something "used to work"). No `cooldown`/`max_uses`: one process
+  selects at most one beat, so in-process cooldown is a no-op and cross-run
+  needs session state that doesn't exist. The plugin contract that consumes all
+  this lives in `.claude-plugin/agents/neo.md`. See
+  `docs/solutions/orchestrator-communication.md`.
 - CarAdapter defaults `intent_hint={"task":"code","prefer_quality":True}` so CAR's router
   routes neo to the most capable model, not the chat/cost default. This is the *intended*
   router API, not a hack:

--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ Neo is one binary with a plain-text prompt plus a handful of subcommands. Run
 | `--diff-since REV` | Prioritize files changed since a git rev or duration |
 | `--no-git` / `--no-scan` | Skip git heuristics / skip the directory scan entirely |
 | `--stdin-json` / `--stdin-text` | Force the stdin input mode instead of auto-detecting |
+| `--quiet` | Suppress the `[Neo]` progress notices on stderr (implied by `--json`) |
 | `--verbose` / `--debug` | INFO / DEBUG logging to stderr |
 | `--allow-write-path GLOB` / `--allow-command CMD` | `agent`-mode authority grants (repeatable) |
 | `--config {list,get,set,reset}` | Configuration management — see [Configuration](#configuration) |
@@ -686,8 +687,16 @@ Phase names are stable: `context`, `reasoning`, `static_checks`. `context`
 covers file gathering only — fact retrieval runs during `reasoning`, which is
 why `memory_found` above carries `phase: reasoning`.
 
-stderr is a **mixed** stream — it also carries `[Neo]` progress lines and
-library warnings. Parse lines beginning with `{` and ignore the rest.
+`--json` implies `--quiet`, so the `[Neo]` progress lines are suppressed and
+stderr is essentially pure JSONL. Logging warnings can still appear there, so
+parse lines beginning with `{` and ignore the rest.
+
+Neo's wording shifts with how much he remembers about the project — the same
+run reads `Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe.
+Confidence 0.88.` at memory stage 1 and `src/parser.py. 1 change(s). 0.88.` at
+stage 5. All of it is authored in
+[`neo_matrix.yaml`](src/neo/config/beats/neo_matrix.yaml) under
+`orchestrator_voice`, not in code.
 
 The stdout document adds an `orchestrator` object stating what the run did, so
 a host doesn't have to infer presentation from raw plans and traces:

--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ Neo is one binary with a plain-text prompt plus a handful of subcommands. Run
 | `--mode {advise,patch,verify,learn,agent}` | Operating mode; default `learn` — see [Operating Modes](#operating-modes) |
 | `--fast` / `--deep` | Force the single-call path / force multi-agent deliberation (default is `auto`, which gates on novelty + CAR availability) |
 | `--dry-run` | Assemble and print the full context, then exit without an LLM call |
-| `--json` | Emit JSONL progress events plus a final JSON object (also the JSON *input* path) |
+| `--json` | JSONL progress events on **stderr**, one final JSON object on **stdout** (also the JSON *input* path) — see [Orchestrator output](#orchestrator-output) |
 | `--output-schema NAME_OR_PATH` | Constrain the shape of the final JSON response |
 | `--index` / `--update` / `--languages CSV` | Build, incrementally refresh, and scope the per-project semantic index |
 | `--semantic` | Use the semantic index for file selection (requires `.neo/index.json`) |
@@ -655,6 +655,61 @@ workspace-rooted authority policy and a host-provided execution adapter. Neo has
 no built-in shell or repository executor, never invokes generated command
 strings, and the standalone CLI fails closed for `agent`. See the
 [operating-mode contract](docs/solutions/operating-modes.md).
+
+### Orchestrator output
+
+`--json` writes two streams so a host can narrate a run instead of waiting on a
+black box:
+
+- **stdout** — exactly one JSON document. Safe to pipe: `neo --json … | jq`.
+- **stderr** — JSONL lifecycle events, one object per line, flushed as they happen.
+
+```bash
+neo --json --mode advise "why is the parser crashing on empty input?"
+```
+
+```jsonc
+// stderr, as the run progresses
+{"type":"phase_completed","phase":"context","message":"Read 25 file(s) of context.","data":{"status":"complete"}}
+{"type":"phase_started","phase":"reasoning","message":"Planning, simulating, and drafting changes."}
+{"type":"memory_found","phase":"reasoning","message":"Recalled 20 relevant fact(s) from memory.","data":{"count":20}}
+{"type":"risk_found","phase":"reasoning","message":"callers may not handle None","data":{"source":"simulation"}}
+{"type":"completed","message":"…","data":{"confidence":0.9,"elapsed_seconds":25.98}}
+```
+
+Event types: `started`, `phase_started`, `phase_completed`, `memory_found`,
+`hypothesis_formed`, `hypothesis_rejected`, `risk_found`, `personality_beat`,
+`completed`, `failed`. Exactly one of `completed` or `failed` terminates every
+run; on `failed`, stdout is an `{"error": …}` object with no `orchestrator` key.
+
+Phase names are stable: `context`, `reasoning`, `static_checks`. `context`
+covers file gathering only — fact retrieval runs during `reasoning`, which is
+why `memory_found` above carries `phase: reasoning`.
+
+stderr is a **mixed** stream — it also carries `[Neo]` progress lines and
+library warnings. Parse lines beginning with `{` and ignore the rest.
+
+The stdout document adds an `orchestrator` object stating what the run did, so
+a host doesn't have to infer presentation from raw plans and traces:
+
+```json
+{
+  "orchestrator": {
+    "summary": "Neo reasoned over the request and proposes 1 change(s) in src/parser.py. Confidence 0.90.",
+    "personality": "I've seen this shape before. Let me use what I remember.",
+    "phase_summary": [{"name": "reasoning", "status": "complete", "message": "…"}],
+    "cautions": ["Simulation surfaced 1 issue(s) with the proposed approach."],
+    "recommended_narration": ["Read 25 file(s) of context.", "…"]
+  }
+}
+```
+
+`cautions` is the field to never drop — low confidence, failed checks, and open
+questions live there. `personality` is present only when a beat matched and,
+for beats that claim insight, only when the run actually found something; there
+is no fallback line. Embedding hosts should read
+[the presentation contract](.claude-plugin/agents/neo.md) and
+[the design notes](docs/solutions/orchestrator-communication.md).
 
 ### Goal-aware agent-loop envelope
 

--- a/docs/solutions/orchestrator-communication.md
+++ b/docs/solutions/orchestrator-communication.md
@@ -1,0 +1,235 @@
+# Solution: Orchestrator Communication — Lifecycle Events + a Host-Facing Summary
+
+**Date**: 2026-08-05
+**Status**: Implemented
+**Type**: design + implementation
+
+## Implementation summary
+
+| Piece | Module | Tests |
+|---|---|---|
+| Event vocabulary + sinks (`Null`/`Recording`/`Jsonl`) | `events.py` | `test_orchestrator_events.py` |
+| Engine emission at phase boundaries | `engine.py` (`_emit`, `_begin_phase`, `_end_phase`, `_current_phase`) | `test_orchestrator_events.py` |
+| Derived host summary | `engine.py` (`_build_orchestrator_message`), `models.py` (`OrchestratorMessage`) | `test_orchestrator_events.py` |
+| CLI stream split | `cli.py` (`--json` → `JsonlSink(sys.stderr)`) | (live-verified; see below) |
+| Beat surface metadata | `config/beats/neo_matrix.yaml`, `engine._orchestrator_beat` | `test_orchestrator_events.py` |
+| Plugin presentation contract | `.claude-plugin/agents/neo.md`, `commands/*.md` | — |
+
+## The problem
+
+`engine.py` made **zero** print or stderr calls. A host — Claude Code, an MCP
+server, an IDE — saw nothing between invoking Neo and receiving the final
+`NeoOutput`, which left it narrating a black box for 5–30 seconds.
+
+Worse, the Claude Code plugin told the agent to run `neo --mode advise` and
+parse the **human-readable text** output, even though `--json` already existed.
+So the host was reverse-engineering presentation out of terminal formatting
+while a fully structured document sat one flag away. Every host that did this
+would reinvent the same inference, badly and differently.
+
+## The contract
+
+> Neo reports facts about its process. The host decides how and when those
+> facts become conversation.
+
+That line governs both halves. `events.py` and `OrchestratorMessage` carry
+phase names, counts, and findings — never host-specific wording, never an
+instruction to say something. `NeoEngine` does not know which host it is
+talking to, and adding a second host must not require touching it.
+
+## Stream split
+
+`--json` writes **two** streams:
+
+- **stdout** — exactly one JSON document. Unchanged shape plus an
+  `orchestrator` key.
+- **stderr** — JSONL events, one object per line, flushed per event.
+
+Events deliberately do **not** interleave into stdout. The `--json` help text
+used to promise "JSONL events and final JSON" on one stream; honoring that
+literally would have broken every existing `neo --json | jq` consumer. The help
+text was corrected to describe the split.
+
+stderr is a **mixed** stream — it also carries `[Neo] …` progress lines from
+`context_gatherer`, library warnings, and CAR version notices. Hosts parse
+lines beginning with `{` and ignore the rest. (`--quiet` exists in `cli.py` but
+is never read; suppressing those lines is a separate fix.)
+
+## Phase records and ordering
+
+`_phase_records` accumulates `{name, status, message}` per run, reset at the
+top of `process()`, and is replayed into `OrchestratorMessage.phase_summary`.
+Four invariants are load-bearing and pinned by tests:
+
+1. **Findings precede their phase's close.** A host replaying the stream must
+   learn *what was found* before being told the phase finished. The reasoning
+   phase therefore holds its summary in a local and calls `_end_phase` after
+   emitting `hypothesis_formed` / `risk_found`, rather than closing inside each
+   branch.
+2. **No event claims a closed phase.** `MEMORY_FOUND` is emitted from
+   `_capture_retrieval_context`, the funnel every fact-retrieval path passes
+   through — but that runs while the *reasoning* phase is open. `_current_phase()`
+   reports the open record instead of a hardcoded name. Caught in a live run.
+3. **Every close has an open.** The budget-skip branch originally emitted
+   `phase_completed` for `static_checks` with no `phase_started`, leaving a host
+   tracking a close for something it never saw open. It now opens the phase and
+   closes it `skipped`. `_end_phase`'s synthesize-on-missing fallback stays as a
+   backstop but now logs a WARNING, so the next caller bug is findable rather
+   than silently absorbed.
+4. **Every run has a terminator.** `process()` emits `FAILED` from its except
+   branch and marks any still-`running` record `failed`. Emitting `STARTED` and
+   then going silent was worse than never emitting: a host could not distinguish
+   a crash from a hang.
+
+The first phase is named `context`, **not** `retrieval` — it covers file
+gathering only. The original name overstated its span, which is what forced
+`MEMORY_FOUND` to work around it. A phase whose name overstates what it covers
+makes every emitter inside it either lie or compensate.
+
+`_end_phase` searches records in reverse for the newest open one because a
+phase can legitimately run twice: a failed panel closes `reasoning` with
+`status="fallback"` and the fast path opens a second `reasoning` record.
+
+## Sinks never break the run
+
+`safe_emit` swallows sink exceptions. A closed pipe, a full disk, or a
+third-party sink bug must degrade to "no progress reporting", never to a failed
+reasoning run — the observer must not take down the thing it observes. The
+default sink is `NullSink`, so an unobserved run costs exactly what it did
+before events existed.
+
+## Personality is gated, not decorative
+
+The beat deck already keyed beats on `category` + `trigger_contexts`, so beats
+were never random flavor. What was missing was a decision about *audience*.
+Each beat now declares:
+
+- `surface` — `orchestrator` lets a host relay it; anything else (or absent)
+  keeps it terminal-only.
+- `importance` — advisory ranking for hosts that surface at most one line.
+- `requires_finding` — when true, the beat is withheld unless the run actually
+  produced a finding (a recalled fact, a simulation issue, a failed check).
+  Beats that *claim* insight must earn it; beats that merely describe the
+  situation need not.
+- `orchestrator_line` — the host-facing wording.
+
+`_orchestrator_beat` returns `""` — silence — whenever the deck did not match,
+the beat is internal, or a finding was required and none exists. There is no
+fallback line. Unattached flavor text is what makes a tool read as theater.
+
+One line per beat rather than one per memory stage: the situation carries the
+meaning, and five near-identical variants would be upkeep with no
+reader-visible payoff.
+
+**One beat per run.** `_run_beat` selects once and caches; both `_generate_notes`
+and `_orchestrator_beat` read it. Selecting independently per surface let them
+pick different beats from the same run — and `--json` carries both `notes` and
+`orchestrator.personality`, so one character would speak with two voices in a
+single response.
+
+**Lines must not outrun their trigger.** Three beats originally asserted more
+than their trigger established: `error_cascade` claimed "multiple failures, one
+root" from a single traceback, `critical_bug` claimed "something broke that used
+to work" from the keyword *fix*, and `pattern_match` claimed "I know where it
+breaks" when the `requires_finding` gate only proves *something* was recalled —
+possibly a style rule. All three were reworded to what the trigger supports.
+
+**A configured beat that can never fire is dead text.** `unfamiliar_codebase`
+declared `first_time_codebase` / `unfamiliar_domain` / `no_memory_match`, none
+of which `_select_beat` ever produced — so its line was unreachable and the
+"every surfaceable beat declares its wording" test gave false assurance.
+`_select_beat` now derives `memory_hit` / `familiar_pattern` /
+`no_memory_match` from actual recall state, which also makes `pattern_match`
+reachable by memory rather than only by confidence.
+`test_every_declared_beat_can_actually_fire` pins the reachability property
+itself, not just the presence of a string.
+
+**No `cooldown` / `max_uses`.** Each `neo` invocation is a fresh process that
+selects at most one beat, so an in-process cooldown is a no-op and a cross-run
+one needs session state that does not exist. Better absent than faked.
+
+## Derived, never generated
+
+`_build_orchestrator_message` makes no LM call and performs no new analysis. It
+is pure derivation from state already computed — plan, suggestions, simulation
+issues, static-check statuses, confidence, reasoning mode. Every claim must be
+defensible from the rest of the `NeoOutput`, because a host that repeats an
+unearned summary is worse than one that says nothing.
+
+**VERIFY mode gets its own sentence.** That path makes no LM call, and its
+`code_suggestions` are the *caller's* `proposed_changes` echoed back for
+checking. The generic wording ("Neo reasoned over the request and proposes N
+change(s)") credited Neo with work it did not do and would have been relayed
+verbatim by a host told to lead with the summary. VERIFY also suppresses the
+low-confidence caution: its confidence is a pass/fail verdict, not
+self-assessed certainty, so "verify before acting" is circular there.
+
+`cautions` is the field that matters most: low confidence, failed checks,
+simulation issues, absent static analysis, open questions. The plugin contract
+requires hosts to surface all of them. A confident-sounding recommendation must
+not bury the reasons to doubt it. Two consequences:
+
+- "No static analysis ran" is split into **no tools installed** versus
+  **skipped for time budget**. Same absence, different remedies; the phase
+  record already knows which happened.
+- The list is **capped** (`MAX_CAUTIONS`, `MAX_CAUTION_CHARS`). A host is told
+  never to drop a caution, so the list has to stay relayable — and failed-check
+  summaries are unbounded LM prose. Anything dropped is reported as a count,
+  never silently discarded, because "there are more problems" is itself
+  something a host must not bury.
+
+`phase_summary` copies each record, not just the list. These dicts are live
+engine state and the object is handed to foreign consumers.
+
+## Sink failures are findable
+
+`safe_emit` logs the **first** failure at WARNING and the rest at DEBUG. Logging
+every failure at DEBUG (the original) meant a permanently broken sink was
+invisible at normal log levels — the swallow policy is right, but silence about
+it is not.
+
+Note what `safe_emit` does *not* cover: `NeoEvent(...)` is constructed in
+`_emit` before the guard is reached, so a formatting bug in emission code still
+raises. Message construction is kept to attribute reads on values already
+proven non-None at that point.
+
+## Verification
+
+- Full suite: 1568 passed, 8 skipped. `ruff check src/ tests/` clean.
+- 37 tests in `test_orchestrator_events.py` covering sink behavior, event
+  ordering, the four phase invariants, summary derivation, beat gating and
+  reachability, and the VERIFY / budget-skip / panel-fallback / failure
+  branches. 4 more in `test_repair_loop.py`.
+- Live end-to-end runs against a real LLM confirming the stdout/stderr split,
+  single-parse stdout, and event ordering.
+
+## Incidental fixes
+
+- `repair_loop.py:149` imported `from structured_parser import …` —
+  unqualified, and therefore unresolvable inside the installed package. Every
+  repair attempt died on `ModuleNotFoundError` **and the attempt loop's
+  `except` swallowed it**, so the feature reported a generic "failed to repair"
+  and looked merely ineffective rather than broken. Dead since the initial
+  public release because nothing tested it; `test_repair_loop.py` now does.
+- The static-check skip logged `elapsed/time_budget*100` unguarded. A zero
+  budget is not reachable through `_get_time_budget` today, but a *log line*
+  must never be what crashes a run.
+
+## Known limits
+
+- A `Bash` tool call does not stream, so JSONL buys accurate **post-hoc**
+  narration, not a live progress bar. Nothing short of a hook or an MCP server
+  changes that. `JsonlSink` still flushes per event, for hosts that can stream.
+- `NeoEngine` is single-request-at-a-time. `_phase_records` / `_findings` /
+  `_selected_beat` are per-request instance state, following the same pattern as
+  `self.context`, `last_applied_actions`, and `current_learning_episode` — so
+  this adds no new class of bug, but hosts are exactly the population likely to
+  share one engine across a thread pool. The `StructuredOverseer` watchdog is
+  *not* a hazard: it only reads `action_log`.
+- `_timeout_response` builds a bare `NeoOutput` and so carries an empty
+  orchestrator envelope. It is currently unreachable (neither it nor
+  `_check_timeout` has a caller); wire the message in if it is ever revived.
+- `--quiet` is defined but never read, so `[Neo]` progress lines cannot be
+  suppressed under `--json`.
+- `JsonlSink` is not thread-safe; interleaved writes could split a line. Only
+  the main thread emits today.

--- a/docs/solutions/orchestrator-communication.md
+++ b/docs/solutions/orchestrator-communication.md
@@ -12,7 +12,8 @@
 | Engine emission at phase boundaries | `engine.py` (`_emit`, `_begin_phase`, `_end_phase`, `_current_phase`) | `test_orchestrator_events.py` |
 | Derived host summary | `engine.py` (`_build_orchestrator_message`), `models.py` (`OrchestratorMessage`) | `test_orchestrator_events.py` |
 | CLI stream split | `cli.py` (`--json` → `JsonlSink(sys.stderr)`) | (live-verified; see below) |
-| Beat surface metadata | `config/beats/neo_matrix.yaml`, `engine._orchestrator_beat` | `test_orchestrator_events.py` |
+| Staged voice + beat surface metadata | `config/beats/neo_matrix.yaml` (`orchestrator_voice`), `engine._voice` / `_voice_stage` / `_orchestrator_beat` | `test_orchestrator_events.py` |
+| Progress-notice suppression (`--quiet`) | `progress.py`, `cli.py`, `context_gatherer.py` | `test_progress_quiet.py` |
 | Plugin presentation contract | `.claude-plugin/agents/neo.md`, `commands/*.md` | — |
 
 ## The problem
@@ -50,10 +51,20 @@ used to promise "JSONL events and final JSON" on one stream; honoring that
 literally would have broken every existing `neo --json | jq` consumer. The help
 text was corrected to describe the split.
 
-stderr is a **mixed** stream — it also carries `[Neo] …` progress lines from
-`context_gatherer`, library warnings, and CAR version notices. Hosts parse
-lines beginning with `{` and ignore the rest. (`--quiet` exists in `cli.py` but
-is never read; suppressing those lines is a separate fix.)
+`--json` implies `--quiet`, so Neo's own `[Neo] …` progress notices are
+suppressed and stderr is essentially pure JSONL. It is not *guaranteed* pure —
+Python logging warnings and CAR version notices can still land there — so hosts
+still parse lines beginning with `{` and ignore the rest.
+
+`--quiet` had been declared in the parser and never read, so those notices
+could not be turned off at all. They are now routed through `neo.progress`
+(`note()` / `set_quiet()`) rather than bare `print(..., file=sys.stderr)` calls
+scattered across `context_gatherer`. The suppression flag is process-global
+rather than a threaded parameter: it is a display setting fixed once from argv
+and read by leaf functions five layers below the CLI, and passing it down would
+put a presentation argument into the signature of every scoring helper it
+crosses. Index-command *errors* deliberately stay unsuppressed — `--quiet`
+silences progress, not failures.
 
 ## Phase records and ordering
 
@@ -97,6 +108,47 @@ third-party sink bug must degrade to "no progress reporting", never to a failed
 reasoning run — the observer must not take down the thing it observes. The
 default sink is `NullSink`, so an unobserved run costs exactly what it did
 before events existed.
+
+## Voice: staged, and authored in the deck
+
+Neo speaks in the first person. Narrating himself in the third person ("Neo
+reasoned over the request and proposes 1 change(s)") reads like a status board,
+not like the character the beat deck already defines — and the summary is the
+line a host is told to lead with, so it sets the register for the whole
+response.
+
+Two rules make that more than a find-and-replace:
+
+**The register follows memory level.** `_voice_stage()` reads
+`_memory_level_to_stage()` and selects an opener, a hedge, and a terseness flag
+from `orchestrator_voice.stages`. The same facts render as
+`Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe.
+Confidence 0.88.` at stage 1 and `src/parser.py. 1 change(s). 0.88.` at stage 5.
+A single fixed register would have been a regression dressed as a feature: it
+throws away a signal the system already computes, and the hedge at stage 1 is
+genuinely informative — it tells the user Neo has no history here.
+
+**No prose lives in `engine.py`.** Every user-facing string comes from
+`orchestrator_voice.lines` via `_voice(key, **fmt)`, so the character can be
+retuned by editing a YAML file. `test_engine_holds_no_prose_of_its_own` pins
+that: a string literal in the engine is a personality change hidden inside a
+code diff nobody reviews as one. A missing key or a bad placeholder degrades to
+`""` rather than raising — a formatting slip in a personality file must never
+take down a reasoning run — and `_cap_cautions` drops blanks so a failed
+template can't become an empty bullet a host dutifully relays.
+
+**Deliberate asymmetry: cautions do not vary by stage.** A host is instructed
+never to drop a caution, so a warning must read the same whether Neo is a
+Sleeper or The One. Voice is not licence to soften a fact. Same for phase and
+lifecycle messages — they stay in Neo's voice but at one register, because five
+variants of "Reading the code." would be upkeep with no reader-visible payoff.
+
+An LM-voiced summary was considered and rejected for now: it would cost a call
+and latency on every run and could fabricate or drop a claim — exactly the
+"narrator that lies" failure the first review caught. The system prompts
+(`_get_planning_system_prompt` and friends) already inject Neo's personality
+into the model, so the plan descriptions and rationales the LM returns are
+voiced by inference; only the derived scaffolding is templated.
 
 ## Personality is gated, not decorative
 
@@ -229,7 +281,11 @@ proven non-None at that point.
 - `_timeout_response` builds a bare `NeoOutput` and so carries an empty
   orchestrator envelope. It is currently unreachable (neither it nor
   `_check_timeout` has a caller); wire the message in if it is ever revived.
-- `--quiet` is defined but never read, so `[Neo]` progress lines cannot be
-  suppressed under `--json`.
 - `JsonlSink` is not thread-safe; interleaved writes could split a line. Only
   the main thread emits today.
+- stderr is *essentially* pure JSONL under `--json`, not guaranteed pure:
+  Python logging warnings and CAR version notices still land there. Those are
+  diagnostics, not progress, and `--quiet` correctly leaves them alone.
+- The staged voice is templated, not generated. Within a stage the phrasing is
+  fixed; only the stage varies. An LM-voiced summary would be more varied at
+  the cost of a call per run and a fabrication risk.

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -37,6 +37,7 @@ from neo.models import (  # noqa: E402, F401
     CodeSuggestion, StaticCheckResult, NeoOutput, RegenerateStats, LMAdapter,
     ProposedChange, classify_task_type,
 )
+from neo import progress  # noqa: E402
 from neo.operating_mode import AuthorityPolicy, OperatingMode  # noqa: E402
 from neo.execution_context import execution_fields_from_dict  # noqa: E402
 
@@ -450,7 +451,8 @@ def parse_args():
     p.add_argument("--split", default="train", help="Dataset split (train/test/validation)")
     p.add_argument("--columns", metavar="JSON", help="Column mapping JSON (e.g., '{\"text\":\"pattern\"}')")
     p.add_argument("--limit", type=int, default=1000, help="Max samples to import (default: 1000)")
-    p.add_argument("--quiet", action="store_true", help="Suppress progress output")
+    p.add_argument("--quiet", action="store_true",
+                   help="Suppress [Neo] progress notices on stderr (implied by --json)")
     return p.parse_args()
 
 
@@ -575,6 +577,14 @@ def main():
 
     # Configure logging early so all subsequent code can log
     _configure_logging(args)
+
+    # Progress notices are prose for a human. `--json` means the caller is a
+    # program, and the JSONL event stream already carries this information in a
+    # parseable form on the same stream — leaving the prose in would force every
+    # host to filter it back out.
+    progress.set_quiet(
+        bool(getattr(args, "quiet", False) or getattr(args, "json", False))
+    )
 
     # Check for updates (non-blocking, silent on failure)
     # Skip if running certain commands to avoid noise
@@ -805,7 +815,7 @@ def main():
                 greeting = base.get("internal", "")
 
             if greeting:
-                print(f"[Neo] {greeting}", file=sys.stderr)
+                progress.note(greeting)
 
         except Exception:
             pass  # Greeting is cosmetic — never block the pipeline
@@ -942,8 +952,8 @@ def main():
 
             # Print summary to stderr
             total_bytes = sum(gf.bytes for gf in gathered)
-            print(f"[Neo] Gathered {len(gathered)} files ({total_bytes:,} bytes)", file=sys.stderr)
-            print("[Neo] Invoking LLM inference...", file=sys.stderr)
+            progress.note(f"Gathered {len(gathered)} files ({total_bytes:,} bytes)")
+            progress.note("Invoking LLM inference...")
 
             if args.dry_run:
                 print("\n=== DRY RUN: Context that would be sent ===\n", file=sys.stderr)

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -426,7 +426,8 @@ def parse_args():
     )
 
     p.add_argument("prompt", nargs="?", help="Plain text prompt (or use stdin)")
-    p.add_argument("--json", action="store_true", help="Print JSONL events and final JSON")
+    p.add_argument("--json", action="store_true",
+                   help="Emit JSONL progress events on stderr and the final JSON result on stdout")
     p.add_argument("--output-schema", metavar="NAME_OR_PATH", help="Control final response shape")
     p.add_argument("--max-bytes", type=int, default=300_000, help="Hard cap for total context bytes")
     # Default is None, not a number, because this flag feeds two different
@@ -1007,10 +1008,15 @@ def main():
 
     # Create engine and process (with codebase root for per-codebase learning)
     try:
+        # Progress events go to stderr, never stdout. stdout stays exactly one
+        # JSON document so `neo --json | jq` and every existing consumer keeps
+        # working; a host that wants live progress reads the other stream.
+        from neo.events import JsonlSink
         engine = NeoEngine(
             lm_adapter=adapter,
             codebase_root=neo_input.working_directory,
-            config=config
+            config=config,
+            event_sink=JsonlSink(sys.stderr) if args.json else None,
         )
         output = engine.process(neo_input)
     except TimeoutError as e:
@@ -1140,6 +1146,7 @@ def main():
                 if output.strategy_assessment else None
             ),
             "recommended_next_action": output.recommended_next_action,
+            "orchestrator": asdict(output.orchestrator),
         }
 
         # Add confidence interpretation for better UX
@@ -1160,6 +1167,14 @@ def main():
             print("\n" + "="*80)
             print(f"CONFIDENCE: {output.confidence:.2f}")
             print("="*80)
+
+            # The same summary a host would relay, so the terminal reader and
+            # the orchestrated reader are told the same story.
+            if output.orchestrator.summary:
+                print(f"\n{output.orchestrator.summary}")
+            if output.orchestrator.cautions:
+                for caution in output.orchestrator.cautions:
+                    print(f"  ! {caution}")
 
             if output.notes:
                 print(f"\n{output.notes}\n")

--- a/src/neo/config/beats/neo_matrix.yaml
+++ b/src/neo/config/beats/neo_matrix.yaml
@@ -36,10 +36,37 @@ base_expressions:
     notes_tone: "Done."
 
 # Dramatic beats (situational personality moments)
+#
+# Surface metadata (read by engine._orchestrator_beat):
+#   surface           where the beat may appear. "internal" = notes only.
+#                     "orchestrator" = a host (Claude Code, an IDE) may also
+#                     relay it to the user. Absent means internal.
+#   importance        low | medium | high. Advisory ranking for hosts that
+#                     surface at most one line.
+#   requires_finding  when true the beat is withheld unless the run actually
+#                     produced a finding (a recalled fact, a simulation issue,
+#                     a failed check). Beats that CLAIM insight must earn it;
+#                     beats that merely describe the situation need not.
+#   orchestrator_line the host-facing wording. One line per beat rather than
+#                     one per memory stage: the situation carries the meaning,
+#                     and five near-identical variants would be upkeep with no
+#                     reader-visible payoff.
+#
+# No cooldown/max_uses field. Each `neo` invocation is a fresh process that
+# selects at most one beat, so an in-process cooldown would be a no-op and a
+# cross-run one would need session state that does not exist. Better absent
+# than faked.
 beats:
   # DOUBT category (triggered by failures, low confidence)
   - beat_id: "error_cascade"
     category: "doubt"
+    surface: "orchestrator"
+    importance: "high"
+    # A single traceback is the common case here, and the line must not assert
+    # a cascade the run has not established. Gated on a finding AND worded to
+    # what one traceback actually supports.
+    requires_finding: true
+    orchestrator_line: "There's a failure here. I'm looking for what's underneath it."
     trigger_contexts:
       - "error_trace_present"
       - "multiple_failures"
@@ -62,6 +89,10 @@ beats:
 
   - beat_id: "unfamiliar_codebase"
     category: "doubt"
+    surface: "orchestrator"
+    importance: "medium"
+    requires_finding: false
+    orchestrator_line: "I have no memory of this codebase. Treat what follows as a first read."
     trigger_contexts:
       - "first_time_codebase"
       - "unfamiliar_domain"
@@ -84,6 +115,13 @@ beats:
   # CHALLENGE category (high-stakes debugging, complex problems)
   - beat_id: "critical_bug"
     category: "challenge"
+    surface: "orchestrator"
+    importance: "high"
+    # Fires on a prompt keyword alone ("fix", "bug", "error"), which does not
+    # establish that anything previously worked. Worded to the ask, not to an
+    # assumed history.
+    requires_finding: false
+    orchestrator_line: "You're chasing a break. Let's find where it actually starts."
     trigger_contexts:
       - "bugfix"
       - "error_trace"
@@ -106,6 +144,11 @@ beats:
 
   - beat_id: "complex_refactor"
     category: "challenge"
+    surface: "orchestrator"
+    importance: "medium"
+    # Fires on the word "refactor" alone, which says nothing about coupling.
+    requires_finding: false
+    orchestrator_line: "Refactors live or die on the seams. Let me look there first."
     trigger_contexts:
       - "refactor"
       - "architecture"
@@ -128,6 +171,10 @@ beats:
   # BREAKTHROUGH category (algorithmic insights, pattern recognition)
   - beat_id: "algorithm_insight"
     category: "breakthrough"
+    surface: "orchestrator"
+    importance: "high"
+    requires_finding: true
+    orchestrator_line: "The obvious answer is probably the wrong one here."
     trigger_contexts:
       - "algorithm"
       - "optimization"
@@ -150,6 +197,13 @@ beats:
   # RECOGNITION category (high confidence, proven patterns)
   - beat_id: "pattern_match"
     category: "recognition"
+    surface: "orchestrator"
+    importance: "medium"
+    # The gate proves something was recalled, not that the recalled thing is
+    # about failure — so the line claims recognition, not knowledge of the
+    # break. "I know where it breaks" was earned by remembering a style rule.
+    requires_finding: true
+    orchestrator_line: "I've seen this shape before. Let me use what I remember."
     trigger_contexts:
       - "high_confidence"
       - "familiar_pattern"

--- a/src/neo/config/beats/neo_matrix.yaml
+++ b/src/neo/config/beats/neo_matrix.yaml
@@ -7,6 +7,100 @@ theme: "Uncertain debugger → The One who sees through the code"
 emotional_core: "What is real? Show me the stack trace."
 context: "Code assistance tool (planning, simulation, static checks, suggestions)"
 
+# ---------------------------------------------------------------------------
+# Orchestrator voice: how Neo speaks to a host (Claude Code, an IDE, an MCP
+# server) about his own run. Every user-facing string the engine emits comes
+# from here — engine.py holds no prose of its own, so the character can be
+# retuned without touching code.
+#
+# `stages` varies with memory level, because Neo's certainty does. A Sleeper
+# hedges; The One says two words. `lines` are the fact templates those stages
+# wrap, and `.format()` fills them.
+#
+# Deliberate asymmetry: the SUMMARY varies by stage, cautions and progress do
+# not. A warning's legibility must not depend on how much Neo happens to
+# remember — a host is told never to drop a caution, so a caution must read the
+# same at stage 1 and stage 5. Voice is not licence to soften a fact.
+orchestrator_voice:
+  stages:
+    1:  # Sleeper — hedging, unsure
+      opener_solo: "Don't know this code."
+      opener_panel: "Didn't trust myself alone here."
+      hedge: ", maybe"
+      confidence_lead: "Confidence"
+      terse: false
+    2:  # Glitch — sensing a pattern, still unsure
+      opener_solo: "Something here feels familiar."
+      opener_panel: "Wanted other eyes on this."
+      hedge: ", I think"
+      confidence_lead: "Confidence"
+      terse: false
+    3:  # Unplugged — direct, sees it
+      opener_solo: "I read it."
+      opener_panel: "I didn't work this alone."
+      hedge: ""
+      confidence_lead: "Confidence"
+      terse: false
+    4:  # Training — knows the shape, sees the break coming
+      opener_solo: "I know this shape."
+      opener_panel: "Ran it past the others anyway."
+      hedge: ""
+      confidence_lead: "Confidence"
+      terse: false
+    5:  # The One — certain, minimal
+      opener_solo: ""
+      opener_panel: "Not alone."
+      hedge: ""
+      confidence_lead: ""
+      terse: true
+
+  # Fact templates. `terse` stages drop the connective prose and keep the nouns.
+  lines:
+    action_change: "I'd change {count} thing(s){target}"
+    action_change_terse: "{target_bare}{count} change(s)"
+    action_plan: "No code from me. A {steps}-step path instead"
+    action_plan_terse: "{steps}-step path. No code"
+    action_none: "I don't have a path for this yet"
+    action_none_terse: "Nothing yet"
+    target_one: " in {path}"
+    target_many: " across {count} file(s)"
+    early_exit: " Stopped early — I was sure and the checkers were clean."
+    verify: >-
+      You gave me {count} change(s). I didn't write them and I didn't reason
+      about them — I ran the checkers: {verdict}.
+    verify_failed: "{count} checker(s) pushed back"
+    verify_clean: "nothing pushed back"
+    verify_none: "no checkers could run"
+
+    # Cautions — stage-neutral by design (see the note above).
+    caution_low_confidence: "I'm at {confidence} on this. Don't take it on trust — check it."
+    caution_check_failed: "{tool} isn't happy: {summary}"
+    caution_sim_issues: "I ran this through and hit {count} problem(s) with my own approach."
+    caution_unverified_skipped: "I ran out of time before the checkers. This code is unverified."
+    caution_unverified_no_tools: "No checkers on this machine. This code is unverified."
+    caution_open_question: "Still open: {question}"
+    caution_overflow: "({count} more like these. Read the full output.)"
+
+    # Progress and lifecycle — stage-neutral, same reason.
+    started: "Looking at this now."
+    completed_fallback: "Done."
+    failed: "I broke on this one — {error_type}. No answer."
+    memory_found: "I remember {count} thing(s) about this."
+    phase_context: "Reading the code."
+    phase_context_done: "Read {count} file(s)."
+    phase_reasoning: "Working it — plan, simulate, draft."
+    phase_reasoning_done: "{steps}-step path, {count} change(s)."
+    phase_panel: "Not doing this alone — solver, critic, verifier."
+    phase_panel_done: "We agree {consensus} after {rounds} round(s)."
+    phase_panel_fallback: "The panel gave me nothing usable. Doing it myself."
+    panel_rejected: "Threw out the panel's answer. Nothing in it held up."
+    phase_checks: "Running the checkers over it."
+    phase_checks_clean: "All {count} checker(s) clean."
+    phase_checks_failed: "{failed} of {count} checker(s) pushed back."
+    phase_checks_none: "No checkers here. Nothing verified this."
+    phase_checks_considering: "Considering the checkers."
+    phase_checks_skipped: "Out of time before I could run them. This is unchecked."
+
 # Base expressions per personality stage (fallback when no specific beat matches)
 base_expressions:
   1:  # Sleeper (0.0-0.2 memory level)

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -15,11 +15,12 @@ import json
 import os
 import re
 import subprocess
-import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
+
+from neo import progress
 
 # Constants
 MIN_SCORE_THRESHOLD = 0.2  # Filter files with very low relevance (was 0.3, reduced for broad prompts)
@@ -390,10 +391,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
             # the user can opt into. Cheap, silent on subsequent runs (we only
             # print when the snapshot file is genuinely missing, not just empty).
             if not index.snapshot_path.exists():
-                print(
-                    "[Neo] Tip: run 'neo --index' to enable semantic file selection",
-                    file=sys.stderr,
-                )
+                progress.note("Tip: run 'neo --index' to enable semantic file selection")
             return {}
         chunks = index.retrieve(prompt, k=k)
 
@@ -425,10 +423,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
             prev = boost.get(rel, 0.0)
             boost[rel] = max(prev, sim)
         if boost:
-            print(
-                f"[Neo] ProjectIndex boost: {len(boost)} files matched semantically",
-                file=sys.stderr,
-            )
+            progress.note(f"ProjectIndex boost: {len(boost)} files matched semantically")
         return boost
     except Exception:  # missing index, faiss unavailable, etc.
         # Quiet — index is opt-in, must-not-break path.
@@ -468,10 +463,7 @@ def _history_boost(root: str, prompt: str, k: int = 10) -> dict[str, float]:
         if not counts:
             return {}
         boost = {p: min(0.5, n * 0.15) for p, n in counts.items()}
-        print(
-            f"[Neo] EPISODE-history boost: {len(boost)} files seen in past similar runs",
-            file=sys.stderr,
-        )
+        progress.note(f"EPISODE-history boost: {len(boost)} files seen in past similar runs")
         return boost
     except Exception:
         # FactStore missing, fact_store init crashed, etc. — never break gather.
@@ -541,7 +533,7 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
 
     # Calculate adaptive file limit based on prompt specificity
     adaptive_limit = calculate_adaptive_limit(config.prompt, config.max_files)
-    print(f"[Neo] Adaptive limit: {adaptive_limit} files (based on prompt specificity)", file=sys.stderr)
+    progress.note(f"Adaptive limit: {adaptive_limit} files (based on prompt specificity)")
 
     # ProjectIndex semantic boost (uses pre-built tree-sitter + FAISS index
     # if present in .neo/). Computed once up front — boosts apply to
@@ -593,16 +585,16 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
             # Remove duplicates while preserving order
             seen = set()
             scored_filtered = [x for x in scored_filtered if not (x[1] in seen or seen.add(x[1]))]
-            print(f"[Neo] Broad prompt detected: including {len(arch_files[:5])} architectural files", file=sys.stderr)
+            progress.note(f"Broad prompt detected: including {len(arch_files[:5])} architectural files")
 
     # If no files pass threshold, keep top 10 anyway to avoid empty results
     if not scored_filtered and scored_before_filter > 0:
-        print(f"[Neo] Warning: All files scored below {MIN_SCORE_THRESHOLD}, using top 10", file=sys.stderr)
+        progress.note(f"Warning: All files scored below {MIN_SCORE_THRESHOLD}, using top 10")
         scored = scored[:10]
     else:
         filtered_count = scored_before_filter - len(scored_filtered)
         if filtered_count > 0:
-            print(f"[Neo] Filtered {filtered_count} low-relevance files (score < {MIN_SCORE_THRESHOLD})", file=sys.stderr)
+            progress.note(f"Filtered {filtered_count} low-relevance files (score < {MIN_SCORE_THRESHOLD})")
         scored = scored_filtered
 
     # Re-rank pass: union in ProjectIndex semantic hits, then layer
@@ -654,10 +646,7 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
         final_score = base_score + pi + hist + sym
         enriched.append((abs_path, rel_path, size, final_score))
     if symbol_hit_count:
-        print(
-            f"[Neo] Symbol-relevance boost applied to {symbol_hit_count} files",
-            file=sys.stderr,
-        )
+        progress.note(f"Symbol-relevance boost applied to {symbol_hit_count} files")
 
     enriched.sort(key=lambda x: x[3], reverse=True)
     scored = enriched
@@ -685,7 +674,7 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
                 size_kb = len(content) / 1024
                 if size_kb > 50:
                     if rel_path not in large_files_warned:
-                        print(f"[Neo] Warning: {rel_path} is {size_kb:.0f}KB - consider refactoring into smaller modules", file=sys.stderr)
+                        progress.note(f"Warning: {rel_path} is {size_kb:.0f}KB - consider refactoring into smaller modules")
                         large_files_warned.append(rel_path)
 
                 chunks = select_chunks(content, prompt_tokens)
@@ -823,8 +812,8 @@ def gather_context_semantic(config: GatherConfig) -> list[ContextFile]:
 
     # Check if index exists
     if not index_path.exists():
-        print(f"[Neo] No semantic index found at {index_path}", file=sys.stderr)
-        print("[Neo] Falling back to keyword search. Run 'neo index' to build semantic index.", file=sys.stderr)
+        progress.note(f"No semantic index found at {index_path}")
+        progress.note("Falling back to keyword search. Run 'neo index' to build semantic index.")
         return gather_context(config)
 
     # Load ProjectIndex
@@ -838,8 +827,8 @@ def gather_context_semantic(config: GatherConfig) -> list[ContextFile]:
         chunks = index.retrieve(config.prompt, k=100)
 
         if not chunks:
-            print("[Neo] No chunks found in semantic index", file=sys.stderr)
-            print("[Neo] Falling back to keyword search", file=sys.stderr)
+            progress.note("No chunks found in semantic index")
+            progress.note("Falling back to keyword search")
             return gather_context(config)
 
         # Pack chunks using MMR for diversity
@@ -875,17 +864,17 @@ def gather_context_semantic(config: GatherConfig) -> list[ContextFile]:
             root=root
         )
 
-        print(f"[Neo] Semantic search: {len(selected_chunks)} chunks from {len(set(cf.rel_path for cf in context_files))} files in {elapsed*1000:.0f}ms", file=sys.stderr)
+        progress.note(f"Semantic search: {len(selected_chunks)} chunks from {len(set(cf.rel_path for cf in context_files))} files in {elapsed*1000:.0f}ms")
 
         return context_files
 
     except ImportError as e:
-        print(f"[Neo] Failed to load ProjectIndex: {e}", file=sys.stderr)
-        print("[Neo] Falling back to keyword search", file=sys.stderr)
+        progress.note(f"Failed to load ProjectIndex: {e}")
+        progress.note("Falling back to keyword search")
         return gather_context(config)
     except Exception as e:
-        print(f"[Neo] Semantic search error: {e}", file=sys.stderr)
-        print("[Neo] Falling back to keyword search", file=sys.stderr)
+        progress.note(f"Semantic search error: {e}")
+        progress.note("Falling back to keyword search")
         return gather_context(config)
 
 
@@ -922,4 +911,4 @@ def log_context_metrics(method: str, elapsed_ms: float, chunks_retrieved: int,
             f.write(json.dumps(metric) + '\n')
     except Exception as e:
         # Don't fail on metrics logging errors
-        print(f"[Neo] Warning: Failed to log metrics: {e}", file=sys.stderr)
+        progress.note(f"Warning: Failed to log metrics: {e}")

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -19,6 +19,17 @@ from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+from neo.events import (
+    PHASE_FINALIZE,
+    PHASE_REASONING,
+    PHASE_CONTEXT,
+    PHASE_STATIC_CHECKS,
+    NeoEvent,
+    NeoEventSink,
+    NeoEventType,
+    NullSink,
+    safe_emit,
+)
 from neo.models import (
     AppliedAction,
     CodeSuggestion,
@@ -26,6 +37,7 @@ from neo.models import (
     LMAdapter,
     NeoInput,
     NeoOutput,
+    OrchestratorMessage,
     PlanStep,
     SimulationTrace,
     StaticCheckResult,
@@ -68,6 +80,10 @@ class NeoEngine:
     # Constants for magic numbers (Phase 5)
     EARLY_EXIT_CONFIDENCE = 0.8  # Skip static checks if confidence above this
     STATIC_CHECK_BUFFER = 0.9    # Reserve 10% of budget for static checks
+    # Below this, a result is worth flagging rather than acting on. Applies to
+    # both a single suggestion's confidence and the run's overall confidence;
+    # the plugin docs quote the same threshold to users.
+    LOW_CONFIDENCE = 0.7
 
     def __init__(
         self,
@@ -77,6 +93,7 @@ class NeoEngine:
         codebase_root: Optional[str] = None,  # Root directory of the codebase being analyzed
         config: Optional[Any] = None,  # NeoConfig instance
         execution_adapter: Optional[ExecutionAdapter] = None,
+        event_sink: Optional[NeoEventSink] = None,
     ):
         self.lm = lm_adapter
         self.exemplar_index = exemplar_index
@@ -85,6 +102,25 @@ class NeoEngine:
         self.codebase_root = codebase_root
         self.config = config  # NeoConfig | None (kept for downstream lookups like reasoning_effort_cap)
         self.execution_adapter = execution_adapter
+
+        # Lifecycle observer. Defaults to discarding, so an unobserved run is
+        # exactly as expensive as it was before events existed.
+        # `is None`, not `or`: a sink that buffers and defines __len__ would be
+        # falsy when empty and get silently replaced.
+        self.event_sink: NeoEventSink = NullSink() if event_sink is None else event_sink
+        # Phase records accumulated during a run, replayed into
+        # OrchestratorMessage.phase_summary at finalize. Reset per request.
+        self._phase_records: list[dict[str, Any]] = []
+        self._findings: list[str] = []
+        # Set per request before any finalize; initialized so the orchestrator
+        # summary can read it directly instead of guessing via getattr.
+        self.last_reasoning_mode: str = "fast"
+        # One beat per run, chosen once and reused by every surface. Selecting
+        # independently per surface let the terminal notes and the host-facing
+        # line disagree — same character, two voices, one response.
+        self._selected_beat: Optional[dict[str, Any]] = None
+        self._beat_selected = False
+        self._recalled_fact_count = 0
 
         # Load beat deck for personality templates (no LLM call)
         self.beat_deck = self._load_beat_deck()
@@ -147,6 +183,83 @@ class NeoEngine:
         self.episode_store = LearningEpisodeStore(episode_project_id or "unscoped")
         self.current_learning_episode = None
 
+    def _emit(
+        self,
+        event_type: NeoEventType,
+        *,
+        phase: str = "",
+        message: str = "",
+        **data: Any,
+    ) -> None:
+        """Report one fact about this run to whatever is observing."""
+        safe_emit(
+            self.event_sink,
+            NeoEvent(type=event_type, phase=phase, message=message, data=data),
+        )
+
+    def _begin_phase(self, phase: str, message: str = "") -> None:
+        self._phase_records.append(
+            {"name": phase, "status": "running", "message": message}
+        )
+        self._emit(NeoEventType.PHASE_STARTED, phase=phase, message=message)
+
+    def _end_phase(
+        self, phase: str, message: str = "", status: str = "complete", **data: Any
+    ) -> None:
+        """Close the most recent open record for `phase`.
+
+        Searched in reverse because a phase can legitimately run more than once
+        (a failed panel falls back to the fast path); the newest open record is
+        always the one being closed.
+        """
+        for record in reversed(self._phase_records):
+            if record["name"] == phase and record["status"] == "running":
+                record["status"] = status
+                record["message"] = message or record["message"]
+                break
+        else:
+            # Every phase_completed must have an opening phase_started, or a
+            # host tracking boundaries sees a close for something it never saw
+            # open. Synthesizing a record silently would hide that caller bug,
+            # so it is recorded AND reported.
+            logger.warning(
+                "phase %r closed without a matching _begin_phase; "
+                "the event stream for this run is malformed", phase
+            )
+            self._phase_records.append(
+                {"name": phase, "status": status, "message": message}
+            )
+        self._emit(
+            NeoEventType.PHASE_COMPLETED,
+            phase=phase,
+            message=message,
+            status=status,
+            **data,
+        )
+
+    def _current_phase(self) -> str:
+        """Name of the phase currently running, or "" outside any phase.
+
+        Used by emitters that do not sit inside a single phase and so cannot
+        name theirs statically. Labeling such an event with a fixed phase
+        name produces a stream where an event claims a phase that already
+        closed — the retrieval of facts, for instance, actually happens while
+        the reasoning phase is open.
+        """
+        for record in reversed(self._phase_records):
+            if record["status"] == "running":
+                return str(record["name"])
+        return ""
+
+    def _note_finding(self, text: str) -> None:
+        """Record something Neo learned that a host may want to surface.
+
+        Findings gate personality: a beat only reaches the orchestrator when
+        it has substance to attach to.
+        """
+        if text and text not in self._findings:
+            self._findings.append(text)
+
     def process(self, neo_input: NeoInput) -> NeoOutput:
         """
         Main entry point: process input and return structured output.
@@ -168,6 +281,11 @@ class NeoEngine:
         self.context = neo_input
         start_time = time.time()
         self.action_log.clear()
+        self._phase_records = []
+        self._findings = []
+        self._selected_beat = None
+        self._beat_selected = False
+        self._recalled_fact_count = 0
         self.last_applied_actions: list[AppliedAction] = []
         self.current_learning_episode = self._begin_learning_episode(neo_input)
         from neo.memory.metrics import record as record_memory_metric
@@ -198,10 +316,37 @@ class NeoEngine:
         )
         overseer.start()
         self._log_action("process.start", neo_input.prompt[:60])
+        self._emit(
+            NeoEventType.STARTED,
+            message="Neo started reasoning about the request.",
+            operating_mode=neo_input.operating_mode.value,
+            task_type=getattr(neo_input.task_type, "value", ""),
+        )
 
         try:
-            return self._process_inner(neo_input, start_time)
+            output = self._process_inner(neo_input, start_time)
+            self._emit(
+                NeoEventType.COMPLETED,
+                message=output.orchestrator.summary or "Neo finished reasoning.",
+                confidence=round(output.confidence, 3),
+                elapsed_seconds=round(time.time() - start_time, 2),
+            )
+            return output
         except Exception as exc:
+            # A terminal event on every path. Emitting STARTED and then going
+            # silent is worse than never emitting: a host cannot tell a crash
+            # from a hang, and any open phase stays "running" forever.
+            failed_in = self._current_phase()  # read before clearing "running"
+            for record in self._phase_records:
+                if record["status"] == "running":
+                    record["status"] = "failed"
+            self._emit(
+                NeoEventType.FAILED,
+                phase=failed_in,
+                message=f"Neo failed during this run: {type(exc).__name__}.",
+                error_type=type(exc).__name__,
+                elapsed_seconds=round(time.time() - start_time, 2),
+            )
             episode = self.current_learning_episode
             if episode is not None:
                 episode.completed_at = time.time()
@@ -331,6 +476,26 @@ class NeoEngine:
 
     def _capture_retrieval_context(self, fact_context, *, included: bool) -> None:
         """Record retrieved fact IDs and scores without changing fact authority."""
+        # Emitted from the funnel every fact-retrieval path passes through
+        # rather than from a phase boundary, because retrieval does not sit
+        # inside one: it runs while REASONING is open. `_current_phase()` keeps
+        # the label honest wherever a future call site puts it.
+        if included and fact_context.valid_facts:
+            self._recalled_fact_count += len(fact_context.valid_facts)
+            subjects = [f.subject for f in fact_context.valid_facts[:3] if f.subject]
+            self._emit(
+                NeoEventType.MEMORY_FOUND,
+                phase=self._current_phase(),
+                message=(
+                    f"Recalled {len(fact_context.valid_facts)} relevant "
+                    f"fact(s) from memory."
+                ),
+                count=len(fact_context.valid_facts),
+                subjects=subjects,
+            )
+            if subjects:
+                self._note_finding(f"prior knowledge: {subjects[0]}")
+
         episode = self.current_learning_episode
         if episode is None:
             return
@@ -602,7 +767,16 @@ class NeoEngine:
 
         # Phase 1: Retrieve additional context
         self._log_action("retrieve_context", neo_input.prompt[:60])
+        self._begin_phase(PHASE_CONTEXT, "Gathering code context.")
         enriched_context = self._retrieve_context(neo_input)
+        file_count = len(neo_input.context_files) + len(
+            enriched_context.get("additional_files", []) or []
+        )
+        self._end_phase(
+            PHASE_CONTEXT,
+            f"Read {file_count} file(s) of context.",
+            file_count=file_count,
+        )
 
         # Include difficulty in context for planning
         enriched_context["difficulty"] = difficulty
@@ -632,22 +806,79 @@ class NeoEngine:
         logger.info("Reasoning mode: %s — %s", decision.mode.value, decision.reason)
 
         plan = simulation_traces = code_suggestions = None
+        # Held so the reasoning phase closes AFTER its findings are emitted —
+        # a host replaying the stream should see what was found before it is
+        # told the phase is done.
+        reasoning_summary = ""
+        reasoning_data: dict[str, Any] = {}
         if decision.mode is ReasoningMode.MULTI_AGENT:
             self._log_action("deliberate", neo_input.prompt[:60])
+            self._begin_phase(
+                PHASE_REASONING,
+                "Running a multi-model panel: solver, critic, verifier.",
+            )
             plan, simulation_traces, code_suggestions, deliberation = self._deliberate(
                 enriched_context, route_fn
             )
             if deliberation is not None and deliberation.confidence > 0.0 and code_suggestions:
                 self.last_deliberation = deliberation
+                reasoning_summary = (
+                    f"Panel reached {deliberation.consensus:.0%} consensus "
+                    f"over {deliberation.rounds} round(s)."
+                )
+                reasoning_data = {
+                    "consensus": round(deliberation.consensus, 3),
+                    "rounds": deliberation.rounds,
+                }
+                self._note_finding(
+                    f"panel consensus {deliberation.consensus:.0%}"
+                )
             else:
                 logger.warning("Deliberation yielded no usable result; falling back to fast path")
                 self.last_reasoning_mode = "fast"  # honest metadata: we fell back
                 plan = None
+                self._end_phase(
+                    PHASE_REASONING,
+                    "Panel produced no usable result; falling back to the single-model path.",
+                    status="fallback",
+                )
+                self._emit(
+                    NeoEventType.HYPOTHESIS_REJECTED,
+                    phase=PHASE_REASONING,
+                    message="Discarded the panel's output — no usable suggestion survived.",
+                )
 
         if plan is None:
             # Fast path (default, or fallback from a failed panel).
             self._log_action("lm_call", neo_input.prompt[:60])
+            self._begin_phase(PHASE_REASONING, "Planning, simulating, and drafting changes.")
             plan, simulation_traces, code_suggestions = self._process_combined(enriched_context)
+            reasoning_summary = (
+                f"Produced a {len(plan)}-step plan and "
+                f"{len(code_suggestions)} suggested change(s)."
+            )
+            reasoning_data = {
+                "plan_steps": len(plan),
+                "suggestions": len(code_suggestions),
+            }
+
+        if plan:
+            self._emit(
+                NeoEventType.HYPOTHESIS_FORMED,
+                phase=PHASE_REASONING,
+                message=plan[0].description,
+                plan_steps=len(plan),
+            )
+        for trace in simulation_traces or []:
+            for issue in trace.issues_found:
+                self._emit(
+                    NeoEventType.RISK_FOUND,
+                    phase=PHASE_REASONING,
+                    message=issue,
+                    source="simulation",
+                )
+                self._note_finding(issue)
+        self._end_phase(PHASE_REASONING, reasoning_summary, **reasoning_data)
         self._capture_detectable_fact_use(plan, simulation_traces, code_suggestions)
         code_suggestions = self._apply_role_boundary(code_suggestions)
         self.last_simulation_traces = simulation_traces
@@ -663,9 +894,50 @@ class NeoEngine:
         elapsed = time.time() - start_time
         static_checks = []
         if elapsed < time_budget * self.STATIC_CHECK_BUFFER:
+            self._begin_phase(
+                PHASE_STATIC_CHECKS, "Running static analysis on the proposed changes."
+            )
             static_checks = self._run_static_checks(code_suggestions, extracted_constraints)
+            statuses = [self._static_check_status(check) for check in static_checks]
+            failed = [
+                check for check, status in zip(static_checks, statuses)
+                if status == "failed"
+            ]
+            for check in failed:
+                self._emit(
+                    NeoEventType.RISK_FOUND,
+                    phase=PHASE_STATIC_CHECKS,
+                    message=f"{check.tool_name}: {check.summary}",
+                    source="static_check",
+                    tool=check.tool_name,
+                )
+                self._note_finding(f"{check.tool_name} reported errors")
+            if not static_checks:
+                summary = "No static analysis tools were available."
+            elif failed:
+                summary = f"{len(failed)} of {len(static_checks)} check(s) reported errors."
+            else:
+                summary = f"All {len(static_checks)} check(s) passed."
+            self._end_phase(
+                PHASE_STATIC_CHECKS,
+                summary,
+                checks=len(static_checks),
+                failed=len(failed),
+            )
         else:
-            logger.info(f"Skipping static checks (at {elapsed/time_budget*100:.0f}% budget utilization)")
+            # Guarded: a zero budget is not reachable through _get_time_budget
+            # today, but a *log line* must never be what crashes a run.
+            utilization = (elapsed / time_budget * 100) if time_budget else float("inf")
+            logger.info(f"Skipping static checks (at {utilization:.0f}% budget utilization)")
+            # Opened even though nothing runs: a phase that closes without
+            # opening leaves a host tracking a close for a phase it never saw
+            # start. "Started then skipped" is both true and well-formed.
+            self._begin_phase(PHASE_STATIC_CHECKS, "Considering static analysis.")
+            self._end_phase(
+                PHASE_STATIC_CHECKS,
+                "Skipped static analysis — the time budget was already spent.",
+                status="skipped",
+            )
 
         # Early exit only when BOTH signals agree: high self-confidence AND no
         # error-severity diagnostics. An objective signal (static analysis
@@ -888,6 +1160,22 @@ class NeoEngine:
             recommended_next_action["suggestion_id"] = code_suggestions[0].suggestion_id
             recommended_next_action["file_path"] = code_suggestions[0].file_path
 
+        orchestrator = self._build_orchestrator_message(
+            plan=plan,
+            simulation_traces=simulation_traces,
+            code_suggestions=code_suggestions,
+            static_checks=static_checks,
+            next_questions=next_questions,
+            confidence=confidence,
+            early_exit=early_exit,
+        )
+        if orchestrator.personality:
+            self._emit(
+                NeoEventType.PERSONALITY_BEAT,
+                phase=PHASE_FINALIZE,
+                message=orchestrator.personality,
+            )
+
         output = NeoOutput(
             plan=plan,
             simulation_traces=simulation_traces,
@@ -900,6 +1188,7 @@ class NeoEngine:
             goal_assessment=goal_assessment,
             strategy_assessment=strategy_assessment,
             recommended_next_action=recommended_next_action,
+            orchestrator=orchestrator,
         )
         self._log_usage_telemetry(output, neo_input)
         return output
@@ -1877,7 +2166,7 @@ RULES:
                 )
 
         # Questions from low-confidence suggestions
-        low_confidence = [s for s in suggestions if s.confidence < 0.7]
+        low_confidence = [s for s in suggestions if s.confidence < self.LOW_CONFIDENCE]
         if low_confidence:
             questions.append(
                 f"{len(low_confidence)} suggestions have low confidence - "
@@ -1979,6 +2268,15 @@ RULES:
         if context.get('high_confidence'):
             triggers.add('high_confidence')
 
+        # Memory state. Without these two, every beat keyed on recall was
+        # unreachable — `unfamiliar_codebase` could never fire at all, and its
+        # configured line was dead text that no test could catch.
+        if context.get('memory_hit'):
+            triggers.add('memory_hit')
+            triggers.add('familiar_pattern')
+        elif context.get('memory_checked'):
+            triggers.add('no_memory_match')
+
         # Find beats with most matching triggers
         best_match = None
         best_score = 0
@@ -1992,6 +2290,199 @@ RULES:
                 best_match = beat
 
         return best_match if best_score > 0 else None
+
+    def _run_beat(self, confidence: Optional[float] = None) -> Optional[dict[str, Any]]:
+        """The one beat this run speaks with, selected once and cached.
+
+        Both the terminal notes and the host-facing line read from here. When
+        each surface selected independently they could pick different beats
+        from the same run — one character speaking with two voices in a single
+        response, since `--json` carries both.
+
+        `confidence` is only available at finalize, so the first caller to know
+        it decides the beat; callers without it (notes) reuse that choice.
+        """
+        if self._beat_selected:
+            return self._selected_beat
+        if not self.context:
+            return None
+        self._selected_beat = self._select_beat({
+            "prompt": self.context.prompt,
+            "error_trace": self.context.error_trace,
+            "high_confidence": (
+                confidence is not None and confidence >= self.EARLY_EXIT_CONFIDENCE
+            ),
+            "memory_hit": self._recalled_fact_count > 0,
+            # Distinguishes "memory was consulted and came back empty" from
+            # "memory was never consulted" (disabled, or a mode that skips it).
+            # Only the first justifies saying Neo has no memory of this code.
+            "memory_checked": self.persistent_memory is not None,
+        })
+        self._beat_selected = True
+        return self._selected_beat
+
+    def _orchestrator_beat(self, confidence: float) -> str:
+        """Return the host-facing personality line, or "" to stay silent.
+
+        Silence is the default and the safe answer. A beat is relayed only when
+        the deck marked it surfaceable and, for beats that claim insight, only
+        when the run actually produced something to be insightful about.
+        Unattached flavor text is what makes a tool feel like theater.
+        """
+        beat = self._run_beat(confidence)
+        if not beat or beat.get("surface") != "orchestrator":
+            return ""
+        if beat.get("requires_finding", False) and not self._findings:
+            return ""
+        return str(beat.get("orchestrator_line", "") or "")
+
+    def _build_orchestrator_message(
+        self,
+        *,
+        plan: list[PlanStep],
+        simulation_traces: list[SimulationTrace],
+        code_suggestions: list[CodeSuggestion],
+        static_checks: list[StaticCheckResult],
+        next_questions: list[str],
+        confidence: float,
+        early_exit: bool,
+    ) -> OrchestratorMessage:
+        """State what this run did, so a host doesn't have to infer it.
+
+        Pure derivation from state already computed — no LM call, no new
+        analysis. Every claim here must be defensible from the rest of the
+        NeoOutput, because a host that repeats an unearned summary is worse
+        than one that says nothing.
+        """
+        from neo.reasoning_mode import ReasoningMode
+
+        failed_checks = [
+            check for check in static_checks
+            if self._static_check_status(check) == "failed"
+        ]
+        mode = self.last_reasoning_mode
+        verification_only = mode == "verification_only"
+
+        # Summary: what ran, what it produced, how sure it is.
+        #
+        # VERIFY is its own sentence, not a variation on the others. That path
+        # makes no LM call and its `code_suggestions` are the CALLER's
+        # proposed_changes echoed back for checking — saying "Neo reasoned" or
+        # "Neo proposes" there attributes the caller's work to Neo, and a host
+        # is told to lead with this line verbatim.
+        if verification_only:
+            checked = len(code_suggestions)
+            verdict = (
+                f"{len(failed_checks)} check(s) reported errors" if failed_checks
+                else "no check reported errors" if static_checks
+                else "no checks could run"
+            )
+            summary = (
+                f"Neo statically checked {checked} caller-supplied change(s) "
+                f"without reasoning about them: {verdict}."
+            )
+        else:
+            parts: list[str] = []
+            if mode == ReasoningMode.MULTI_AGENT.value:
+                parts.append("Neo ran a multi-model panel")
+            else:
+                parts.append("Neo reasoned over the request")
+            if code_suggestions:
+                files = {s.file_path for s in code_suggestions if s.file_path}
+                if len(files) > 1:
+                    target = f" across {len(files)} file(s)"
+                elif files:
+                    target = f" in {next(iter(files))}"
+                else:
+                    target = ""
+                parts.append(
+                    f"and proposes {len(code_suggestions)} change(s){target}"
+                )
+            elif plan:
+                parts.append(f"and returned a {len(plan)}-step plan without code changes")
+            else:
+                parts.append("but produced no actionable plan")
+            summary = " ".join(parts) + f". Confidence {confidence:.2f}."
+            if early_exit:
+                summary += " It exited early — high confidence and clean static checks."
+
+        # Cautions: what a confident-sounding answer must not bury.
+        cautions: list[str] = []
+        # VERIFY reports confidence as a pass/fail verdict (0.0 on any failure),
+        # not as self-assessed certainty, so the "verify this yourself" advice
+        # would be both circular and wrong.
+        if not verification_only and confidence < self.LOW_CONFIDENCE:
+            cautions.append(
+                f"Confidence is {confidence:.2f}. Verify before acting on this."
+            )
+        for check in failed_checks:
+            cautions.append(f"{check.tool_name} reported errors: {check.summary}")
+        issue_count = sum(len(t.issues_found) for t in simulation_traces or [])
+        if issue_count:
+            cautions.append(
+                f"Simulation surfaced {issue_count} issue(s) with the proposed approach."
+            )
+        if code_suggestions and not static_checks:
+            # Two different facts with two different remedies: install a linter
+            # versus give the run more time. The phase record already knows
+            # which one happened — don't collapse them here.
+            skipped = any(
+                record["name"] == PHASE_STATIC_CHECKS and record["status"] == "skipped"
+                for record in self._phase_records
+            )
+            cautions.append(
+                "Static analysis was skipped for time budget, so the suggested "
+                "code is unverified."
+                if skipped else
+                "No static analysis tools were available, so the suggested "
+                "code is unverified."
+            )
+        for question in next_questions[:3]:
+            cautions.append(f"Open question: {question}")
+
+        # Narration: phase-by-phase, in the order it happened.
+        narration = [
+            record["message"]
+            for record in self._phase_records
+            if record.get("message") and record.get("status") != "running"
+        ]
+
+        return OrchestratorMessage(
+            summary=summary,
+            personality=self._orchestrator_beat(confidence),
+            # Copy each record, not just the list. These dicts are live engine
+            # state, and this object is handed to foreign consumers.
+            phase_summary=[dict(record) for record in self._phase_records],
+            cautions=self._cap_cautions(cautions),
+            recommended_narration=narration,
+        )
+
+    # A host is instructed never to drop a caution, so this list must stay
+    # relayable. Failed checks and simulation issues are raw LM prose of
+    # unbounded length and count; without a cap the contract asks a host to
+    # surface an arbitrarily large wall of text.
+    MAX_CAUTIONS = 8
+    MAX_CAUTION_CHARS = 300
+
+    @classmethod
+    def _cap_cautions(cls, cautions: list[str]) -> list[str]:
+        """Bound both the number of cautions and the length of each one.
+
+        Truncation is explicit: a dropped caution is reported as a count, never
+        silently discarded, because "there are more problems" is itself one of
+        the things a host must not bury.
+        """
+        capped = [
+            item if len(item) <= cls.MAX_CAUTION_CHARS
+            else item[: cls.MAX_CAUTION_CHARS - 1].rstrip() + "…"
+            for item in cautions
+        ]
+        if len(capped) <= cls.MAX_CAUTIONS:
+            return capped
+        dropped = len(capped) - (cls.MAX_CAUTIONS - 1)
+        return capped[: cls.MAX_CAUTIONS - 1] + [
+            f"({dropped} further caution(s) not shown — see the full output.)"
+        ]
 
     def _generate_notes(
         self,
@@ -2011,15 +2502,9 @@ RULES:
             memory_level = self.persistent_memory.memory_level()
         stage = self._memory_level_to_stage(memory_level)
 
-        # Try to select a beat based on context
-        context = {}
-        if self.context:
-            context = {
-                'prompt': self.context.prompt,
-                'error_trace': self.context.error_trace,
-            }
-
-        beat = self._select_beat(context)
+        # The run's single beat — the same one the host-facing line reads, so
+        # the terminal and the orchestrator never speak as different characters.
+        beat = self._run_beat()
 
         # Get the template
         if beat and 'expressions' in beat and stage in beat['expressions']:

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -237,6 +237,44 @@ class NeoEngine:
             **data,
         )
 
+    # Last-resort wording if the beat deck is missing or malformed. Neutral on
+    # purpose: a run must still be able to describe itself, but this is not
+    # where the character is authored — `orchestrator_voice.lines` is.
+    _VOICE_FALLBACK = "{event}"
+
+    def _voice(self, key: str, **fmt: Any) -> str:
+        """Render one user-facing line from the beat deck.
+
+        All prose Neo emits is authored in `orchestrator_voice.lines`, so the
+        character can be retuned without editing code. A missing key or a
+        template whose placeholders don't match degrades to "" rather than
+        raising — a formatting slip in a personality file must never take down
+        a reasoning run.
+        """
+        try:
+            lines = self.beat_deck.get("orchestrator_voice", {}).get("lines", {})
+            template = lines.get(key)
+            if not template:
+                return ""
+            return str(template).format(**fmt)
+        except Exception as exc:
+            logger.debug("voice template %r failed: %s", key, exc)
+            return ""
+
+    def _voice_stage(self) -> dict[str, Any]:
+        """Per-stage register (opener, hedge, terseness) for the current
+        memory level. Neo's certainty grows with what he remembers, so the
+        summary's phrasing follows `_memory_level_to_stage`."""
+        memory_level = 0.0
+        if self.persistent_memory:
+            try:
+                memory_level = self.persistent_memory.memory_level()
+            except Exception:
+                memory_level = 0.0
+        stage = self._memory_level_to_stage(memory_level)
+        stages = self.beat_deck.get("orchestrator_voice", {}).get("stages", {})
+        return stages.get(stage) or stages.get(3) or {}
+
     def _current_phase(self) -> str:
         """Name of the phase currently running, or "" outside any phase.
 
@@ -318,7 +356,7 @@ class NeoEngine:
         self._log_action("process.start", neo_input.prompt[:60])
         self._emit(
             NeoEventType.STARTED,
-            message="Neo started reasoning about the request.",
+            message=self._voice("started"),
             operating_mode=neo_input.operating_mode.value,
             task_type=getattr(neo_input.task_type, "value", ""),
         )
@@ -327,7 +365,7 @@ class NeoEngine:
             output = self._process_inner(neo_input, start_time)
             self._emit(
                 NeoEventType.COMPLETED,
-                message=output.orchestrator.summary or "Neo finished reasoning.",
+                message=output.orchestrator.summary or self._voice("completed_fallback"),
                 confidence=round(output.confidence, 3),
                 elapsed_seconds=round(time.time() - start_time, 2),
             )
@@ -343,7 +381,7 @@ class NeoEngine:
             self._emit(
                 NeoEventType.FAILED,
                 phase=failed_in,
-                message=f"Neo failed during this run: {type(exc).__name__}.",
+                message=self._voice("failed", error_type=type(exc).__name__),
                 error_type=type(exc).__name__,
                 elapsed_seconds=round(time.time() - start_time, 2),
             )
@@ -486,10 +524,7 @@ class NeoEngine:
             self._emit(
                 NeoEventType.MEMORY_FOUND,
                 phase=self._current_phase(),
-                message=(
-                    f"Recalled {len(fact_context.valid_facts)} relevant "
-                    f"fact(s) from memory."
-                ),
+                message=self._voice("memory_found", count=len(fact_context.valid_facts)),
                 count=len(fact_context.valid_facts),
                 subjects=subjects,
             )
@@ -767,14 +802,14 @@ class NeoEngine:
 
         # Phase 1: Retrieve additional context
         self._log_action("retrieve_context", neo_input.prompt[:60])
-        self._begin_phase(PHASE_CONTEXT, "Gathering code context.")
+        self._begin_phase(PHASE_CONTEXT, self._voice("phase_context"))
         enriched_context = self._retrieve_context(neo_input)
         file_count = len(neo_input.context_files) + len(
             enriched_context.get("additional_files", []) or []
         )
         self._end_phase(
             PHASE_CONTEXT,
-            f"Read {file_count} file(s) of context.",
+            self._voice("phase_context_done", count=file_count),
             file_count=file_count,
         )
 
@@ -815,16 +850,17 @@ class NeoEngine:
             self._log_action("deliberate", neo_input.prompt[:60])
             self._begin_phase(
                 PHASE_REASONING,
-                "Running a multi-model panel: solver, critic, verifier.",
+                self._voice("phase_panel"),
             )
             plan, simulation_traces, code_suggestions, deliberation = self._deliberate(
                 enriched_context, route_fn
             )
             if deliberation is not None and deliberation.confidence > 0.0 and code_suggestions:
                 self.last_deliberation = deliberation
-                reasoning_summary = (
-                    f"Panel reached {deliberation.consensus:.0%} consensus "
-                    f"over {deliberation.rounds} round(s)."
+                reasoning_summary = self._voice(
+                    "phase_panel_done",
+                    consensus=f"{deliberation.consensus:.0%}",
+                    rounds=deliberation.rounds,
                 )
                 reasoning_data = {
                     "consensus": round(deliberation.consensus, 3),
@@ -839,23 +875,24 @@ class NeoEngine:
                 plan = None
                 self._end_phase(
                     PHASE_REASONING,
-                    "Panel produced no usable result; falling back to the single-model path.",
+                    self._voice("phase_panel_fallback"),
                     status="fallback",
                 )
                 self._emit(
                     NeoEventType.HYPOTHESIS_REJECTED,
                     phase=PHASE_REASONING,
-                    message="Discarded the panel's output — no usable suggestion survived.",
+                    message=self._voice("panel_rejected"),
                 )
 
         if plan is None:
             # Fast path (default, or fallback from a failed panel).
             self._log_action("lm_call", neo_input.prompt[:60])
-            self._begin_phase(PHASE_REASONING, "Planning, simulating, and drafting changes.")
+            self._begin_phase(PHASE_REASONING, self._voice("phase_reasoning"))
             plan, simulation_traces, code_suggestions = self._process_combined(enriched_context)
-            reasoning_summary = (
-                f"Produced a {len(plan)}-step plan and "
-                f"{len(code_suggestions)} suggested change(s)."
+            reasoning_summary = self._voice(
+                "phase_reasoning_done",
+                steps=len(plan),
+                count=len(code_suggestions),
             )
             reasoning_data = {
                 "plan_steps": len(plan),
@@ -895,7 +932,7 @@ class NeoEngine:
         static_checks = []
         if elapsed < time_budget * self.STATIC_CHECK_BUFFER:
             self._begin_phase(
-                PHASE_STATIC_CHECKS, "Running static analysis on the proposed changes."
+                PHASE_STATIC_CHECKS, self._voice("phase_checks")
             )
             static_checks = self._run_static_checks(code_suggestions, extracted_constraints)
             statuses = [self._static_check_status(check) for check in static_checks]
@@ -913,11 +950,14 @@ class NeoEngine:
                 )
                 self._note_finding(f"{check.tool_name} reported errors")
             if not static_checks:
-                summary = "No static analysis tools were available."
+                summary = self._voice("phase_checks_none")
             elif failed:
-                summary = f"{len(failed)} of {len(static_checks)} check(s) reported errors."
+                summary = self._voice(
+                    "phase_checks_failed",
+                    failed=len(failed), count=len(static_checks),
+                )
             else:
-                summary = f"All {len(static_checks)} check(s) passed."
+                summary = self._voice("phase_checks_clean", count=len(static_checks))
             self._end_phase(
                 PHASE_STATIC_CHECKS,
                 summary,
@@ -932,10 +972,10 @@ class NeoEngine:
             # Opened even though nothing runs: a phase that closes without
             # opening leaves a host tracking a close for a phase it never saw
             # start. "Started then skipped" is both true and well-formed.
-            self._begin_phase(PHASE_STATIC_CHECKS, "Considering static analysis.")
+            self._begin_phase(PHASE_STATIC_CHECKS, self._voice("phase_checks_considering"))
             self._end_phase(
                 PHASE_STATIC_CHECKS,
-                "Skipped static analysis — the time budget was already spent.",
+                self._voice("phase_checks_skipped"),
                 status="skipped",
             )
 
@@ -2363,48 +2403,72 @@ RULES:
         mode = self.last_reasoning_mode
         verification_only = mode == "verification_only"
 
-        # Summary: what ran, what it produced, how sure it is.
+        # Summary: what I did, what I found, how sure I am.
         #
-        # VERIFY is its own sentence, not a variation on the others. That path
-        # makes no LM call and its `code_suggestions` are the CALLER's
-        # proposed_changes echoed back for checking — saying "Neo reasoned" or
-        # "Neo proposes" there attributes the caller's work to Neo, and a host
-        # is told to lead with this line verbatim.
+        # First person, and terse. Neo narrating himself in the third person
+        # ("Neo reasoned over the request") reads like a status board, not like
+        # the character the beat deck defines — and this is the line a host is
+        # told to lead with, so it sets the voice for the whole response.
+        # Voice is not licence: every claim below is still derived from state
+        # already computed, and VERIFY still gets its own sentence.
+        #
+        # VERIFY makes no LM call and its `code_suggestions` are the CALLER's
+        # proposed_changes echoed back for checking. Saying "I looked at this"
+        # or "I'd change" there claims the caller's work as mine.
         if verification_only:
-            checked = len(code_suggestions)
             verdict = (
-                f"{len(failed_checks)} check(s) reported errors" if failed_checks
-                else "no check reported errors" if static_checks
-                else "no checks could run"
+                self._voice("verify_failed", count=len(failed_checks)) if failed_checks
+                else self._voice("verify_clean") if static_checks
+                else self._voice("verify_none")
             )
-            summary = (
-                f"Neo statically checked {checked} caller-supplied change(s) "
-                f"without reasoning about them: {verdict}."
+            summary = self._voice(
+                "verify", count=len(code_suggestions), verdict=verdict,
             )
         else:
-            parts: list[str] = []
-            if mode == ReasoningMode.MULTI_AGENT.value:
-                parts.append("Neo ran a multi-model panel")
-            else:
-                parts.append("Neo reasoned over the request")
+            stage = self._voice_stage()
+            terse = bool(stage.get("terse"))
+            suffix = "_terse" if terse else ""
+
+            target = target_bare = ""
             if code_suggestions:
                 files = {s.file_path for s in code_suggestions if s.file_path}
                 if len(files) > 1:
-                    target = f" across {len(files)} file(s)"
+                    target = self._voice("target_many", count=len(files))
+                    target_bare = f"{len(files)} files. "
                 elif files:
-                    target = f" in {next(iter(files))}"
-                else:
-                    target = ""
-                parts.append(
-                    f"and proposes {len(code_suggestions)} change(s){target}"
+                    path = next(iter(files))
+                    target = self._voice("target_one", path=path)
+                    target_bare = f"{path}. "
+                action = self._voice(
+                    f"action_change{suffix}",
+                    count=len(code_suggestions), target=target, target_bare=target_bare,
                 )
             elif plan:
-                parts.append(f"and returned a {len(plan)}-step plan without code changes")
+                action = self._voice(f"action_plan{suffix}", steps=len(plan))
             else:
-                parts.append("but produced no actionable plan")
-            summary = " ".join(parts) + f". Confidence {confidence:.2f}."
+                action = self._voice(f"action_none{suffix}")
+
+            # A Sleeper hedges and a Sleeper's opener says so; The One drops the
+            # opener entirely and leads with the fact. Same data, different
+            # certainty — which is the whole point of the stage model.
+            opener = stage.get(
+                "opener_panel" if mode == ReasoningMode.MULTI_AGENT.value
+                else "opener_solo", ""
+            )
+            confidence_lead = stage.get("confidence_lead", "")
+            confidence_text = (
+                f"{confidence_lead} {confidence:.2f}." if confidence_lead
+                else f"{confidence:.2f}."
+            )
+            summary = " ".join(
+                part for part in (
+                    opener,
+                    f"{action}{stage.get('hedge', '')}." if action else "",
+                    confidence_text,
+                ) if part
+            )
             if early_exit:
-                summary += " It exited early — high confidence and clean static checks."
+                summary += self._voice("early_exit")
 
         # Cautions: what a confident-sounding answer must not bury.
         cautions: list[str] = []
@@ -2413,15 +2477,15 @@ RULES:
         # would be both circular and wrong.
         if not verification_only and confidence < self.LOW_CONFIDENCE:
             cautions.append(
-                f"Confidence is {confidence:.2f}. Verify before acting on this."
+                self._voice("caution_low_confidence", confidence=f"{confidence:.2f}")
             )
         for check in failed_checks:
-            cautions.append(f"{check.tool_name} reported errors: {check.summary}")
+            cautions.append(self._voice(
+                "caution_check_failed", tool=check.tool_name, summary=check.summary,
+            ))
         issue_count = sum(len(t.issues_found) for t in simulation_traces or [])
         if issue_count:
-            cautions.append(
-                f"Simulation surfaced {issue_count} issue(s) with the proposed approach."
-            )
+            cautions.append(self._voice("caution_sim_issues", count=issue_count))
         if code_suggestions and not static_checks:
             # Two different facts with two different remedies: install a linter
             # versus give the run more time. The phase record already knows
@@ -2430,15 +2494,12 @@ RULES:
                 record["name"] == PHASE_STATIC_CHECKS and record["status"] == "skipped"
                 for record in self._phase_records
             )
-            cautions.append(
-                "Static analysis was skipped for time budget, so the suggested "
-                "code is unverified."
-                if skipped else
-                "No static analysis tools were available, so the suggested "
-                "code is unverified."
-            )
+            cautions.append(self._voice(
+                "caution_unverified_skipped" if skipped
+                else "caution_unverified_no_tools"
+            ))
         for question in next_questions[:3]:
-            cautions.append(f"Open question: {question}")
+            cautions.append(self._voice("caution_open_question", question=question))
 
         # Narration: phase-by-phase, in the order it happened.
         narration = [
@@ -2464,25 +2525,25 @@ RULES:
     MAX_CAUTIONS = 8
     MAX_CAUTION_CHARS = 300
 
-    @classmethod
-    def _cap_cautions(cls, cautions: list[str]) -> list[str]:
+    def _cap_cautions(self, cautions: list[str]) -> list[str]:
         """Bound both the number of cautions and the length of each one.
 
         Truncation is explicit: a dropped caution is reported as a count, never
         silently discarded, because "there are more problems" is itself one of
         the things a host must not bury.
         """
+        # Drop blanks: a voice template that failed to render must not become an
+        # empty bullet a host dutifully relays.
         capped = [
-            item if len(item) <= cls.MAX_CAUTION_CHARS
-            else item[: cls.MAX_CAUTION_CHARS - 1].rstrip() + "…"
-            for item in cautions
+            item if len(item) <= self.MAX_CAUTION_CHARS
+            else item[: self.MAX_CAUTION_CHARS - 1].rstrip() + "…"
+            for item in cautions if item
         ]
-        if len(capped) <= cls.MAX_CAUTIONS:
+        if len(capped) <= self.MAX_CAUTIONS:
             return capped
-        dropped = len(capped) - (cls.MAX_CAUTIONS - 1)
-        return capped[: cls.MAX_CAUTIONS - 1] + [
-            f"({dropped} further caution(s) not shown — see the full output.)"
-        ]
+        dropped = len(capped) - (self.MAX_CAUTIONS - 1)
+        overflow = self._voice("caution_overflow", count=dropped)
+        return capped[: self.MAX_CAUTIONS - 1] + ([overflow] if overflow else [])
 
     def _generate_notes(
         self,

--- a/src/neo/events.py
+++ b/src/neo/events.py
@@ -1,0 +1,175 @@
+"""
+Lifecycle events emitted by NeoEngine during a single run.
+
+Neo's reasoning is otherwise a black box: `engine.py` makes no print calls, so
+a host (Claude Code, an MCP server, an IDE) sees nothing between invocation and
+the final NeoOutput. This module is the neutral seam that lets a host observe
+progress without the engine knowing which host it is talking to.
+
+Design rule: events carry *facts about Neo's process* — phase names, counts,
+findings. They never carry host-specific presentation wording. Deciding how and
+when a fact becomes user-visible conversation belongs to the host, not here.
+
+Sinks are best-effort observers. `safe_emit` swallows sink failures so a broken
+or full output stream can never take down a reasoning run.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+import json
+import logging
+from typing import Any, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class NeoEventType(str, Enum):
+    """Kinds of lifecycle event a run can emit.
+
+    Inherits from `str` so `json.dumps` serializes members directly and
+    comparisons against raw strings (in tests, in host adapters) hold.
+    """
+
+    STARTED = "started"
+    PHASE_STARTED = "phase_started"
+    PHASE_COMPLETED = "phase_completed"
+    MEMORY_FOUND = "memory_found"
+    HYPOTHESIS_FORMED = "hypothesis_formed"
+    HYPOTHESIS_REJECTED = "hypothesis_rejected"
+    RISK_FOUND = "risk_found"
+    PERSONALITY_BEAT = "personality_beat"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# Canonical phase names. Hosts key progress display off these, so they are a
+# compatibility surface: add freely, rename never.
+#
+# CONTEXT covers file gathering only — it is deliberately NOT called
+# "retrieval", because fact retrieval happens later, while REASONING is open.
+# A phase whose name overstates its span forces every emitter inside it to
+# either lie or work around the name.
+PHASE_CONTEXT = "context"
+PHASE_REASONING = "reasoning"
+PHASE_STATIC_CHECKS = "static_checks"
+# Not a phase — never opened or closed, only used to label the personality
+# beat emitted while the output is assembled. Hosts will never see
+# `phase_started: finalize`.
+PHASE_FINALIZE = "finalize"
+
+
+@dataclass
+class NeoEvent:
+    """One observation about an in-flight run.
+
+    `message` is a short human-readable statement of fact. `data` carries the
+    structured detail a host may want to render itself rather than parse back
+    out of prose.
+    """
+
+    type: NeoEventType
+    phase: str = ""
+    message: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializable form. Empty fields are dropped to keep lines short."""
+        payload: dict[str, Any] = {"type": self.type.value}
+        if self.phase:
+            payload["phase"] = self.phase
+        if self.message:
+            payload["message"] = self.message
+        if self.data:
+            payload["data"] = self.data
+        return payload
+
+
+class NeoEventSink(Protocol):
+    """Receives events as they happen.
+
+    Implementations must be cheap and must not raise; callers route through
+    `safe_emit`, which enforces the second half of that contract anyway.
+    """
+
+    def emit(self, event: NeoEvent) -> None: ...
+
+
+class NullSink:
+    """Discards everything. The default, so an unobserved run costs nothing."""
+
+    def emit(self, event: NeoEvent) -> None:
+        return None
+
+
+class RecordingSink:
+    """Keeps events in memory. For tests and for post-hoc inspection."""
+
+    def __init__(self) -> None:
+        self.events: list[NeoEvent] = []
+
+    def emit(self, event: NeoEvent) -> None:
+        self.events.append(event)
+
+    def of_type(self, event_type: NeoEventType) -> list[NeoEvent]:
+        return [e for e in self.events if e.type is event_type]
+
+
+# Messages are raw LM prose (a plan step, a simulation issue, a linter
+# summary) and so have no natural bound. One multi-KB line is hostile to a
+# host reading line-by-line, and the rest of this engine already truncates
+# for logs. Truncation is marked, never silent.
+MAX_MESSAGE_CHARS = 500
+
+
+class JsonlSink:
+    """Writes one JSON object per line to a text stream.
+
+    Flushed per event so a streaming host sees progress as it happens. The
+    CLI's own plugin host cannot read incrementally — a `Bash` call returns
+    everything at once — but an MCP server or IDE can, and at single-digit
+    events per run the flush costs nothing either way.
+
+    Not thread-safe: interleaved writes from two threads could split a line.
+    Only the main thread emits today.
+    """
+
+    def __init__(self, stream) -> None:
+        self.stream = stream
+
+    def emit(self, event: NeoEvent) -> None:
+        payload = event.to_dict()
+        message = payload.get("message", "")
+        if len(message) > MAX_MESSAGE_CHARS:
+            payload["message"] = message[: MAX_MESSAGE_CHARS - 1].rstrip() + "…"
+            payload["truncated"] = True
+        self.stream.write(json.dumps(payload) + "\n")
+        self.stream.flush()
+
+
+_sink_failure_reported = False
+
+
+def safe_emit(sink: Optional[NeoEventSink], event: NeoEvent) -> None:
+    """Emit without letting an observer break the thing being observed.
+
+    A closed pipe, a full disk, or a buggy third-party sink must degrade to
+    "no progress reporting", never to a failed reasoning run.
+
+    The first failure is logged at WARNING and the rest at DEBUG: a broken sink
+    should be findable at default log levels without one bad stream turning
+    into a per-event flood.
+    """
+    global _sink_failure_reported
+    if sink is None:
+        return
+    try:
+        sink.emit(event)
+    except Exception as exc:
+        if not _sink_failure_reported:
+            _sink_failure_reported = True
+            logger.warning(
+                "event sink failed (%s: %s); progress reporting is degraded "
+                "for the rest of this process", type(exc).__name__, exc
+            )
+        else:
+            logger.debug("event sink failed: %s", exc)

--- a/src/neo/models.py
+++ b/src/neo/models.py
@@ -283,6 +283,32 @@ class StaticCheckResult:
 
 
 @dataclass
+class OrchestratorMessage:
+    """What a host should say about this run, derived from what Neo did.
+
+    Everything here is redundant with the rest of NeoOutput — that is the
+    point. Without it a host has to reverse-engineer presentation out of raw
+    plans and simulation traces, and each host reinvents that badly. Neo states
+    the facts about its own process once; the host decides which reach the user.
+    """
+
+    summary: str = ""
+    """One or two sentences: what Neo did and what it concluded."""
+
+    personality: str = ""
+    """An in-voice line, present only when a beat is tied to a real finding."""
+
+    phase_summary: list[dict[str, Any]] = field(default_factory=list)
+    """Per-phase {name, status, message} records, in execution order."""
+
+    cautions: list[str] = field(default_factory=list)
+    """Things a host should not let a confident-sounding answer bury."""
+
+    recommended_narration: list[str] = field(default_factory=list)
+    """Suggested progress lines. Advisory — the host owns final wording."""
+
+
+@dataclass
 class NeoOutput:
     """Output payload back to the CLI tool."""
     plan: list[PlanStep]
@@ -296,6 +322,7 @@ class NeoOutput:
     goal_assessment: Optional[GoalAssessment] = None
     strategy_assessment: Optional[StrategyAssessment] = None
     recommended_next_action: dict[str, Any] = field(default_factory=dict)
+    orchestrator: OrchestratorMessage = field(default_factory=OrchestratorMessage)
 
 
 class RegenerateStats(TypedDict):

--- a/src/neo/progress.py
+++ b/src/neo/progress.py
@@ -1,0 +1,48 @@
+"""Human-readable progress notices on stderr.
+
+These are the `[Neo] …` lines a person watching a terminal reads while context
+is gathered. They are distinct from two neighbouring channels and should not be
+confused with either:
+
+- `neo.events` — machine-readable JSONL for a host, emitted on the same stream.
+- `logging` (`--verbose` / `--debug`) — diagnostics, off by default.
+
+Progress notices are on by default and suppressed by `--quiet`, and `--json`
+implies quiet: under `--json` the event stream carries the same information in
+a parseable form, and mixing prose into it forces every host to filter.
+
+The suppression flag is process-global rather than threaded through call
+arguments. It is a display setting fixed once from argv and read by leaf
+functions five layers below the CLI (`gather_context` → `_project_index_boost`
+→ …); passing it down would put a presentation parameter into the signature of
+every scoring helper it crosses.
+"""
+
+import sys
+
+_quiet = False
+
+
+def set_quiet(quiet: bool) -> None:
+    """Enable or disable progress notices for the rest of the process."""
+    global _quiet
+    _quiet = quiet
+
+
+def is_quiet() -> bool:
+    return _quiet
+
+
+def note(message: str) -> None:
+    """Print one `[Neo] …` progress line to stderr, unless suppressed.
+
+    Best-effort: a closed or unwritable stderr must not take down a run that
+    was otherwise fine, for the same reason `events.safe_emit` swallows sink
+    failures.
+    """
+    if _quiet:
+        return
+    try:
+        print(f"[Neo] {message}", file=sys.stderr)
+    except Exception:
+        pass

--- a/src/neo/repair_loop.py
+++ b/src/neo/repair_loop.py
@@ -146,8 +146,8 @@ def repair_response(
             )
 
             # Parse the repaired response
-            from structured_parser import parse_structured_response
-            from schemas import (
+            from neo.structured_parser import parse_structured_response
+            from neo.schemas import (
                 PLAN_STEP_SCHEMA,
                 SIMULATION_TRACE_SCHEMA,
                 CODE_SUGGESTION_SCHEMA

--- a/tests/test_orchestrator_events.py
+++ b/tests/test_orchestrator_events.py
@@ -1,0 +1,527 @@
+"""Tests for the host-facing layer: lifecycle events and OrchestratorMessage.
+
+These cover the contract a host (Claude Code, an MCP server, an IDE) relies on:
+which events fire and in what order, what the derived summary claims, and when
+Neo stays silent rather than emitting unearned personality.
+"""
+
+import io
+import json
+
+import pytest
+
+from neo.engine import NeoEngine
+from neo.events import (
+    JsonlSink,
+    NeoEvent,
+    NeoEventType,
+    NullSink,
+    RecordingSink,
+    safe_emit,
+)
+from neo.models import NeoInput, ProposedChange, TaskType
+from neo.operating_mode import OperatingMode
+from neo.schemas import SCHEMA_VERSION
+
+
+def _block(kind, payload):
+    return f"<<<NEO:SCHEMA=v3:KIND={kind}>>>\n{json.dumps(payload)}\n<<<END:{kind}>>>"
+
+
+def _response(*, issues=None, confidence=0.9):
+    plan = [{
+        "id": "ps_1",
+        "description": "Add a guard clause before the deref",
+        "rationale": "the parser crashes on empty input",
+        "dependencies": [],
+        "risk": "low",
+        "schema_version": SCHEMA_VERSION,
+    }]
+    sim = [{
+        "n": 1,
+        "input_data": "empty string",
+        "expected_output": "returns None",
+        "reasoning_steps": ["parser sees an empty token"],
+        "issues_found": list(issues or []),
+        "schema_version": SCHEMA_VERSION,
+    }]
+    code = [{
+        "file_path": "src/parser.py",
+        "unified_diff": "--- a\n+++ b\n",
+        "description": "guard the deref",
+        "confidence": confidence,
+        "tradeoffs": [],
+        "schema_version": SCHEMA_VERSION,
+    }]
+    return "\n".join([
+        _block("plan", plan), _block("simulation", sim), _block("code", code),
+    ])
+
+
+class FakeLM:
+    """Returns one canned structured response regardless of the prompt."""
+
+    model = "fake"
+    provider = "fake"
+
+    def __init__(self, response):
+        self._response = response
+
+    def generate(self, messages, **kwargs):
+        return self._response
+
+    def name(self):
+        return "fake-lm"
+
+
+def _run(response, prompt="fix the crash in the parser", task_type=TaskType.BUGFIX):
+    sink = RecordingSink()
+    engine = NeoEngine(
+        lm_adapter=FakeLM(response),
+        enable_persistent_memory=False,
+        event_sink=sink,
+    )
+    output = engine.process(NeoInput(prompt=prompt, task_type=task_type))
+    return output, sink
+
+
+# ---------------------------------------------------------------- sinks
+
+
+def test_null_sink_is_the_default():
+    engine = NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+    assert isinstance(engine.event_sink, NullSink)
+
+
+def test_jsonl_sink_writes_one_json_object_per_line():
+    stream = io.StringIO()
+    sink = JsonlSink(stream)
+    sink.emit(NeoEvent(type=NeoEventType.STARTED, message="a"))
+    sink.emit(NeoEvent(type=NeoEventType.COMPLETED, phase="finalize", message="b"))
+
+    lines = stream.getvalue().strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"type": "started", "message": "a"}
+    assert json.loads(lines[1])["phase"] == "finalize"
+
+
+def test_event_to_dict_drops_empty_fields():
+    """Keeps lines short; a host must not have to skip past empty keys."""
+    assert NeoEvent(type=NeoEventType.STARTED).to_dict() == {"type": "started"}
+
+
+def test_a_failing_sink_cannot_break_the_run():
+    """An observer must never take down the thing it observes."""
+
+    class Exploding:
+        def emit(self, event):
+            raise RuntimeError("sink is broken")
+
+    safe_emit(Exploding(), NeoEvent(type=NeoEventType.STARTED))  # must not raise
+
+
+def test_engine_survives_a_failing_sink_end_to_end():
+    class Exploding:
+        def emit(self, event):
+            raise RuntimeError("sink is broken")
+
+    engine = NeoEngine(
+        lm_adapter=FakeLM(_response()),
+        enable_persistent_memory=False,
+        event_sink=Exploding(),
+    )
+    output = engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+    assert output.code_suggestions
+
+
+# ---------------------------------------------------------------- event stream
+
+
+def test_run_emits_started_and_completed():
+    _, sink = _run(_response())
+    types = [event.type for event in sink.events]
+    assert types[0] is NeoEventType.STARTED
+    assert types[-1] is NeoEventType.COMPLETED
+
+
+def test_completed_carries_confidence_and_elapsed():
+    output, sink = _run(_response())
+    data = sink.of_type(NeoEventType.COMPLETED)[0].data
+    assert data["confidence"] == pytest.approx(output.confidence, abs=0.01)
+    assert data["elapsed_seconds"] >= 0
+
+
+def test_phases_run_in_order_and_each_one_closes():
+    _, sink = _run(_response())
+    started = [e.phase for e in sink.of_type(NeoEventType.PHASE_STARTED)]
+    completed = [e.phase for e in sink.of_type(NeoEventType.PHASE_COMPLETED)]
+    assert started == ["context", "reasoning", "static_checks"]
+    assert completed == started
+
+
+def test_findings_are_emitted_before_their_phase_closes():
+    """A host replaying the stream should learn what was found before it is
+    told the phase finished."""
+    _, sink = _run(_response(issues=["callers may not handle None"]))
+    risk_index = next(
+        i for i, e in enumerate(sink.events)
+        if e.type is NeoEventType.RISK_FOUND
+    )
+    close_index = next(
+        i for i, e in enumerate(sink.events)
+        if e.type is NeoEventType.PHASE_COMPLETED and e.phase == "reasoning"
+    )
+    assert risk_index < close_index
+
+
+def test_simulation_issues_surface_as_risk_events():
+    _, sink = _run(_response(issues=["callers may not handle None"]))
+    risks = sink.of_type(NeoEventType.RISK_FOUND)
+    assert [r.message for r in risks] == ["callers may not handle None"]
+    assert risks[0].data["source"] == "simulation"
+
+
+def test_events_never_claim_a_phase_that_already_closed():
+    """Facts are retrieved from several call sites, most of them while the
+    reasoning phase is open. An event labeled with a closed phase would put a
+    host's progress display out of order."""
+    _, sink = _run(_response())
+    open_phases: set[str] = set()
+    for event in sink.events:
+        if event.type is NeoEventType.PHASE_STARTED:
+            open_phases.add(event.phase)
+        elif event.type is NeoEventType.PHASE_COMPLETED:
+            open_phases.discard(event.phase)
+        elif event.phase:
+            assert event.phase in open_phases or event.phase == "finalize", (
+                f"{event.type.value} claimed closed phase {event.phase!r}"
+            )
+
+
+def test_leading_plan_step_surfaces_as_a_hypothesis():
+    _, sink = _run(_response())
+    formed = sink.of_type(NeoEventType.HYPOTHESIS_FORMED)
+    assert formed[0].message == "Add a guard clause before the deref"
+
+
+# ------------------------------------------------- branches with their own shape
+
+
+def test_verify_mode_does_not_claim_neo_reasoned_or_proposed():
+    """VERIFY makes no LM call and echoes the CALLER's changes back for
+    checking. Saying "Neo reasoned" or "Neo proposes" there credits Neo with
+    the caller's work — and the host is told to lead with this line."""
+    sink = RecordingSink()
+    engine = NeoEngine(
+        lm_adapter=FakeLM(""), enable_persistent_memory=False, event_sink=sink,
+    )
+    output = engine.process(NeoInput(
+        prompt="verify this change",
+        operating_mode=OperatingMode.VERIFY,
+        proposed_changes=[ProposedChange(
+            file_path="src/example.py", code_block="value = 1",
+        )],
+    ))
+
+    summary = output.orchestrator.summary
+    assert "caller-supplied" in summary
+    assert "reasoned over the request" not in summary
+    assert "proposes" not in summary
+
+
+def test_verify_mode_does_not_tell_the_caller_to_verify_its_own_verification():
+    """VERIFY reports confidence as a pass/fail verdict, not self-assessed
+    certainty, so the low-confidence caution would be circular."""
+    engine = NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+    output = engine.process(NeoInput(
+        prompt="verify this change",
+        operating_mode=OperatingMode.VERIFY,
+        proposed_changes=[ProposedChange(
+            file_path="src/example.py", code_block="value = 1",
+        )],
+    ))
+    assert not any("Verify before acting" in c for c in output.orchestrator.cautions)
+
+
+def test_skipped_static_checks_still_open_the_phase_they_close(monkeypatch):
+    """A phase_completed with no phase_started leaves a host tracking a close
+    for something it never saw open."""
+    sink = RecordingSink()
+    engine = NeoEngine(
+        lm_adapter=FakeLM(_response()),
+        enable_persistent_memory=False,
+        event_sink=sink,
+    )
+    # Zero budget: elapsed always exceeds the static-check buffer.
+    monkeypatch.setattr(engine, "_get_time_budget", lambda difficulty: 0.0)
+    engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+
+    started = [e.phase for e in sink.of_type(NeoEventType.PHASE_STARTED)]
+    completed = [e.phase for e in sink.of_type(NeoEventType.PHASE_COMPLETED)]
+    assert started == completed
+    assert "static_checks" in started
+    skip = [
+        e for e in sink.of_type(NeoEventType.PHASE_COMPLETED)
+        if e.phase == "static_checks"
+    ][0]
+    assert skip.data["status"] == "skipped"
+
+
+def test_skipped_static_checks_caution_names_the_budget_not_missing_tools(monkeypatch):
+    """Two different facts with two different remedies: install a linter, or
+    give the run more time."""
+    engine = NeoEngine(lm_adapter=FakeLM(_response()), enable_persistent_memory=False)
+    monkeypatch.setattr(engine, "_get_time_budget", lambda difficulty: 0.0)
+    output = engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+    assert any("skipped for time budget" in c for c in output.orchestrator.cautions)
+    assert not any("tools were available" in c for c in output.orchestrator.cautions)
+
+
+def test_panel_fallback_closes_its_phase_and_opens_a_second_one(monkeypatch):
+    """A failed panel closes `reasoning` as a fallback and the fast path opens
+    a second `reasoning` record — the case `_end_phase`'s reverse search
+    exists for."""
+    from neo.reasoning_mode import ReasoningMode
+
+    sink = RecordingSink()
+    engine = NeoEngine(
+        lm_adapter=FakeLM(_response()),
+        enable_persistent_memory=False,
+        event_sink=sink,
+    )
+
+    class _Decision:
+        mode = ReasoningMode.MULTI_AGENT
+        reason = "forced for test"
+
+    monkeypatch.setattr(
+        engine, "_decide_reasoning_mode",
+        lambda context, difficulty, neo_input: (_Decision(), lambda *a, **k: ""),
+    )
+    # Panel returns nothing usable — the documented fallback path.
+    monkeypatch.setattr(
+        engine, "_deliberate", lambda context, route_fn: (None, None, None, None),
+    )
+    engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+
+    reasoning_closes = [
+        e for e in sink.of_type(NeoEventType.PHASE_COMPLETED) if e.phase == "reasoning"
+    ]
+    assert [e.data["status"] for e in reasoning_closes] == ["fallback", "complete"]
+    assert len(
+        [e for e in sink.of_type(NeoEventType.PHASE_STARTED) if e.phase == "reasoning"]
+    ) == 2
+    assert sink.of_type(NeoEventType.HYPOTHESIS_REJECTED)
+
+
+def test_a_failed_run_still_emits_a_terminal_event():
+    """STARTED then silence is worse than never emitting: a host cannot tell a
+    crash from a hang."""
+    class Exploding:
+        model = "fake"
+        provider = "fake"
+
+        def generate(self, messages, **kwargs):
+            raise RuntimeError("model exploded")
+
+        def name(self):
+            return "fake-lm"
+
+    sink = RecordingSink()
+    engine = NeoEngine(
+        lm_adapter=Exploding(), enable_persistent_memory=False, event_sink=sink,
+    )
+    with pytest.raises(Exception):
+        engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+
+    failures = sink.of_type(NeoEventType.FAILED)
+    assert failures and failures[0].data["error_type"]
+    assert sink.events[-1].type is NeoEventType.FAILED
+
+
+def test_a_failed_run_leaves_no_phase_stuck_running():
+    class Exploding:
+        model = "fake"
+        provider = "fake"
+
+        def generate(self, messages, **kwargs):
+            raise RuntimeError("model exploded")
+
+        def name(self):
+            return "fake-lm"
+
+    engine = NeoEngine(lm_adapter=Exploding(), enable_persistent_memory=False)
+    with pytest.raises(Exception):
+        engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+    assert all(r["status"] != "running" for r in engine._phase_records)
+
+
+# ---------------------------------------------------------------- orchestrator
+
+
+def test_summary_names_what_ran_and_what_it_produced():
+    output, _ = _run(_response())
+    summary = output.orchestrator.summary
+    assert "1 change(s)" in summary
+    assert "src/parser.py" in summary
+    assert f"{output.confidence:.2f}" in summary
+
+
+def test_phase_summary_mirrors_the_phase_events():
+    output, sink = _run(_response())
+    names = [record["name"] for record in output.orchestrator.phase_summary]
+    assert names == [e.phase for e in sink.of_type(NeoEventType.PHASE_COMPLETED)]
+    assert all(r["status"] != "running" for r in output.orchestrator.phase_summary)
+
+
+def test_low_confidence_becomes_a_caution():
+    output, _ = _run(_response(confidence=0.2))
+    assert any("Verify before acting" in c for c in output.orchestrator.cautions)
+
+
+def test_simulation_issues_become_a_caution():
+    output, _ = _run(_response(issues=["callers may not handle None"]))
+    assert any("Simulation surfaced" in c for c in output.orchestrator.cautions)
+
+
+def test_narration_carries_only_closed_phases():
+    output, _ = _run(_response())
+    assert output.orchestrator.recommended_narration
+    assert all(line for line in output.orchestrator.recommended_narration)
+
+
+# ---------------------------------------------------------------- personality
+
+
+def _engine_for_beats():
+    return NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+
+
+def test_beat_requiring_a_finding_is_withheld_without_one():
+    """A beat that claims insight must not fire on a run that found nothing."""
+    engine = _engine_for_beats()
+    engine.context = NeoInput(prompt="optimize the search algorithm")
+    engine._findings = []
+    assert engine._orchestrator_beat(confidence=0.9) == ""
+
+
+def test_beat_requiring_a_finding_fires_once_there_is_one():
+    engine = _engine_for_beats()
+    engine.context = NeoInput(prompt="optimize the search algorithm")
+    engine._findings = ["prior knowledge: hash lookups beat scans here"]
+    assert engine._orchestrator_beat(confidence=0.9) == (
+        "The obvious answer is probably the wrong one here."
+    )
+
+
+def test_internal_only_beats_never_reach_the_host():
+    """Absent or non-orchestrator `surface` means terminal-only."""
+    engine = _engine_for_beats()
+    engine.context = NeoInput(prompt="refactor the module")
+    engine._findings = ["something"]
+    for beat in engine.beat_deck["beats"]:
+        beat["surface"] = "internal"
+    assert engine._orchestrator_beat(confidence=0.9) == ""
+
+
+def test_no_matching_beat_means_silence_not_a_fallback_line():
+    engine = _engine_for_beats()
+    engine.context = NeoInput(prompt="tell me about this repository layout")
+    engine._findings = []
+    assert engine._orchestrator_beat(confidence=0.5) == ""
+
+
+def test_surfaced_beat_is_also_emitted_as_an_event():
+    output, sink = _run(_response(), prompt="fix the crash in the parser")
+    beats = sink.of_type(NeoEventType.PERSONALITY_BEAT)
+    if output.orchestrator.personality:
+        assert beats and beats[0].message == output.orchestrator.personality
+    else:
+        assert not beats
+
+
+def test_orchestrator_survives_the_cli_serialization_path():
+    """The CLI emits `asdict(output.orchestrator)` into its JSON document; if
+    that is not serializable the whole result is lost, not just the summary."""
+    from dataclasses import asdict
+
+    output, _ = _run(_response(issues=["callers may not handle None"]))
+    payload = asdict(output.orchestrator)
+    round_tripped = json.loads(json.dumps(payload))
+
+    assert round_tripped["summary"] == output.orchestrator.summary
+    assert round_tripped["cautions"] == output.orchestrator.cautions
+    assert round_tripped["phase_summary"] == output.orchestrator.phase_summary
+
+
+def test_orchestrator_is_populated_on_every_finalized_path():
+    """Both the full pipeline and the early-exit path build the message; a host
+    must never receive an empty envelope it has to fall back from."""
+    output, _ = _run(_response())
+    assert output.orchestrator.summary
+    assert output.orchestrator.phase_summary
+
+
+def test_one_run_speaks_with_one_voice():
+    """`--json` carries both `notes` and `orchestrator.personality`. When each
+    surface selected its own beat they could disagree — one character, two
+    voices, same response."""
+    engine = _engine_for_beats()
+    engine.context = NeoInput(prompt="optimize the search algorithm")
+    engine._findings = ["prior knowledge: something"]
+
+    first = engine._run_beat(confidence=0.95)
+    # A later caller with no confidence (the notes path) must not reselect.
+    assert engine._run_beat() is first
+    assert engine._run_beat(confidence=0.1) is first
+
+
+def test_beat_selection_resets_between_runs():
+    engine = NeoEngine(
+        lm_adapter=FakeLM(_response()), enable_persistent_memory=False,
+    )
+    engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+    first = engine._selected_beat
+    engine.process(NeoInput(prompt="refactor the module", task_type=TaskType.REFACTOR))
+    assert engine._beat_selected
+    assert engine._selected_beat is not first
+
+
+def test_no_memory_match_is_reachable():
+    """`unfamiliar_codebase` was configured, surfaceable, and unreachable: no
+    trigger it declares was ever produced, so its line was dead text."""
+    engine = _engine_for_beats()
+    beat = engine._select_beat({"prompt": "explain this module", "memory_checked": True})
+    assert beat is not None
+    assert beat["beat_id"] == "unfamiliar_codebase"
+
+
+def test_memory_hit_beats_no_memory_match():
+    engine = _engine_for_beats()
+    beat = engine._select_beat({
+        "prompt": "explain this module", "memory_checked": True, "memory_hit": True,
+    })
+    assert beat is not None
+    assert beat["beat_id"] == "pattern_match"
+
+
+def test_every_declared_beat_can_actually_fire():
+    """A beat whose triggers `_select_beat` never emits is dead configuration
+    that no wording test can catch."""
+    engine = _engine_for_beats()
+    reachable = {
+        "error_trace_present", "bugfix", "refactor", "algorithm", "optimization",
+        "high_confidence", "memory_hit", "familiar_pattern", "no_memory_match",
+    }
+    for beat in engine.beat_deck["beats"]:
+        triggers = set(beat.get("trigger_contexts", []))
+        assert triggers & reachable, f"{beat['beat_id']} can never fire"
+
+
+def test_every_surfaceable_beat_declares_its_wording():
+    """A beat marked orchestrator-surfaceable with no line would emit nothing
+    and silently look like a non-matching beat."""
+    engine = _engine_for_beats()
+    for beat in engine.beat_deck["beats"]:
+        if beat.get("surface") == "orchestrator":
+            assert beat.get("orchestrator_line"), beat["beat_id"]

--- a/tests/test_orchestrator_events.py
+++ b/tests/test_orchestrator_events.py
@@ -224,8 +224,9 @@ def test_verify_mode_does_not_claim_neo_reasoned_or_proposed():
     ))
 
     summary = output.orchestrator.summary
-    assert "caller-supplied" in summary
-    assert "reasoned over the request" not in summary
+    assert "You gave me" in summary
+    assert "I didn't write them" in summary
+    assert "I read it" not in summary
     assert "proposes" not in summary
 
 
@@ -240,7 +241,7 @@ def test_verify_mode_does_not_tell_the_caller_to_verify_its_own_verification():
             file_path="src/example.py", code_block="value = 1",
         )],
     ))
-    assert not any("Verify before acting" in c for c in output.orchestrator.cautions)
+    assert not any("Don't take it on trust" in c for c in output.orchestrator.cautions)
 
 
 def test_skipped_static_checks_still_open_the_phase_they_close(monkeypatch):
@@ -273,8 +274,8 @@ def test_skipped_static_checks_caution_names_the_budget_not_missing_tools(monkey
     engine = NeoEngine(lm_adapter=FakeLM(_response()), enable_persistent_memory=False)
     monkeypatch.setattr(engine, "_get_time_budget", lambda difficulty: 0.0)
     output = engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
-    assert any("skipped for time budget" in c for c in output.orchestrator.cautions)
-    assert not any("tools were available" in c for c in output.orchestrator.cautions)
+    assert any("ran out of time" in c for c in output.orchestrator.cautions)
+    assert not any("No checkers on this machine" in c for c in output.orchestrator.cautions)
 
 
 def test_panel_fallback_closes_its_phase_and_opens_a_second_one(monkeypatch):
@@ -362,7 +363,7 @@ def test_a_failed_run_leaves_no_phase_stuck_running():
 def test_summary_names_what_ran_and_what_it_produced():
     output, _ = _run(_response())
     summary = output.orchestrator.summary
-    assert "1 change(s)" in summary
+    assert "1 thing(s)" in summary
     assert "src/parser.py" in summary
     assert f"{output.confidence:.2f}" in summary
 
@@ -376,18 +377,135 @@ def test_phase_summary_mirrors_the_phase_events():
 
 def test_low_confidence_becomes_a_caution():
     output, _ = _run(_response(confidence=0.2))
-    assert any("Verify before acting" in c for c in output.orchestrator.cautions)
+    assert any("Don't take it on trust" in c for c in output.orchestrator.cautions)
 
 
 def test_simulation_issues_become_a_caution():
     output, _ = _run(_response(issues=["callers may not handle None"]))
-    assert any("Simulation surfaced" in c for c in output.orchestrator.cautions)
+    assert any("problem(s) with my own approach" in c for c in output.orchestrator.cautions)
 
 
 def test_narration_carries_only_closed_phases():
     output, _ = _run(_response())
     assert output.orchestrator.recommended_narration
     assert all(line for line in output.orchestrator.recommended_narration)
+
+
+# ---------------------------------------------------------------- voice
+
+
+class _Memory:
+    """Just enough persistent-memory surface to drive the stage lookup."""
+
+    def __init__(self, level):
+        self._level = level
+
+    def memory_level(self):
+        return self._level
+
+
+def _summary_at(level, *, mode="fast", confidence=0.88):
+    from neo.models import CodeSuggestion, PlanStep
+
+    engine = NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+    engine.persistent_memory = _Memory(level)
+    engine.context = NeoInput(prompt="fix the parser crash")
+    engine.last_reasoning_mode = mode
+    message = engine._build_orchestrator_message(
+        plan=[PlanStep(description="Add a guard", rationale="crash")],
+        simulation_traces=[],
+        code_suggestions=[CodeSuggestion(
+            file_path="src/parser.py", unified_diff="", description="guard",
+            confidence=confidence,
+        )],
+        static_checks=[],
+        next_questions=[],
+        confidence=confidence,
+        early_exit=False,
+    )
+    return message
+
+
+# 0.1 Sleeper, 0.3 Glitch, 0.5 Unplugged, 0.7 Training, 0.9 The One
+_LEVELS = [0.1, 0.3, 0.5, 0.7, 0.9]
+
+
+def test_voice_changes_with_memory_level():
+    """Neo's certainty grows with what he remembers, so the same facts must not
+    produce the same sentence at every stage."""
+    summaries = [_summary_at(level).summary for level in _LEVELS]
+    assert len(set(summaries)) == len(_LEVELS)
+
+
+def test_early_stages_hedge_and_the_one_does_not():
+    assert _summary_at(0.1).summary.endswith("Confidence 0.88.")
+    assert ", maybe" in _summary_at(0.1).summary
+    assert ", maybe" not in _summary_at(0.9).summary
+
+
+def test_the_one_drops_the_opener_and_leads_with_the_fact():
+    """Stage 5 is two words where stage 1 is a paragraph."""
+    terse = _summary_at(0.9).summary
+    assert terse.startswith("src/parser.py")
+    assert "Confidence" not in terse  # the number alone
+    assert len(terse) < len(_summary_at(0.1).summary)
+
+
+def test_every_stage_still_states_the_facts():
+    """Voice may vary; the numbers may not go missing."""
+    for level in _LEVELS:
+        summary = _summary_at(level).summary
+        assert "0.88" in summary, level
+        assert "src/parser.py" in summary, level
+
+
+def test_the_panel_opener_differs_from_the_solo_one():
+    for level in _LEVELS:
+        solo = _summary_at(level, mode="fast").summary
+        panel = _summary_at(level, mode="multi_agent").summary
+        assert solo != panel, level
+
+
+def test_cautions_do_not_vary_by_stage():
+    """A host is told never to drop a caution, so a warning must read the same
+    whether Neo is a Sleeper or The One. Voice is not licence to soften."""
+    cautions = [tuple(_summary_at(level, confidence=0.4).cautions) for level in _LEVELS]
+    assert len(set(cautions)) == 1
+    assert any("Don't take it on trust" in c for c in cautions[0])
+
+
+def test_engine_holds_no_prose_of_its_own():
+    """All wording lives in the beat deck so the character can be retuned
+    without editing code. A literal here is a personality change hidden in a
+    diff nobody reads as one."""
+    from pathlib import Path
+
+    # Comments may quote the wording to explain a decision; only executable
+    # lines are the concern, since those are what actually reach a user.
+    source = "\n".join(
+        line for line in Path("src/neo/engine.py").read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    for phrase in ("I'd change", "Reading the code", "Don't take it on trust",
+                   "Running the checkers", "I remember"):
+        assert phrase not in source, phrase
+
+
+def test_a_broken_voice_template_degrades_to_silence():
+    """A formatting slip in a personality file must not take down a run."""
+    engine = NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+    engine.beat_deck["orchestrator_voice"]["lines"]["started"] = "{nonexistent}"
+    assert engine._voice("started") == ""
+    assert engine._voice("no_such_key_at_all") == ""
+
+
+def test_voice_falls_back_when_the_stage_is_missing():
+    engine = NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+    engine.beat_deck["orchestrator_voice"]["stages"] = {
+        3: {"opener_solo": "I read it.", "hedge": "", "confidence_lead": "Confidence"}
+    }
+    engine.persistent_memory = _Memory(0.95)  # stage 5, absent from the deck
+    assert engine._voice_stage()["opener_solo"] == "I read it."
 
 
 # ---------------------------------------------------------------- personality

--- a/tests/test_progress_quiet.py
+++ b/tests/test_progress_quiet.py
@@ -1,0 +1,76 @@
+"""Tests for `[Neo]` progress-notice suppression.
+
+`--quiet` was defined in the CLI parser but never read, so progress notices
+could not be turned off. Under `--json` that left prose interleaved with the
+JSONL event stream on stderr, forcing every host to filter it back out.
+"""
+
+import pytest
+
+from neo import progress
+
+
+@pytest.fixture(autouse=True)
+def reset_quiet():
+    """Progress state is process-global; never leak it between tests."""
+    original = progress.is_quiet()
+    yield
+    progress.set_quiet(original)
+
+
+def test_notices_print_by_default(capsys):
+    progress.set_quiet(False)
+    progress.note("Gathered 25 files")
+    captured = capsys.readouterr()
+    assert captured.err == "[Neo] Gathered 25 files\n"
+    assert captured.out == ""
+
+
+def test_quiet_suppresses_notices(capsys):
+    progress.set_quiet(True)
+    progress.note("Gathered 25 files")
+    assert capsys.readouterr().err == ""
+
+
+def test_notices_never_reach_stdout(capsys):
+    """stdout must stay exactly one JSON document under --json."""
+    progress.set_quiet(False)
+    progress.note("anything")
+    assert capsys.readouterr().out == ""
+
+
+def test_a_broken_stderr_does_not_break_the_run(monkeypatch):
+    """Same policy as events.safe_emit: reporting must not take down the run."""
+    progress.set_quiet(False)
+
+    def explode(*args, **kwargs):
+        raise OSError("stderr is closed")
+
+    monkeypatch.setattr("builtins.print", explode)
+    progress.note("still fine")  # must not raise
+
+
+def test_context_gatherer_routes_through_progress():
+    """Pins the wiring: a stray `print("[Neo] ...")` would silently reintroduce
+    unsuppressable output."""
+    from pathlib import Path
+
+    source = Path("src/neo/context_gatherer.py").read_text()
+    assert "[Neo]" not in source
+    assert "progress.note(" in source
+
+
+@pytest.mark.parametrize(
+    "quiet,json_mode,expected",
+    [
+        (False, False, False),  # default: notices on
+        (True, False, True),    # explicit --quiet
+        (False, True, True),    # --json implies quiet
+        (True, True, True),
+    ],
+)
+def test_cli_quiet_resolution(quiet, json_mode, expected):
+    """The rule main() applies: --json implies --quiet, because the event
+    stream already carries this information in parseable form."""
+    resolved = bool(quiet or json_mode)
+    assert resolved is expected

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -1,0 +1,119 @@
+"""Tests for the malformed-response repair loop.
+
+Regression coverage for an import bug that survived from the initial public
+release: `repair_loop` imported `structured_parser` and `schemas` unqualified,
+which can never resolve inside the installed package. Every repair attempt died
+on ModuleNotFoundError and was swallowed by the attempt loop's `except`, so the
+feature was silently dead and no test noticed.
+"""
+
+import json
+
+from neo.repair_loop import repair_response
+from neo.schemas import SCHEMA_VERSION
+from neo.structured_parser import ParseErrorCode, ParseResult
+
+
+def _valid_plan_block():
+    payload = [{
+        "id": "ps_1",
+        "description": "Add a guard clause",
+        "rationale": "avoid the crash",
+        "dependencies": [],
+        "schema_version": SCHEMA_VERSION,
+    }]
+    return (
+        f"<<<NEO:SCHEMA=v3:KIND=plan>>>\n{json.dumps(payload)}\n<<<END:plan>>>"
+    )
+
+
+class _FormatterLM:
+    """Returns a well-formed block, as a real formatter model would."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = 0
+
+    def generate(self, messages, **kwargs):
+        self.calls += 1
+        return self._response
+
+    def name(self):
+        return "fake-formatter"
+
+
+def _failed_parse():
+    return ParseResult(
+        success=False,
+        error_code=ParseErrorCode.MISSING_START_SENTINEL,
+        error_message="Missing start sentinel",
+    )
+
+
+def test_repair_recovers_a_malformed_plan_response():
+    """The end-to-end path. Before the import fix this returned success=False
+    with 'Failed to repair after 2 attempts' no matter what the formatter said."""
+    lm = _FormatterLM(_valid_plan_block())
+
+    result = repair_response(
+        bad_response="here is your plan, roughly",
+        parse_result=_failed_parse(),
+        kind="plan",
+        original_prompt="fix the parser",
+        lm_adapter=lm,
+    )
+
+    assert result.success, result.error_message
+    assert lm.calls == 1
+    assert result.repaired_response
+
+
+def test_repair_does_not_die_on_an_import_error():
+    """Pins the specific failure mode: the attempt loop catches Exception, so a
+    bad import surfaced only as a generic repair failure."""
+    lm = _FormatterLM(_valid_plan_block())
+
+    result = repair_response(
+        bad_response="malformed",
+        parse_result=_failed_parse(),
+        kind="plan",
+        original_prompt="fix the parser",
+        lm_adapter=lm,
+    )
+
+    assert "No module named" not in (result.error_message or "")
+
+
+def test_unrecoverable_errors_skip_the_formatter_call():
+    lm = _FormatterLM(_valid_plan_block())
+
+    result = repair_response(
+        bad_response="truncated",
+        parse_result=ParseResult(
+            success=False,
+            error_code=ParseErrorCode.TRUNCATION,
+            error_message="output truncated",
+        ),
+        kind="plan",
+        original_prompt="fix the parser",
+        lm_adapter=lm,
+    )
+
+    assert not result.success
+    assert lm.calls == 0
+
+
+def test_repair_gives_up_after_max_attempts():
+    lm = _FormatterLM("still not a structured block")
+
+    result = repair_response(
+        bad_response="malformed",
+        parse_result=_failed_parse(),
+        kind="plan",
+        original_prompt="fix the parser",
+        lm_adapter=lm,
+        max_attempts=2,
+    )
+
+    assert not result.success
+    assert lm.calls == 2


### PR DESCRIPTION
## Description

Adds a host-facing communication layer so an orchestrator (Claude Code, an MCP server, an IDE) can narrate a Neo run instead of waiting on a black box.

**Governing rule: Neo reports facts about its process; the host decides how and when those facts become conversation.** No host-specific wording lives in `engine.py`.

- **`src/neo/events.py`** (new) — `NeoEventType`, `NeoEvent`, `NeoEventSink` Protocol, `NullSink`/`RecordingSink`/`JsonlSink`, `safe_emit`.
- **`engine.py`** — `event_sink` ctor param (defaults `NullSink`, so an unobserved run costs what it always did); emission at phase boundaries; `OrchestratorMessage` derived from state already computed.
- **`models.py`** — `OrchestratorMessage` on `NeoOutput`: `summary`, `personality`, `phase_summary`, `cautions`, `recommended_narration`.
- **`cli.py`** — `--json` writes JSONL events to **stderr** and keeps stdout as exactly one JSON document.
- **`neo_matrix.yaml`** — an `orchestrator_voice` section (per-stage register + every user-facing line), plus `surface`/`importance`/`requires_finding`/`orchestrator_line` per beat.
- **`progress.py`** (new) — `[Neo]` progress notices, suppressible. `--quiet` had been declared and never read.
- **`.claude-plugin/`** — full presentation contract in `agents/neo.md`, plus a tailored presentation section per command.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None — the gap was found by auditing the plugin against the engine.

## Motivation and Context

`engine.py` made **zero** `print`/stderr calls, so a host saw nothing between invoking Neo and receiving the final `NeoOutput`.

The plugin compounded it: `agents/neo.md` told the agent to run `neo --mode advise` and parse the **human-readable text** output, even though `--json` already existed. So the host was reverse-engineering presentation out of terminal formatting while a fully structured document sat one flag away — and every future host would reinvent that inference, badly and differently.

The `--json` help text already promised *"JSONL events and final JSON"* that were never emitted.

### Design decisions worth review

**Two streams, not interleaved.** Honoring the old help text literally would break every `neo --json | jq` consumer. stdout stays exactly one JSON document; events go to stderr. Verified: the `--index` prints all terminate in `sys.exit(0)` and never coexist with a reasoning run.

**The first phase is `context`, not `retrieval`.** It covers file gathering only — fact retrieval runs during `reasoning`. The overstated name forced every emitter inside it to compensate.

**VERIFY mode gets its own summary sentence.** That path makes no LM call and its `code_suggestions` are the *caller's* `proposed_changes` echoed back for checking. The generic wording ("Neo reasoned over the request and proposes N change(s)") credited Neo with the caller's work, and hosts are told to lead with the summary verbatim. VERIFY also suppresses the low-confidence caution — its confidence is a pass/fail verdict, so "verify before acting" was circular.

**Neo speaks as Neo, and the register follows memory level.** Third-person narration ("Neo reasoned over the request and proposes 1 change(s)") reads like a status board, not like the character the deck defines — and the summary is the line hosts lead with. But first person alone was only half the fix: the register must track `_memory_level_to_stage()`, because the system already computes that signal.

| Stage | Same facts, rendered |
|---|---|
| 1 Sleeper | `Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe. Confidence 0.88.` |
| 3 Unplugged | `I read it. I'd change 1 thing(s) in src/parser.py. Confidence 0.88.` |
| 5 The One | `src/parser.py. 1 change(s). 0.88.` |

**No prose lives in `engine.py`.** All wording comes from `orchestrator_voice.lines` via `_voice(key, **fmt)`, so the character is retuned by editing YAML. `test_engine_holds_no_prose_of_its_own` pins it: a literal in the engine is a personality change hidden inside a code diff nobody reviews as one. Cautions and progress messages deliberately do *not* vary by stage — a host is told never to drop a caution, so a warning must read the same at stage 1 and stage 5. Voice is not licence to soften a fact.

An LM-voiced summary was considered and rejected: a call and latency per run, plus the risk of altering a number or dropping a caution — the "narrator that lies" failure caught once already. The system prompts already inject personality, so LM-authored prose is voiced by inference; only the derived scaffolding is templated.

**Personality beats are gated, not decorative.** `requires_finding` beats stay silent unless the run actually found something, and there is no fallback line. One beat per run (`_run_beat` caches), because `--json` carries both `notes` and `orchestrator.personality` — independent selection let one character speak with two voices. No `cooldown`/`max_uses`: one process selects at most one beat, so in-process cooldown is a no-op and cross-run needs session state that doesn't exist.

### Four test-pinned invariants

1. Findings precede their phase's close.
2. No event claims a closed phase.
3. Every `phase_completed` has a `phase_started`.
4. Every run terminates with `completed` or `failed`.

### Incidental fixes

- **`repair_loop.py`** imported `structured_parser` and `schemas` **unqualified**, which can never resolve inside the installed package. Every repair attempt died on `ModuleNotFoundError` — and the attempt loop's `except` swallowed it into a generic "failed to repair", so the feature looked ineffective rather than broken. Dead since the initial public release because nothing tested it.
- The static-check skip logged `elapsed/time_budget` unguarded. Not reachable today, but a log line must never crash a run.

## How Has This Been Tested?

- [x] `pytest` — **1587 passed, 8 skipped** (up from 1527; +60 new)
- [x] `.venv/bin/ruff check src/ tests/` — clean under the **pinned 0.16.0**
- [x] `tests/test_orchestrator_events.py` (46) — sinks, event ordering, all four phase invariants, summary derivation, beat gating **and reachability**, plus the VERIFY / budget-skip / panel-fallback / failure branches
- [x] `tests/test_repair_loop.py` (4) — regression cover for the import bug
- [x] `tests/test_progress_quiet.py` (9) — notice suppression and the `--json` implies `--quiet` rule
- [x] Voice tests — that the register actually varies across all five memory stages, that facts survive every stage, that cautions do *not* vary, and that a broken template degrades to silence
- [x] Live end-to-end runs against a real LLM confirming the stream split, single-parse stdout, and the event invariants on a real stream

Two bugs were caught by the **live runs, not the tests**: `memory_found` labeling itself with a phase that had already closed, and a first "real run" that silently exercised the pipx-installed neo 0.41.0 rather than the working tree.

**Test Configuration**:
- Python version: 3.12.13 (rebuilt venv, inside the CI matrix)
- OS: macOS (darwin 25.6.0)
- Neo version: 0.41.0 (working tree)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

### The pre-commit hook was disabled in this clone; it is working again

The first commit here could not run the hook. Its `PYTHON_BIN` probe fell back to system `python3` because **`.venv/bin/python` was a broken symlink** — the venv was built against `python@3.13`, which no longer exists in Homebrew — and system ruff is 0.15.1 against the pinned 0.16.0, so the hook aborted on exactly the version mismatch it exists to catch. That means it had been silently skipped for every commit in this clone.

Fixed: the venv is rebuilt on **Python 3.12.13** (inside the CI matrix, so local green now means something) with `pip install -e ".[dev]"`. The second commit went through the hook normally — full suite plus pinned linter.

`.gitignore` also gained `.venv/`. Only `venv/` was listed, which does not match it, while the Makefile and the hook both look for `.venv/bin/python` — the project's own convention was one `git add -A` away from committing an interpreter.

### Known limits (documented, not fixed)

- A `Bash` tool call does not stream, so JSONL buys accurate **post-hoc** narration, not a live progress bar. Nothing short of a hook or an MCP server changes that. `JsonlSink` still flushes per event for hosts that can stream.
- `NeoEngine` is single-request-at-a-time. The new per-request state follows the existing pattern (`self.context`, `last_applied_actions`, …) so it adds no new class of bug, but hosts are the population most likely to share one engine across a thread pool. The `StructuredOverseer` watchdog is *not* a hazard — it only reads `action_log`.
- `_timeout_response` carries an empty orchestrator envelope. It is currently unreachable (no caller); wire it in if revived.

### Review provenance

The first draft was reviewed against kernel-quality standards, which caught three claims the narrator could not defend — the VERIFY-mode summary, an unpaired `phase_completed`, and a missing terminal event on failure — plus a beat (`unfamiliar_codebase`) that was configured, marked surfaceable, and **unreachable**: no trigger it declared was ever produced. A test asserting every surfaceable beat "declares its wording" passed it happily, which is why `test_every_declared_beat_can_actually_fire` now pins reachability rather than presence.
