### PR TITLE
fix(plugins): bring the Codex adapter up to the orchestrator contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.37.0",
+  "version": "0.41.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,27 @@
   needs session state that doesn't exist. The plugin contract that consumes all
   this lives in `.claude-plugin/agents/neo.md`. See
   `docs/solutions/orchestrator-communication.md`.
+- **Host adapters must stay in parity.** There are TWO checked-in integration
+  surfaces, and they are easy to miss: `.claude-plugin/` (agent + 6 slash
+  commands) and **`plugins/neo/`** (Codex CLI plugin + 6 skills, manifest at
+  `plugins/neo/.codex-plugin/plugin.json`, registered by
+  `.agents/plugins/marketplace.json`). `.agents/skills/` holds RELEASE
+  maintenance skills, not the Neo capabilities — looking there and concluding
+  the Codex plugin is missing is a documented wrong turn. Neither adapter owns
+  an output format: both invoke `neo --json` and read the same `orchestrator`
+  envelope. When the contract changes, BOTH change — the Codex skills sat on
+  "parse the four structured sections: CONFIDENCE, PLAN, SIMULATIONS, CODE
+  SUGGESTIONS" while the Claude side had already moved to `--json`.
+  `tests/test_host_adapter_parity.py` pins it: both surfaces expose the same
+  six capabilities, invoke `--json`, teach `orchestrator.summary`/`cautions`,
+  document the error shape and attribution, and use phase/event names that
+  actually exist in `events.py`. It also pins that both plugin manifests match
+  the `pyproject.toml` version — `prepare-release` documents bumping them, but
+  a documented step with no enforcement gets skipped (they had reached 0.19.0 /
+  0.37.0 / 0.41.0). Role differs even though protocol does not: Claude Code
+  delegates to Neo as a subagent (visible boundary), Codex calls Neo mid-loop
+  (no boundary), so the Codex skills carry stronger attribution wording and an
+  explicit "Neo's result is an input, not the deliverable".
 - CarAdapter defaults `intent_hint={"task":"code","prefer_quality":True}` so CAR's router
   routes neo to the most capable model, not the chat/cost default. This is the *intended*
   router API, not a hack:

--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ The plugin wraps the local `neo` CLI, so the binary must be installed first (`pi
 
 Plugin sources live under [`plugins/neo/`](plugins/neo/) — see the manifest and skill definitions.
 
+Both plugins consume the **same host-neutral contract**: the skills invoke
+`neo --json` and read the `orchestrator` envelope described under
+[Orchestrator output](#orchestrator-output). Neither hosts its own output
+format, and `tests/test_host_adapter_parity.py` fails if one surface teaches a
+contract the other does not. The difference is role, not protocol — under
+Claude Code, Neo is usually a delegated subagent with a visible boundary;
+under Codex, Neo is a step inside the same coding loop, which is why the Codex
+skills insist on explicit attribution and on continuing the task rather than
+treating Neo's answer as the deliverable.
+
 
 ## Works Alongside Your AI Tools
 

--- a/docs/solutions/orchestrator-communication.md
+++ b/docs/solutions/orchestrator-communication.md
@@ -233,6 +233,46 @@ not bury the reasons to doubt it. Two consequences:
 `phase_summary` copies each record, not just the list. These dicts are live
 engine state and the object is handed to foreign consumers.
 
+## One contract, two adapters
+
+The contract is host-neutral by construction: `events.py` and
+`OrchestratorMessage` know nothing about who is consuming them, and the
+per-host wording lives entirely in the adapters.
+
+| Surface | Location | Shape |
+|---|---|---|
+| Claude Code | `.claude-plugin/` | agent + 6 slash commands |
+| Codex CLI | `plugins/neo/` | plugin manifest + 6 skills |
+| CAR / A2A | `neo.a2ui`, `neo serve` | A2A status + artifact events |
+
+(`.agents/skills/` holds *release-maintenance* skills, not Neo capabilities.
+Looking there for the Codex plugin and concluding it is missing is an easy
+wrong turn — the manifest is at `plugins/neo/.codex-plugin/plugin.json`,
+registered by `.agents/plugins/marketplace.json`.)
+
+**Adapters drift, and drift is invisible.** The Codex skills instructed the
+model to parse "four structured sections: `CONFIDENCE`, `PLAN`, `SIMULATIONS`,
+`CODE SUGGESTIONS`" out of terminal-formatted prose — the exact anti-pattern
+the Claude side had just stopped doing. One adapter got the contract change;
+the other did not, and nothing failed. `test_host_adapter_parity.py` now pins
+the invariant: same six capabilities on both surfaces, both invoking `--json`,
+both teaching `orchestrator.summary`/`cautions`, both documenting the error
+shape and attribution, and every documented phase/event name checked against
+`events.py` rather than against prose.
+
+The same test pins manifest versions against `pyproject.toml`. `prepare-release`
+documents bumping both plugin manifests, but a documented step with no
+enforcement is a step that gets skipped: the package, the Claude manifest, and
+the Codex manifest had reached 0.41.0 / 0.37.0 / 0.19.0.
+
+**Role differs even though protocol does not.** Under Claude Code, Neo is
+usually a delegated subagent — the user can see the boundary. Under Codex, Neo
+is a step inside the same coding loop: Codex calls Neo, reads the result, then
+edits files and runs tests in the same breath. Nothing marks where Neo's
+reasoning ends and Codex's begins, so the Codex skills carry stronger
+attribution wording ("Neo found …") and an explicit instruction that Neo's
+result is an input, not the deliverable.
+
 ## Sink failures are findable
 
 `safe_emit` logs the **first** failure at WARNING and the rest at DEBUG. Logging

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.19.0",
+  "version": "0.41.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/plugins/neo/skills/neo-architect/SKILL.md
+++ b/plugins/neo/skills/neo-architect/SKILL.md
@@ -14,7 +14,7 @@ When the user invokes this skill (`$neo-architect <question>`), do the following
 3. **Invoke Neo with an architecture-framed prompt.** Allow up to 5 minutes.
 
    ```bash
-   neo --mode advise <<'QUERY'
+   neo --json --mode advise <<'QUERY'
    Architectural decision: <restate the question with constraints>.
 
    Current state of the codebase:
@@ -27,6 +27,31 @@ When the user invokes this skill (`$neo-architect <question>`), do the following
 4. **Present Neo's plan and simulations together.** Architecture answers benefit from the SIMULATIONS section especially — those describe how the recommendation would actually play out.
 
 5. **Surface any architectural facts Neo retrieved from memory.** If past projects had similar decisions, Neo references them — those are higher-trust than fresh reasoning.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `$neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For architecture specifically: name the **alternatives considered and why each
+lost** — a recommendation without its rejected options is an opinion, not
+guidance, and `hypothesis_rejected` events plus the plan's rationale fields
+carry it. State the tradeoff Neo accepted in the user's terms: what gets harder
+if they follow this advice. Be explicit that this is advice — context Neo
+cannot see (team, timeline, politics) routinely dominates.
 
 ## Notes
 

--- a/plugins/neo/skills/neo-debug/SKILL.md
+++ b/plugins/neo/skills/neo-debug/SKILL.md
@@ -14,7 +14,7 @@ When the user invokes this skill (`$neo-debug <bug description>`), do the follow
 3. **Invoke Neo with a debug-framed prompt.** Allow up to 5 minutes.
 
    ```bash
-   neo --mode advise <<'QUERY'
+   neo --json --mode advise <<'QUERY'
    Debug this issue: <user's description>
 
    Symptoms: <what happens>
@@ -32,6 +32,32 @@ When the user invokes this skill (`$neo-debug <bug description>`), do the follow
 4. **Present Neo's hypotheses ranked by confidence.** Lead with the verification step the user can take next — debugging is an iterative loop, not a one-shot answer.
 
 5. **If Neo returns multiple competing hypotheses, surface them all.** Don't collapse to "the most likely one" — concurrent-systems bugs often have multiple contributing causes.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `$neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For debugging specifically: report what was **ruled out**, not just what was
+concluded. Every `hypothesis_rejected` event and every simulation issue in
+`risk_found` narrows the search — that is the substance of a debugging session.
+Say what evidence supports the leading hypothesis and what would falsify it. If
+`memory_found` fired, say so: a prior occurrence of this failure is the single
+most useful thing Neo can contribute. Never present a hypothesis as a
+diagnosis — Neo does not run the code, so verifying it is your job.
 
 ## Notes
 

--- a/plugins/neo/skills/neo-optimize/SKILL.md
+++ b/plugins/neo/skills/neo-optimize/SKILL.md
@@ -14,7 +14,7 @@ When the user invokes this skill (`$neo-optimize <target>`), do the following:
 3. **Invoke Neo with an optimization-framed prompt.** Allow up to 5 minutes.
 
    ```bash
-   neo --mode advise <<'QUERY'
+   neo --json --mode advise <<'QUERY'
    Suggest optimizations for the following code. Focus on: algorithmic improvements (lower asymptotic complexity), redundant computation, allocation in hot loops, IO batching opportunities. Skip micro-style changes.
 
    <paste current implementation + relevant callers>
@@ -24,6 +24,31 @@ When the user invokes this skill (`$neo-optimize <target>`), do the following:
 4. **Present Neo's suggestions ranked by expected impact.** Each CodeSuggestion includes `estimated_risk` and `blast_radius` — surface those alongside the recommendation.
 
 5. **For high-risk changes, recommend benchmarking before applying.** Neo's confidence reflects pattern-match strength, not measured speedup.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `$neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For optimization specifically: show the **evidence** for the bottleneck — the
+complexity argument or the code path Neo pointed at. An optimization claim with
+no evidence is a guess wearing a confidence score. State the expected impact and
+its basis; if Neo estimated rather than measured, say "estimated", because Neo
+never executes or benchmarks anything. Surface correctness risks especially — a
+faster wrong answer is a regression. Recommend measuring before and after.
 
 ## Notes
 

--- a/plugins/neo/skills/neo-pattern/SKILL.md
+++ b/plugins/neo/skills/neo-pattern/SKILL.md
@@ -18,7 +18,7 @@ When the user invokes this skill (`$neo-pattern <code reference or description>`
 4. **Invoke Neo with a pattern-framed prompt.** Allow up to 5 minutes.
 
    ```bash
-   neo --mode learn <<'QUERY'
+   neo --json --mode learn <<'QUERY'
    <Extract a reusable pattern from> | <Find code matching this pattern>:
 
    <code or description here>
@@ -28,6 +28,32 @@ When the user invokes this skill (`$neo-pattern <code reference or description>`
    ```
 
 5. **Present the pattern with concrete examples.** A named pattern with two example sites is more useful than an abstract description of one.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `$neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For pattern extraction specifically: cite the instances the pattern was drawn
+from — a "pattern" with one example is an anecdote, so say how many occurrences
+Neo actually saw. Report `memory_found` when the pattern matched something Neo
+already knew; recurrence across sessions is the strongest signal available here.
+Be accurate about learning: this run records an episode **candidate**, not a
+durable fact. Promotion needs two independent git-verified acceptances. Do not
+tell the user Neo "learned" this.
 
 ## Notes
 

--- a/plugins/neo/skills/neo-review/SKILL.md
+++ b/plugins/neo/skills/neo-review/SKILL.md
@@ -14,7 +14,7 @@ When the user invokes this skill (`$neo-review <file or module>`), do the follow
 3. **Invoke Neo with a review-framed prompt.** Allow up to 5 minutes.
 
    ```bash
-   neo --mode advise <<'QUERY'
+   neo --json --mode advise <<'QUERY'
    Review the following code for: security vulnerabilities, edge cases, error handling, performance issues. Provide concrete suggestions with confidence scores.
 
    <paste relevant code or summarize what you read>
@@ -24,6 +24,30 @@ When the user invokes this skill (`$neo-review <file or module>`), do the follow
 4. **Filter Neo's output to review-relevant findings.** Group by severity. Flag any finding with confidence ≥ 0.8 as actionable; treat lower-confidence findings as worth-checking-but-verify.
 
 5. **Cross-reference with Neo's KNOWN ISSUES IN NEARBY CODE section if present.** Neo's context-assembly already surfaces TODOs, stubs, swallowed exceptions, hardcoded credentials — those overlap with review concerns and add weight to related findings.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `$neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For a review specifically: group findings by severity, not by file — a security
+issue and a naming nit are not peers. Surface `risk_found` events alongside the
+cautions; a review that reads as clean because the caveats were trimmed is
+worse than no review. Say which assumptions Neo challenged, and give the
+confidence number rather than rounding it up in prose.
 
 ## Notes
 

--- a/plugins/neo/skills/neo/SKILL.md
+++ b/plugins/neo/skills/neo/SKILL.md
@@ -9,19 +9,83 @@ When the user invokes this skill (`$neo <question or task>`), do the following:
 
 1. **Verify Neo is installed.** Run `neo --version` once. If the command is missing, tell the user: "Neo CLI not installed. Run `pip install neo-reasoner[openai]` and set `OPENAI_API_KEY`, then retry." Stop.
 
-2. **Gather context.** Use your file-reading tools to collect the most relevant files for the user's question (typically 1–5 files). Include the user's full question text.
+2. **Say what you are delegating.** One sentence, before the call: the user should know what question is in flight before a 5–30 second pause.
 
-3. **Invoke Neo via stdin heredoc.** Allow up to 5 minutes — Neo runs multi-agent reasoning across LLM calls.
+3. **Gather context.** Use your file-reading tools to collect the most relevant files for the user's question (typically 1–5 files). Include the user's full question text.
+
+4. **Invoke Neo with `--json`.** Allow up to 5 minutes — Neo runs multi-agent reasoning across LLM calls.
 
    ```bash
-   neo --mode advise <<'QUERY'
+   neo --json --mode advise <<'QUERY'
    <restate the user's question here, plus any short context excerpts>
    QUERY
    ```
 
-4. **Parse Neo's output.** Neo returns four structured sections: `CONFIDENCE`, `PLAN`, `SIMULATIONS`, `CODE SUGGESTIONS`. Each suggestion carries its own confidence score.
+   `--json` controls output only; a plain-text heredoc is still read as text.
 
-5. **Present results to the user.** Lead with Neo's overall confidence and the highest-confidence suggestion. Quote Neo's reasoning verbatim where it's load-bearing. If confidence is below 0.7, flag it explicitly.
+5. **Read both streams.** Never parse Neo's human-readable text output — it is formatted for a terminal reader and omits the fields below.
+
+## Output contract
+
+**stdout** is exactly one JSON document. **stderr** is JSONL progress events,
+one object per line. `--json` implies `--quiet`, so stderr is essentially pure
+JSONL, but logging warnings can still appear — parse lines beginning with `{`
+and ignore the rest. Do not discard stderr with `2>/dev/null`.
+
+The stdout document carries an `orchestrator` object built for exactly this
+purpose:
+
+| Field | Use |
+|---|---|
+| `summary` | Lead with it. Neo's own account of what he did and concluded. |
+| `personality` | Optional in-voice beat. Relay verbatim when present. |
+| `phase_summary` | Per-phase records. Use to explain a slow or unusual run. |
+| `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
+| `recommended_narration` | Advisory progress lines. Reword freely. |
+
+Useful event types on stderr: `memory_found` (prior facts recalled),
+`hypothesis_formed`, `hypothesis_rejected` (an approach was discarded — usually
+worth surfacing), `risk_found`, and exactly one of `completed` or `failed`
+terminating every run. Phase names are stable: `context`, `reasoning`,
+`static_checks`.
+
+**On failure**, stdout is an error object with no `orchestrator` key:
+`{"error": "RequestTimeout", "message": "...", "suggestions": [...]}`. Check for
+`error` first. Say plainly that Neo did not complete, and do not substitute your
+own analysis while implying it came from Neo.
+
+## Communicating Neo's answer
+
+1. Present `orchestrator.summary` before the detailed answer.
+2. Surface every entry in `orchestrator.cautions`.
+3. Mention significant rejected hypotheses and risks from the event stream.
+   What Neo ruled out is often more useful than what he settled on.
+4. Do not dump raw traces, full simulation output, or the event stream itself.
+5. **Attribute explicitly.** You call Neo inside your own coding loop and keep
+   working afterwards, so there is no visible boundary between his reasoning
+   and yours. Without attribution the user will assume every word was yours.
+   Write "Neo's take: …" or "Neo found …", and keep your own analysis in your
+   own voice.
+6. **Neo's result is an input, not the deliverable.** Continue the task —
+   inspect files, make the change, run the tests — and report the combined
+   outcome. `recommended_next_action` in the JSON names a concrete starting
+   point.
+
+## Neo's voice
+
+Neo speaks in the first person, clipped and direct. His register shifts with how
+much he remembers about this project: a hedge at low memory ("Don't know this
+code… , maybe") is information, and terseness at high memory ("src/parser.py.
+1 change(s). 0.88.") is the same signal inverted. Relay his wording rather than
+translating it into your own register — that is also what keeps the attribution
+legible. Cautions deliberately do **not** vary by register; a warning reads the
+same however terse Neo is, and must not be softened.
+
+`orchestrator.personality` is an additional beat, present only when Neo's beat
+deck matched the situation and, for beats claiming insight, only when the run
+actually found something. It is already filtered — relay it verbatim, attached
+to the substance that earned it, or say nothing when the field is empty. There
+is no fallback line.
 
 ## Notes
 

--- a/tests/test_host_adapter_parity.py
+++ b/tests/test_host_adapter_parity.py
@@ -1,0 +1,175 @@
+"""Parity tests for Neo's host adapters.
+
+Neo publishes one host-neutral contract (`neo.events` + `OrchestratorMessage`)
+and thin per-host adapters that tell an orchestrator how to consume it:
+
+    .claude-plugin/   -> Claude Code agent + slash commands
+    plugins/neo/      -> Codex CLI plugin + skills
+
+Adapters drift. The Codex skills sat on "parse the four structured sections"
+for a full release after the Claude side moved to `--json`, which is exactly
+the failure these tests exist to catch: a contract change landing in one
+adapter and silently not the other.
+
+Manifest versions drift the same way. `prepare-release` documents bumping both
+plugin manifests, but a documented step with no enforcement is a step that gets
+skipped — the two manifests and the package had reached three different
+versions.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+CLAUDE_PLUGIN = REPO / ".claude-plugin"
+CODEX_PLUGIN = REPO / "plugins" / "neo"
+
+# The six capabilities Neo claims on every integration surface.
+CAPABILITIES = ["neo", "neo-review", "neo-debug", "neo-architect",
+                "neo-optimize", "neo-pattern"]
+
+
+def _package_version() -> str:
+    for line in (REPO / "pyproject.toml").read_text().splitlines():
+        if line.startswith("version = "):
+            return line.split("=", 1)[1].strip().strip('"')
+    raise AssertionError("no version in pyproject.toml")
+
+
+def _codex_skill(name: str) -> str:
+    return (CODEX_PLUGIN / "skills" / name / "SKILL.md").read_text()
+
+
+def _claude_command(name: str) -> str:
+    return (CLAUDE_PLUGIN / "commands" / f"{name}.md").read_text()
+
+
+# ------------------------------------------------------------ both exist
+
+
+def test_both_integration_surfaces_are_checked_in():
+    """The README claims three surfaces. Two of them are directories here, and
+    a claim in a README that no directory backs is a claim that will be found
+    false by a user, not by us."""
+    assert (CLAUDE_PLUGIN / "plugin.json").is_file()
+    assert (CODEX_PLUGIN / ".codex-plugin" / "plugin.json").is_file()
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_every_capability_exists_on_both_surfaces(name):
+    assert (CODEX_PLUGIN / "skills" / name / "SKILL.md").is_file(), f"codex: {name}"
+    assert (CLAUDE_PLUGIN / "commands" / f"{name}.md").is_file(), f"claude: {name}"
+
+
+def test_neither_surface_carries_extra_capabilities():
+    """'The same six skills' has to stay six on both sides."""
+    codex = {p.name for p in (CODEX_PLUGIN / "skills").iterdir() if p.is_dir()}
+    claude = {p.stem for p in (CLAUDE_PLUGIN / "commands").glob("*.md")}
+    assert codex == set(CAPABILITIES)
+    assert claude == set(CAPABILITIES)
+
+
+def test_local_marketplace_points_at_the_codex_plugin():
+    """`codex plugin marketplace add ./` is a documented install path; a stale
+    path here breaks it silently."""
+    manifest = json.loads((REPO / ".agents" / "plugins" / "marketplace.json").read_text())
+    paths = [p["source"]["path"] for p in manifest["plugins"]]
+    assert "./plugins/neo" in paths
+    for path in paths:
+        assert (REPO / path).is_dir(), path
+
+
+# ------------------------------------------------------------ versions
+
+
+def test_plugin_manifests_match_the_package_version():
+    version = _package_version()
+    for manifest in (CLAUDE_PLUGIN / "plugin.json",
+                     CODEX_PLUGIN / ".codex-plugin" / "plugin.json"):
+        assert json.loads(manifest.read_text())["version"] == version, manifest
+
+
+def test_dunder_version_matches_the_package_version():
+    from neo import __version__
+
+    assert __version__ == _package_version()
+
+
+# ------------------------------------------------------------ the contract
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_codex_skills_invoke_neo_with_json(name):
+    assert "neo --json" in _codex_skill(name), name
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_codex_skills_teach_the_orchestrator_envelope(name):
+    body = _codex_skill(name)
+    assert "orchestrator.summary" in body, name
+    assert "orchestrator.cautions" in body, name
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_no_surface_still_instructs_parsing_the_text_output(name):
+    """The specific regression: Codex was told to read `CONFIDENCE`, `PLAN`,
+    `SIMULATIONS`, `CODE SUGGESTIONS` out of terminal-formatted prose."""
+    for body in (_codex_skill(name), _claude_command(name)):
+        assert "four structured sections" not in body, name
+
+
+def test_claude_agent_and_codex_entry_skill_teach_the_same_contract():
+    """Both entry points must name the same stream split, the same fields, and
+    the same failure shape. Wording differs; the contract may not."""
+    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
+    skill = _codex_skill("neo")
+    for token in ("--json", "stdout", "stderr", "orchestrator.summary",
+                  "orchestrator.cautions", "personality", "context",
+                  "reasoning", "static_checks"):
+        assert token in agent, f"claude agent missing {token}"
+        assert token in skill, f"codex skill missing {token}"
+
+
+def test_both_entry_points_document_the_error_shape():
+    """A host that reads `orchestrator` before checking `error` reports a
+    successful run that never happened."""
+    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
+    skill = _codex_skill("neo")
+    for body in (agent, skill):
+        assert '"error"' in body
+
+
+def test_both_entry_points_require_attribution():
+    """Neo's conclusions and the host's own analysis must stay separable."""
+    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
+    skill = _codex_skill("neo")
+    for body in (agent, skill):
+        assert "Neo found" in body
+
+
+def test_documented_phase_names_match_the_code():
+    """Phase names are a compatibility surface; docs that drift from `events.py`
+    send hosts looking for a phase that never fires."""
+    from neo import events
+
+    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
+    skill = _codex_skill("neo")
+    for phase in (events.PHASE_CONTEXT, events.PHASE_REASONING,
+                  events.PHASE_STATIC_CHECKS):
+        assert phase in agent, phase
+        assert phase in skill, phase
+
+
+def test_documented_event_types_exist_in_the_code():
+    from neo.events import NeoEventType
+
+    skill = _codex_skill("neo")
+    documented = [t for t in ("memory_found", "hypothesis_formed",
+                              "hypothesis_rejected", "risk_found",
+                              "completed", "failed") if t in skill]
+    assert documented, "the entry skill documents no event types"
+    valid = {member.value for member in NeoEventType}
+    for name in documented:
+        assert name in valid, name


### PR DESCRIPTION
## Description

Brings the Codex plugin up to the orchestrator contract introduced in #161, and adds a parity test so the two host adapters cannot silently diverge again.

**The Codex plugin was never missing.** It is checked in at [`plugins/neo/`](plugins/neo/) — manifest at `plugins/neo/.codex-plugin/plugin.json`, six skills, registered by `.agents/plugins/marketplace.json`. (`.agents/skills/` holds *release-maintenance* skills, which is what makes this an easy wrong turn.) The README already pointed at it.

What was actually wrong: the Codex adapter never learned the contract #161 introduced.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Follow-up to #161.

## Motivation and Context

All six Codex skills still told the model to run `neo --mode advise` and parse **"four structured sections: `CONFIDENCE`, `PLAN`, `SIMULATIONS`, `CODE SUGGESTIONS`"** out of terminal-formatted prose — exactly the anti-pattern #161 removed from the Claude side. One adapter got the contract change, the other did not, and nothing failed.

The contract itself was already host-neutral: `events.py` and `OrchestratorMessage` know nothing about who consumes them, so only the adapter needed updating. No second output format was introduced, and none should be.

**Role differs even though protocol does not.** Under Claude Code, Neo is usually a delegated subagent and the user can see the boundary. Under Codex, Neo is a step inside the same coding loop — Codex calls Neo, then inspects files and runs tests in the same breath, and nothing marks where Neo's reasoning ends and Codex's begins. The Codex skills therefore carry stronger attribution wording ("Neo found …") and an explicit *"Neo's result is an input, not the deliverable."*

**Version drift.** `prepare-release` documents bumping both plugin manifests, but a documented step with no enforcement is a step that gets skipped: package / Claude / Codex had reached **0.41.0 / 0.37.0 / 0.19.0**. Now synced and pinned by a test.

## How Has This Been Tested?

- [x] `pytest` — **1621 passed, 8 skipped** (+34 new)
- [x] `.venv/bin/ruff check src/ tests/` — clean under the pinned 0.16.0
- [x] `tests/test_host_adapter_parity.py` (34) — both surfaces exist and expose the same six capabilities; both invoke `--json`; both teach `orchestrator.summary`/`cautions`; both document the error shape and attribution; manifests match `pyproject.toml`; every documented phase and event name is checked against `events.py` rather than against prose; the local marketplace path resolves.
- [x] **Verified the test catches the real regression**: at `HEAD~`, all six `--json` assertions and both version assertions fail.

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS (darwin 25.6.0)
- Neo version: 0.41.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

No source code changed — this is adapter instructions, manifests, docs, and tests. The engine and the contract are untouched.

Worth knowing: `test_host_adapter_parity.py` asserts on the *content of markdown instructions*, which is unusual. The justification is that those files are the integration contract — they are what a host actually executes — and the failure mode they guard against is silent by construction. A drifted adapter produces no error; it just quietly makes the model parse the wrong thing.
