### PR TITLE
chore(release): single-source the version, and put tools/ under lint

### DIFF
--- a/.agents/skills/source-command-prepare-release/SKILL.md
+++ b/.agents/skills/source-command-prepare-release/SKILL.md
@@ -24,11 +24,9 @@ Updates version numbers, CHANGELOG.md, and builds distributions for a new releas
 1. **Validates** the new version is higher than current and follows semver format
 2. **Reviews** commits since last release tag
 3. **Updates** CHANGELOG.md with new version section and categorized changes
-4. **Updates** version in:
-   - `pyproject.toml` (line 7)
-   - `src/neo/__init__.py` (line 5)
-   - `.claude-plugin/plugin.json`
-   - `plugins/neo/.codex-plugin/plugin.json`
+4. **Updates** the version in `pyproject.toml`, then runs `make sync-version`
+   to propagate it to the three derived files (`src/neo/__init__.py`, both
+   plugin manifests)
 5. **Syncs** the local editable install metadata so `importlib.metadata.version("neo-reasoner")` matches the new version
 6. **Builds** wheel and sdist distributions
 7. **Reports** what was done and next steps
@@ -71,11 +69,20 @@ Add new section at top of `CHANGELOG.md`:
 
 ### Step 4: Update Versions
 
-Update version string in all four files:
-- `pyproject.toml`: Change `version = "X.Y.Z"`
-- `src/neo/__init__.py`: Change `__version__ = "X.Y.Z"`
-- `.claude-plugin/plugin.json`: Change `"version": "X.Y.Z"`
-- `plugins/neo/.codex-plugin/plugin.json`: Change `"version": "X.Y.Z"`
+Edit **one** file, then propagate:
+
+- `pyproject.toml`: change `version = "X.Y.Z"` — this is the source of truth.
+
+```bash
+make sync-version
+```
+
+That rewrites `src/neo/__init__.py`, `.claude-plugin/plugin.json`, and
+`plugins/neo/.codex-plugin/plugin.json` to match. Do **not** hand-edit those
+three: this step used to be "update the version string in all four files", and
+the manifests silently drifted to 0.37.0 and 0.19.0 while the package was at
+0.41.0. `tests/test_host_adapter_parity.py` fails if they are out of sync, and
+`python tools/sync_version.py --check` reports drift without writing.
 
 ### Step 5: Sync Local Editable Metadata
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -37,7 +37,7 @@ if [ -n "$PINNED_RUFF" ] && [ "$PINNED_RUFF" != "$LOCAL_RUFF" ]; then
 fi
 
 echo "Running ruff lint (same command as CI)..."
-"$PYTHON_BIN" -m ruff check src/ tests/
+"$PYTHON_BIN" -m ruff check src/ tests/ tools/
 
 echo "Running tests (same command as CI)..."
 "$PYTHON_BIN" -m pytest tests/ -q --tb=line

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: pip install -e ".[dev]"
 
     - name: Lint with ruff
-      run: ruff check src/ tests/
+      run: ruff check src/ tests/ tools/
 
     - name: Run tests
       run: pytest -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,17 @@
   actually exist in `events.py`. It also pins that both plugin manifests match
   the `pyproject.toml` version — `prepare-release` documents bumping them, but
   a documented step with no enforcement gets skipped (they had reached 0.19.0 /
-  0.37.0 / 0.41.0). Role differs even though protocol does not: Claude Code
+  0.37.0 / 0.41.0). **The version is now single-sourced**: `pyproject.toml` is
+  the truth and `tools/sync_version.py` (`make sync-version`) propagates it to
+  `src/neo/__init__.py` and both manifests. Release bumps edit ONE file; never
+  hand-edit the derived three. `--check` reports drift without writing. Edits
+  are surgical regex replacements, not `json.dumps` re-serialization — a
+  version bump must stay a one-line diff or it becomes unreviewable — and only
+  the FIRST `"version"` key is rewritten so a nested one can't be clobbered.
+  `tools/` is now covered by lint; it never was, which is why a dead import sat
+  in `ab_controlled.py`. The ruff invocation is duplicated in `Makefile`
+  (`lint` + `ci-local`), `.github/workflows/ci.yml` and `.githooks/pre-commit`
+  — all four MUST stay identical or local green stops predicting CI green. Role differs even though protocol does not: Claude Code
   delegates to Neo as a subagent (visible boundary), Codex calls Neo mid-loop
   (no boundary), so the Codex skills carry stronger attribution wording and an
   explicit "Neo's result is an input, not the deliverable".

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test format lint hooks ci-local clean
+.PHONY: help install install-dev test format lint hooks ci-local clean sync-version
 
 # Prefer the project venv over whatever happens to be on PATH. A system-wide
 # `ruff` is routinely a different version from the pinned one, and linting with
@@ -13,6 +13,7 @@ help:
 	@echo "  make test          - Run all tests"
 	@echo "  make format        - Format code with black"
 	@echo "  make lint          - Lint code with ruff"
+	@echo "  make sync-version  - Propagate pyproject's version to the derived files"
 	@echo "  make hooks         - Enable the pre-commit hook (run once per clone)"
 	@echo "  make ci-local      - Run exactly what CI runs, before pushing"
 	@echo "  make clean         - Clean up generated files"
@@ -30,14 +31,19 @@ format:
 	$(PYTHON) -m black src/ tests/
 
 lint:
-	$(PYTHON) -m ruff check src/ tests/
+	$(PYTHON) -m ruff check src/ tests/ tools/
+
+# Bump `version` in pyproject.toml, then run this. The plugin manifests and
+# __version__ are derived, never hand-edited.
+sync-version:
+	$(PYTHON) tools/sync_version.py
 
 hooks:
 	git config core.hooksPath .githooks
 	@echo "pre-commit hook enabled (.githooks). It runs the same lint + tests as CI."
 
 ci-local:
-	$(PYTHON) -m ruff check src/ tests/
+	$(PYTHON) -m ruff check src/ tests/ tools/
 	$(PYTHON) -m pytest -q
 
 clean:

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,0 +1,140 @@
+"""Tests for the version-propagation tool.
+
+`pyproject.toml` holds the release version; `src/neo/__init__.py` and the two
+plugin manifests restate it. `prepare-release` used to ask a human to edit all
+four, which is how the package, the Claude manifest and the Codex manifest
+reached 0.41.0 / 0.37.0 / 0.19.0. This tool makes three of the four derived.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+TOOL = REPO / "tools" / "sync_version.py"
+
+
+def _load_tool():
+    spec = importlib.util.spec_from_file_location("sync_version", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """A miniature repo with the same four files, so tests never write to the
+    real tree."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "neo-reasoner"\nversion = "1.2.3"\n'
+    )
+    pkg = tmp_path / "src" / "neo"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text('"""doc."""\n\n__version__ = "0.0.1"\n')
+    claude = tmp_path / ".claude-plugin"
+    claude.mkdir()
+    (claude / "plugin.json").write_text(
+        '{\n  "name": "neo",\n  "version": "0.0.2",\n  "description": "x"\n}\n'
+    )
+    codex = tmp_path / "plugins" / "neo" / ".codex-plugin"
+    codex.mkdir(parents=True)
+    (codex / "plugin.json").write_text(
+        '{\n  "name": "neo",\n  "version": "0.0.3",\n  "description": "y"\n}\n'
+    )
+
+    tool = _load_tool()
+    monkeypatch.setattr(tool, "REPO", tmp_path)
+    monkeypatch.setattr(tool, "PYPROJECT", tmp_path / "pyproject.toml")
+    monkeypatch.setattr(tool, "DERIVED", [
+        (tmp_path / "src" / "neo" / "__init__.py", tool.DERIVED[0][1]),
+        (claude / "plugin.json", tool.DERIVED[1][1]),
+        (codex / "plugin.json", tool.DERIVED[2][1]),
+    ])
+    return tool, tmp_path
+
+
+def test_source_version_reads_pyproject(fake_repo):
+    tool, _ = fake_repo
+    assert tool.source_version() == "1.2.3"
+
+
+def test_sync_rewrites_every_derived_file(fake_repo):
+    tool, root = fake_repo
+    stale = tool.sync("1.2.3", check_only=False)
+
+    assert len(stale) == 3
+    assert '__version__ = "1.2.3"' in (root / "src/neo/__init__.py").read_text()
+    for manifest in (root / ".claude-plugin/plugin.json",
+                     root / "plugins/neo/.codex-plugin/plugin.json"):
+        assert json.loads(manifest.read_text())["version"] == "1.2.3"
+
+
+def test_check_mode_reports_without_writing(fake_repo):
+    tool, root = fake_repo
+    before = (root / ".claude-plugin/plugin.json").read_text()
+
+    stale = tool.sync("1.2.3", check_only=True)
+
+    assert len(stale) == 3
+    assert (root / ".claude-plugin/plugin.json").read_text() == before
+
+
+def test_sync_is_idempotent_and_leaves_formatting_alone(fake_repo):
+    """Surgical replacement, not re-serialization: a version bump must stay a
+    one-line diff, or it becomes unreviewable."""
+    tool, root = fake_repo
+    manifest = root / ".claude-plugin/plugin.json"
+
+    tool.sync("1.2.3", check_only=False)
+    first = manifest.read_text()
+    assert tool.sync("1.2.3", check_only=False) == []
+    assert manifest.read_text() == first
+    # Original hand-written layout survives.
+    assert first.startswith('{\n  "name": "neo",\n  "version": "1.2.3",')
+
+
+def test_a_missing_version_field_is_an_error_not_a_silent_skip(fake_repo):
+    tool, root = fake_repo
+    (root / ".claude-plugin/plugin.json").write_text('{\n  "name": "neo"\n}\n')
+
+    with pytest.raises(SystemExit):
+        tool.sync("1.2.3", check_only=True)
+
+
+def test_only_the_first_version_field_is_rewritten(fake_repo):
+    """A nested "version" added later must not be clobbered by a release bump."""
+    tool, root = fake_repo
+    manifest = root / ".claude-plugin/plugin.json"
+    manifest.write_text(
+        '{\n  "name": "neo",\n  "version": "0.0.2",\n'
+        '  "engine": {\n  "version": "9.9.9"\n  }\n}\n'
+    )
+
+    tool.sync("1.2.3", check_only=False)
+
+    data = json.loads(manifest.read_text())
+    assert data["version"] == "1.2.3"
+    assert data["engine"]["version"] == "9.9.9"
+
+
+# ------------------------------------------------------- against the real tree
+
+
+def test_the_real_repository_is_in_sync():
+    """Same invariant test_host_adapter_parity asserts, reached through the
+    tool a human actually runs."""
+    tool = _load_tool()
+    assert tool.sync(tool.source_version(), check_only=True) == []
+
+
+def test_release_skill_no_longer_asks_for_hand_edits():
+    """The process gap, not just its symptom: a documented four-file edit with
+    no enforcement is a step that gets skipped."""
+    skill = (REPO / ".agents" / "skills" / "source-command-prepare-release"
+             / "SKILL.md").read_text()
+    assert "make sync-version" in skill
+    assert "Do **not** hand-edit" in skill
+    # The old Step 4 listed each derived file as its own "Change ..." edit.
+    assert 'plugin.json`: Change `"version"' not in skill

--- a/tools/ab_controlled.py
+++ b/tools/ab_controlled.py
@@ -27,7 +27,6 @@ import argparse
 import json
 import random
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # for ab_reasoning

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Propagate the version in pyproject.toml to every file that restates it.
+
+One release version is written down in four places:
+
+    pyproject.toml                          <- the source of truth (the build reads it)
+    src/neo/__init__.py                     <- __version__
+    .claude-plugin/plugin.json              <- Claude Code plugin manifest
+    plugins/neo/.codex-plugin/plugin.json   <- Codex CLI plugin manifest
+
+`prepare-release` used to ask a human to edit all four by hand. That is a
+documented step with no enforcement, and it got skipped: the package, the
+Claude manifest and the Codex manifest reached 0.41.0 / 0.37.0 / 0.19.0 before
+anyone noticed. `tests/test_host_adapter_parity.py` now catches the drift, but
+catching it after the fact is worse than not creating it.
+
+Usage:
+    python tools/sync_version.py            # rewrite the derived files
+    python tools/sync_version.py --check    # exit 1 if any is stale (CI/hook)
+
+Edits are surgical string replacements, not re-serialization: rewriting a JSON
+manifest through `json.dumps` would reformat the whole file and bury a one-line
+version bump in an unreviewable diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+PYPROJECT = REPO / "pyproject.toml"
+
+# (path, regex with a single capturing group around the version literal)
+DERIVED: list[tuple[Path, re.Pattern[str]]] = [
+    (REPO / "src" / "neo" / "__init__.py",
+     re.compile(r'^(__version__\s*=\s*")([^"]+)(")', re.MULTILINE)),
+    (REPO / ".claude-plugin" / "plugin.json",
+     re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.MULTILINE)),
+    (REPO / "plugins" / "neo" / ".codex-plugin" / "plugin.json",
+     re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.MULTILINE)),
+]
+
+_PYPROJECT_VERSION = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def source_version() -> str:
+    """Read the authoritative version out of pyproject.toml."""
+    match = _PYPROJECT_VERSION.search(PYPROJECT.read_text())
+    if not match:
+        raise SystemExit(f"no `version = \"...\"` found in {PYPROJECT}")
+    return match.group(1)
+
+
+def sync(version: str, *, check_only: bool) -> list[str]:
+    """Rewrite (or inspect) every derived file. Returns the stale ones."""
+    stale: list[str] = []
+    for path, pattern in DERIVED:
+        text = path.read_text()
+        match = pattern.search(text)
+        if not match:
+            raise SystemExit(f"no version field found in {path}")
+        current = match.group(2)
+        if current == version:
+            continue
+        rel = path.relative_to(REPO)
+        stale.append(f"{rel}: {current} -> {version}")
+        if not check_only:
+            # count=1: only the first match, so a nested "version" key added
+            # later cannot be clobbered silently.
+            path.write_text(pattern.sub(rf"\g<1>{version}\g<3>", text, count=1))
+    return stale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check", action="store_true",
+        help="report drift and exit 1 without writing anything",
+    )
+    args = parser.parse_args()
+
+    version = source_version()
+    stale = sync(version, check_only=args.check)
+
+    if not stale:
+        print(f"version {version}: all files in sync")
+        return 0
+
+    if args.check:
+        print(f"version {version}: {len(stale)} file(s) out of sync", file=sys.stderr)
+        for line in stale:
+            print(f"  {line}", file=sys.stderr)
+        print("run: python tools/sync_version.py", file=sys.stderr)
+        return 1
+
+    for line in stale:
+        print(f"  updated {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Closes the process gap #162 only papered over: the version is now written down **once**.

#162 added a test that fails when the plugin manifests drift from `pyproject.toml`. That catches drift *after* it happens — it does nothing to stop it being created. The version still lived in four files and `prepare-release` still asked a human to edit all four by hand, which is exactly how the package, the Claude manifest and the Codex manifest reached **0.41.0 / 0.37.0 / 0.19.0**.

- **`tools/sync_version.py`** (new) + `make sync-version` — propagates `pyproject.toml`'s version to `src/neo/__init__.py` and both plugin manifests. `--check` reports drift without writing.
- **`prepare-release` Step 4** — edit one file, run one command, with an explicit "do not hand-edit the derived three" and the reason.
- **`tools/` is now linted** — it never was.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code cleanup/refactoring

## Related Issue

Follow-up to #162.

## Motivation and Context

### Two details that matter more than they look

**Edits are surgical regex replacements, not `json.dumps` re-serialization.** A JSON round-trip would reformat the whole manifest and bury a one-line version bump in a diff nobody can review. Verified: after simulating the 0.19.0 drift and repairing it, `git diff` is empty — no formatting churn.

**Only the first `"version"` key is rewritten** (`count=1`), so a nested `"version"` added later cannot be silently clobbered by a release bump. Pinned by a test.

### `tools/` was never linted

The Makefile, CI and the pre-commit hook all ran `ruff check src/ tests/`. So a dead `import time` had been sitting in `tools/ab_controlled.py` — and `tools/` is where the new release script lives, which made leaving it unlinted untenable. Removed the import and added `tools/` to all four invocations (`Makefile lint`, `Makefile ci-local`, `ci.yml`, `.githooks/pre-commit`). Those four must stay identical or local green stops predicting CI green — the failure mode the hook's own header documents.

## How Has This Been Tested?

- [x] `pytest` — **1629 passed, 8 skipped** (+8 new)
- [x] `make ci-local` — clean, with `tools/` now in scope
- [x] `tests/test_sync_version.py` (8) — propagation, `--check` writes nothing, idempotence, formatting preserved, a missing version field is an error rather than a silent skip, nested keys survive, the real tree is in sync, and the release skill no longer asks for hand-edits
- [x] **Manually exercised the real failure**: simulated the 0.19.0 drift, confirmed `--check` exits 1 and names the file, confirmed repair produces a zero-line diff and is idempotent

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS (darwin 25.6.0)
- Neo version: 0.41.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`src/neo/__init__.py`'s `__version__` stays a literal rather than deriving from `importlib.metadata`, because metadata lookup fails in a source checkout that hasn't been installed. It is generated now, and two tests pin it, which gets the same guarantee without the import-time fragility.
