### PR TITLE
release: 0.42.0 — enforce one-request-per-engine, then cut the release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.42.0] - 2026-08-05
+
+### Added
+
+- **Neo can now tell a host what it is doing.** `engine.py` previously made *zero* `print`/stderr calls, so an orchestrator (Claude Code, Codex, an IDE, an MCP server) saw nothing between invoking Neo and receiving the final `NeoOutput`. Worse, the Claude Code plugin instructed the agent to parse Neo's **human-readable text output** — reverse-engineering presentation out of terminal formatting while a fully structured document sat one flag away.
+
+  New `neo.events` module: `NeoEventType`, `NeoEvent`, a `NeoEventSink` Protocol, and `Null`/`Recording`/`Jsonl` sinks. `NeoOutput` gains an `orchestrator` envelope (`summary`, `personality`, `phase_summary`, `cautions`, `recommended_narration`) derived from state already computed — no LM call, no new analysis. The governing rule is that **Neo reports facts about its process and the host decides how and when they become conversation**; no host-specific wording lives in the engine.
+
+  `--json` now writes two streams: stdout is exactly **one** JSON document (so `neo --json | jq` keeps working) and stderr is JSONL progress events. They are deliberately not interleaved — the old `--json` help text promised events on one stream and honoring that literally would have broken every existing consumer. (`events.py`, `engine.py`, `models.py`, `cli.py`)
+
+- **Four invariants over the event stream**, each pinned by a test: findings are emitted *before* their phase closes; no event may claim a phase that has already closed; every `phase_completed` has a matching `phase_started`; and every run terminates with exactly one `completed` or `failed`. Emitting `started` and then going silent was worse than emitting nothing — a host cannot distinguish a crash from a hang.
+
+- **Neo speaks as Neo, and the register follows memory level.** All user-facing wording now comes from `orchestrator_voice` in `neo_matrix.yaml` via `_voice(key, **fmt)`; `engine.py` holds no prose of its own, so the character can be retuned without editing code (`test_engine_holds_no_prose_of_its_own` pins that). The same facts render as `Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe. Confidence 0.88.` at memory stage 1 and `src/parser.py. 1 change(s). 0.88.` at stage 5. Cautions and progress messages deliberately do **not** vary by stage: a host is told never to drop a caution, so a warning must read the same however terse Neo is. Voice is not licence to soften a fact.
+
+### Fixed
+
+- **`repair_loop` had been dead since the initial public release.** It imported `structured_parser` and `schemas` *unqualified*, which can never resolve inside the installed package. Every repair attempt died on `ModuleNotFoundError` — and the attempt loop's `except` swallowed it into a generic "failed to repair after 2 attempts", so the feature looked ineffective rather than broken. Nothing tested it; `tests/test_repair_loop.py` now does. (`repair_loop.py`)
+
+- **The Codex plugin never learned the new contract.** All six skills under `plugins/neo/` still ran `neo --mode advise` and told the model to parse "four structured sections: `CONFIDENCE`, `PLAN`, `SIMULATIONS`, `CODE SUGGESTIONS`" out of terminal-formatted prose — the exact anti-pattern removed from the Claude side. One adapter got the change and the other silently did not. The contract itself was already host-neutral, so only the adapter needed updating. `tests/test_host_adapter_parity.py` now fails if one surface teaches a contract the other does not. (`plugins/neo/skills/*`)
+
+- **`--quiet` was declared and never read**, so the `[Neo]` progress notices could not be turned off — which is why stderr under `--json` was a mixed stream every host had to filter. Notices now route through the new `neo.progress` module instead of bare `print(file=sys.stderr)` calls scattered across `context_gatherer`, and `--json` implies `--quiet`. Index-command *errors* stay unsuppressed: `--quiet` silences progress, not failures. (`progress.py`, `cli.py`, `context_gatherer.py`)
+
+- **Concurrent `process()` calls on one `NeoEngine` are now rejected instead of corrupting state.** Nearly all run state lives on the instance, so overlapping calls cross-attributed suggestions, facts and learning episodes between unrelated requests — silently. `process()` takes a non-blocking lock and raises `EngineBusyError`; the lock releases in a `finally` so a failed run leaves the engine reusable. This is not theoretical: `car_host` caches engines per working directory and reuses them, relying on CAR's drain task being single-threaded, which its own comment calls "an implementation detail". The A2A host now answers an overlap with a retryable `EngineBusy` response rather than a stack trace — a peer seeing a generic `ProcessingError` would assume its own request was malformed and stop retrying. (`engine.py`, `car_host.py`)
+
+- **The version is single-sourced.** It was written down in four files and `prepare-release` asked a human to edit all four by hand, which is how the package, the Claude manifest and the Codex manifest reached 0.41.0 / 0.37.0 / 0.19.0. `pyproject.toml` is now the source of truth and `make sync-version` propagates it; a release bump edits one file. Edits are surgical regex replacements rather than `json.dumps` re-serialization, so a version bump stays a one-line diff instead of a whole-file reformat, and only the first `"version"` key is rewritten so a nested one cannot be clobbered. (`tools/sync_version.py`)
+
+- Guarded an unreachable-but-fatal `elapsed / time_budget` division in the static-check skip log. A zero budget is not reachable through `_get_time_budget` today, but a *log line* must never be what crashes a run. (`engine.py`)
+
+### Changed
+
+- `tools/` is now covered by lint. The Makefile, CI and the pre-commit hook all ran `ruff check src/ tests/`, so a dead `import time` had been sitting in `tools/ab_controlled.py` — and `tools/` is where the new release script lives. All four invocations must stay identical or local green stops predicting CI green. (`Makefile`, `.github/workflows/ci.yml`, `.githooks/pre-commit`)
+
+- `.gitignore` gained `.venv/`. Only `venv/` was listed, which does not match it, while the Makefile and the pre-commit hook both look for `.venv/bin/python` — the project's own convention was one `git add -A` away from committing an entire interpreter.
+
+- The first pipeline phase is named `context`, not `retrieval`: it covers file gathering only, and fact retrieval actually runs while `reasoning` is open. A phase whose name overstates its span forces every emitter inside it to either lie or compensate.
+
 ## [0.41.0] - 2026-07-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,23 @@
   needs session state that doesn't exist. The plugin contract that consumes all
   this lives in `.claude-plugin/agents/neo.md`. See
   `docs/solutions/orchestrator-communication.md`.
+- **`NeoEngine` is one-request-at-a-time, enforced.** `process()` takes a
+  non-blocking `threading.Lock` and raises `EngineBusyError` (a `RuntimeError`
+  subclass, so broad handlers still catch it) on overlap; the body moved to
+  `_process_guarded`. Nearly all run state lives on the instance
+  (`context`, `current_learning_episode`, `_phase_records`, `_findings`,
+  `_selected_beat`, `resolved_execution_context`, `last_applied_actions`), so
+  concurrent calls would cross-attribute suggestions/facts/episodes between
+  unrelated requests — **silently**, which is why this fails loudly instead.
+  Non-blocking is deliberate: queueing would hide a caller's design bug behind
+  a latency mystery. **This is not theoretical** — `car_host._get_or_create_engine`
+  caches engines per working-dir and REUSES them across calls, relying on CAR's
+  drain task being single-threaded (its own comment calls that "an
+  implementation detail", i.e. upstream and not ours to guarantee). `_handle_call`
+  therefore maps `EngineBusyError` to a distinct retryable `EngineBusy`
+  response — a peer that sees generic `ProcessingError` assumes its own request
+  was malformed and stops retrying. The lock releases in a `finally`, so a
+  failed run doesn't leave the engine permanently busy (pinned by a test).
 - **Host adapters must stay in parity.** There are TWO checked-in integration
   surfaces, and they are easy to miss: `.claude-plugin/` (agent + 6 slash
   commands) and **`plugins/neo/`** (Codex CLI plugin + 6 skills, manifest at

--- a/docs/solutions/orchestrator-communication.md
+++ b/docs/solutions/orchestrator-communication.md
@@ -312,12 +312,20 @@ proven non-None at that point.
 - A `Bash` tool call does not stream, so JSONL buys accurate **post-hoc**
   narration, not a live progress bar. Nothing short of a hook or an MCP server
   changes that. `JsonlSink` still flushes per event, for hosts that can stream.
-- `NeoEngine` is single-request-at-a-time. `_phase_records` / `_findings` /
+- `NeoEngine` is single-request-at-a-time, and this is now **enforced**, not
+  merely documented: `process()` takes a non-blocking lock and raises
+  `EngineBusyError` on overlap. `_phase_records` / `_findings` /
   `_selected_beat` are per-request instance state, following the same pattern as
-  `self.context`, `last_applied_actions`, and `current_learning_episode` — so
-  this adds no new class of bug, but hosts are exactly the population likely to
-  share one engine across a thread pool. The `StructuredOverseer` watchdog is
-  *not* a hazard: it only reads `action_log`.
+  `self.context`, `last_applied_actions`, and `current_learning_episode`, so
+  overlapping runs would cross-attribute suggestions and learning episodes
+  between unrelated requests — silently. `neo.car_host` caches engines per
+  working directory and reuses them, relying on CAR's drain task being
+  single-threaded, which its own comment calls "an implementation detail"; that
+  detail is upstream and not ours to guarantee, so the host now answers an
+  overlap with a retryable `EngineBusy` response rather than a stack trace.
+  Non-blocking on purpose: queueing would hide a caller's design bug behind a
+  latency mystery. The `StructuredOverseer` watchdog is *not* a hazard — it only
+  reads `action_log`.
 - `_timeout_response` builds a bare `NeoOutput` and so carries an empty
   orchestrator envelope. It is currently unreachable (neither it nor
   `_check_timeout` has a caller); wire the message in if it is ever revived.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.41.0"
+version = "0.42.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/src/neo/car_host.py
+++ b/src/neo/car_host.py
@@ -111,6 +111,14 @@ def run_server(
     # resolved working_directory string; lock-guarded for the rare
     # concurrent first-call case (CAR's drain task is single-threaded
     # today but that's an implementation detail).
+    #
+    # That last point is load-bearing and NOT ours to guarantee: engines are
+    # reused across calls, and `NeoEngine.process()` handles one request at a
+    # time because a run's state lives on the instance. If CAR ever drains
+    # concurrently, the second overlapping call for the same cwd raises
+    # `EngineBusyError` rather than interleaving two requests' learning
+    # episodes; `_handle_call` turns that into a retryable `EngineBusy`
+    # response instead of a stack trace.
     engines: dict[str, "NeoEngine"] = {}
     engines_lock = threading.Lock()
 
@@ -175,9 +183,29 @@ def run_server(
 
         working_dir = neo_input.working_directory or os.getcwd()
 
+        # Imported here, not at module scope: `neo.engine` is heavy and this
+        # host defers it (see the TYPE_CHECKING guard above). By this point the
+        # engine factory has already imported it, so this is a dict lookup.
+        from neo.engine import EngineBusyError
+
         try:
             engine = _get_or_create_engine(working_dir)
             output = engine.process(neo_input)
+        except EngineBusyError:
+            # Engines are cached per cwd, so an overlapping call for the same
+            # codebase hits the single-request guard. Report it as a distinct,
+            # retryable condition — a peer that sees "ProcessingError" will
+            # assume its own request was malformed and stop retrying.
+            logger.warning("concurrent request for %s rejected as busy", working_dir)
+            return json.dumps({
+                "error": "EngineBusy",
+                "message": (
+                    "Neo is already processing a request for this working "
+                    "directory. Retry when it completes."
+                ),
+                "retryable": True,
+                "working_directory": working_dir,
+            })
         except Exception as e:
             logger.exception("NeoEngine.process raised")
             return json.dumps({

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import textwrap
+import threading
 import time
 from collections import deque
 from pathlib import Path
@@ -61,6 +62,16 @@ if TYPE_CHECKING:
 
 # Initialize logger
 logger = logging.getLogger(__name__)
+
+
+class EngineBusyError(RuntimeError):
+    """Raised when a second request overlaps on one NeoEngine instance.
+
+    Subclasses `RuntimeError` so existing broad handlers keep working, while
+    callers that can do something smarter — an A2A host answering a peer, say —
+    can catch this specifically and report a retryable condition instead of a
+    malformed-request error.
+    """
 
 
 class NeoEngine:
@@ -121,6 +132,14 @@ class NeoEngine:
         self._selected_beat: Optional[dict[str, Any]] = None
         self._beat_selected = False
         self._recalled_fact_count = 0
+        # One request at a time per engine. Nearly everything a run needs is
+        # per-request instance state (`context`, `current_learning_episode`,
+        # `_phase_records`, `last_applied_actions`, …), so two concurrent
+        # `process()` calls on one instance would interleave into each other —
+        # cross-attributing suggestions, facts and learning episodes between
+        # unrelated requests. That corruption is silent, which is why this
+        # fails loudly instead.
+        self._process_lock = threading.Lock()
 
         # Load beat deck for personality templates (no LLM call)
         self.beat_deck = self._load_beat_deck()
@@ -312,7 +331,30 @@ class NeoEngine:
         7. Run static checks (if time permits)
         8. Store reasoning in persistent memory
         9. Return structured output
+
+        **One request at a time per engine instance.** A run keeps its state on
+        `self`, so overlapping calls would interleave — two requests sharing one
+        learning episode, suggestions attributed to the wrong prompt. Callers
+        serving concurrent requests must construct one engine per in-flight
+        request, or serialize them. Overlap raises `RuntimeError` rather than
+        corrupting quietly.
         """
+        # Non-blocking: a caller that overlaps requests has a design bug, and
+        # silently queueing would hide it behind a latency mystery instead.
+        if not self._process_lock.acquire(blocking=False):
+            raise EngineBusyError(
+                "NeoEngine.process() is already running on this instance. "
+                "A NeoEngine handles one request at a time — its per-request "
+                "state lives on the instance. Construct one engine per "
+                "concurrent request, or serialize the calls."
+            )
+        try:
+            return self._process_guarded(neo_input)
+        finally:
+            self._process_lock.release()
+
+    def _process_guarded(self, neo_input: NeoInput) -> NeoOutput:
+        """`process()` body, with the single-request lock already held."""
         self._validate_operating_mode(neo_input)
         from neo.execution_context import resolve_execution_context
         self.resolved_execution_context = resolve_execution_context(neo_input)
@@ -325,6 +367,7 @@ class NeoEngine:
         self._beat_selected = False
         self._recalled_fact_count = 0
         self.last_applied_actions: list[AppliedAction] = []
+
         self.current_learning_episode = self._begin_learning_episode(neo_input)
         from neo.memory.metrics import record as record_memory_metric
         record_memory_metric(

--- a/tests/test_engine_single_request.py
+++ b/tests/test_engine_single_request.py
@@ -1,0 +1,184 @@
+"""A NeoEngine handles one request at a time.
+
+Almost everything a run needs lives on the instance — `context`,
+`current_learning_episode`, `_phase_records`, `last_applied_actions`,
+`resolved_execution_context`. Two overlapping `process()` calls would interleave
+into each other and cross-attribute suggestions, facts and learning episodes
+between unrelated requests.
+
+That corruption is silent, which is the problem. `neo.car_host` caches engines
+per working directory and reuses them across calls, relying on CAR's drain task
+being single-threaded — an upstream implementation detail neo does not control.
+So the guard fails loudly instead of trusting it.
+"""
+
+import json
+import threading
+
+import pytest
+
+from neo.engine import EngineBusyError, NeoEngine
+from neo.models import NeoInput, TaskType
+from neo.schemas import SCHEMA_VERSION
+
+
+def _block(kind, payload):
+    return f"<<<NEO:SCHEMA=v3:KIND={kind}>>>\n{json.dumps(payload)}\n<<<END:{kind}>>>"
+
+
+def _response():
+    plan = [{"id": "ps_1", "description": "Add a guard", "rationale": "crash",
+             "dependencies": [], "schema_version": SCHEMA_VERSION}]
+    sim = [{"n": 1, "input_data": "x", "expected_output": "y",
+            "reasoning_steps": ["z"], "issues_found": [],
+            "schema_version": SCHEMA_VERSION}]
+    code = [{"file_path": "src/parser.py", "unified_diff": "", "description": "d",
+             "confidence": 0.9, "tradeoffs": [], "schema_version": SCHEMA_VERSION}]
+    return "\n".join([_block("plan", plan), _block("simulation", sim),
+                      _block("code", code)])
+
+
+class _ReentrantLM:
+    """Calls back into the engine mid-run, which is the cheapest faithful
+    simulation of an overlapping request."""
+
+    model = "fake"
+    provider = "fake"
+
+    def __init__(self, engine_ref, response):
+        self.engine_ref = engine_ref
+        self.response = response
+        self.inner_error = None
+
+    def generate(self, messages, **kwargs):
+        if self.inner_error is None:
+            try:
+                self.engine_ref[0].process(NeoInput(prompt="overlapping request"))
+                self.inner_error = False
+            except EngineBusyError as exc:
+                self.inner_error = exc
+        return self.response
+
+    def name(self):
+        return "reentrant-lm"
+
+
+class _SlowLM:
+    """Holds the run open so a second thread can collide with it."""
+
+    model = "fake"
+    provider = "fake"
+
+    def __init__(self, response, started, release):
+        self.response = response
+        self.started = started
+        self.release = release
+
+    def generate(self, messages, **kwargs):
+        self.started.set()
+        self.release.wait(timeout=10)
+        return self.response
+
+    def name(self):
+        return "slow-lm"
+
+
+def test_overlapping_process_raises_rather_than_interleaving():
+    ref = []
+    lm = _ReentrantLM(ref, _response())
+    engine = NeoEngine(lm_adapter=lm, enable_persistent_memory=False)
+    ref.append(engine)
+
+    engine.process(NeoInput(prompt="first request", task_type=TaskType.BUGFIX))
+
+    assert isinstance(lm.inner_error, EngineBusyError), (
+        "an overlapping process() call was allowed through"
+    )
+
+
+def test_concurrent_threads_cannot_share_one_engine():
+    started, release = threading.Event(), threading.Event()
+    engine = NeoEngine(
+        lm_adapter=_SlowLM(_response(), started, release),
+        enable_persistent_memory=False,
+    )
+
+    result = {}
+
+    def first():
+        try:
+            engine.process(NeoInput(prompt="first", task_type=TaskType.BUGFIX))
+            result["first"] = "ok"
+        except Exception as exc:  # pragma: no cover - diagnostic
+            result["first"] = exc
+
+    worker = threading.Thread(target=first)
+    worker.start()
+    try:
+        assert started.wait(timeout=10), "the first run never reached the LM"
+        with pytest.raises(EngineBusyError):
+            engine.process(NeoInput(prompt="second", task_type=TaskType.BUGFIX))
+    finally:
+        release.set()
+        worker.join(timeout=15)
+
+    assert result.get("first") == "ok", "the guard broke the run it was protecting"
+
+
+def test_the_lock_is_released_so_the_engine_stays_reusable():
+    """Sequential reuse is the normal case — car_host caches engines per cwd."""
+    engine = NeoEngine(
+        lm_adapter=_SlowLM(_response(), threading.Event(), _preset_event()),
+        enable_persistent_memory=False,
+    )
+    for _ in range(3):
+        engine.process(NeoInput(prompt="again", task_type=TaskType.BUGFIX))
+
+
+def test_the_lock_is_released_after_a_failed_run():
+    """A raising run must not leave the engine permanently busy."""
+
+    class Exploding:
+        model = "fake"
+        provider = "fake"
+
+        def __init__(self):
+            self.calls = 0
+
+        def generate(self, messages, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("model exploded")
+            return _response()
+
+        def name(self):
+            return "exploding-lm"
+
+    engine = NeoEngine(lm_adapter=Exploding(), enable_persistent_memory=False)
+    with pytest.raises(Exception):
+        engine.process(NeoInput(prompt="first", task_type=TaskType.BUGFIX))
+
+    # Must not raise EngineBusyError.
+    engine.process(NeoInput(prompt="second", task_type=TaskType.BUGFIX))
+
+
+def test_busy_error_is_a_runtime_error():
+    """Existing broad handlers must keep catching it."""
+    assert issubclass(EngineBusyError, RuntimeError)
+
+
+def test_a2a_host_reports_busy_as_retryable():
+    """A peer that sees a generic ProcessingError assumes its own request was
+    malformed and stops retrying."""
+    source = (
+        __import__("pathlib").Path("src/neo/car_host.py").read_text()
+    )
+    assert "EngineBusyError" in source
+    assert '"error": "EngineBusy"' in source
+    assert '"retryable": True' in source
+
+
+def _preset_event():
+    event = threading.Event()
+    event.set()
+    return event


### PR DESCRIPTION
## Description

Two parts: the last real defect from the known-limits list, then the 0.42.0 release.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Completes the follow-ups from #161, #162, #163.

## Motivation and Context

### Enforce the single-request constraint instead of documenting it

`NeoEngine` was *documented* as one-request-at-a-time and nothing checked. Nearly all run state lives on the instance — `context`, `current_learning_episode`, `_phase_records`, `_findings`, `_selected_beat`, `resolved_execution_context`, `last_applied_actions` — so overlapping `process()` calls interleave and cross-attribute suggestions, facts and learning episodes between unrelated requests. **Silently**, which is what makes it worth failing loudly on.

`process()` now takes a non-blocking `threading.Lock` and raises `EngineBusyError` (a `RuntimeError` subclass, so existing broad handlers keep working). Non-blocking is deliberate: queueing would hide a caller's design bug behind a latency mystery. The lock releases in a `finally`, so a failed run leaves the engine reusable — pinned by a test, since that is the failure that would turn one bad request into a permanently dead engine.

**This is not theoretical.** `car_host._get_or_create_engine` caches engines per working directory and reuses them across calls, relying on CAR's drain task being single-threaded — which its own comment already calls *"an implementation detail"*, i.e. upstream and not ours to guarantee. `_handle_call` now maps `EngineBusyError` to a distinct retryable `EngineBusy` response: a peer that sees a generic `ProcessingError` assumes its own request was malformed and stops retrying.

### What was *not* fixed, and why

The known-limits list had three entries. Only one was a defect:

- **No live streaming through a `Bash` call** — a harness constraint, not a neo bug. A `Bash` tool call returns output after completion; nothing in this repo changes that. `JsonlSink` still flushes per event for hosts that *can* stream.
- **Templated-not-generated voice** — a decision, not a defect. LM-voiced summaries were considered and explicitly rejected: a call and latency per run, plus the risk of altering a number or dropping a caution.

## How Has This Been Tested?

- [x] `pytest` — **1635 passed, 8 skipped** (+6 new)
- [x] `ruff check src/ tests/ tools/` — clean under the pinned 0.16.0
- [x] `tests/test_engine_single_request.py` (6) — including a genuine two-thread collision (one run held open at the LM boundary while a second thread calls in) and a re-entrant call from inside the LM adapter
- [x] Lock release verified after both a successful and a **raising** run
- [x] Release artifacts built and spot-checked: `neo_reasoner-0.42.0-py3-none-any.whl` + sdist contain `events.py`, `progress.py`, and the beat deck
- [x] Editable metadata refreshed — `importlib.metadata.version('neo-reasoner') == '0.42.0'`

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS (darwin 25.6.0)
- Neo version: 0.42.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

First release to use the single-source version path from #163: `pyproject.toml` bumped, `make sync-version` propagated it to `__init__` and both plugin manifests.

**Publishing is not automatic on tag.** `publish.yml` triggers on `release: published`, so pushing the tag is safe; creating the GitHub Release is what ships to PyPI — and a PyPI version can never be reused. Holding that step for explicit sign-off.