### PR TITLE
fix(outcomes): stop deleting pending suggestions before the user acts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,29 @@
   `workflow`, `security`, `file-patterns`, `architecture`, `performance` are the
   suggested vocabulary, but any string is valid. `retrieve_relevant(..., domain=...)`
   filters by exact match; `domain=None` returns all facts including unset ones.
+- **Pending sessions are RETAINED, not cleared** (`outcomes.collect_outcomes`).
+  A session whose files haven't changed yet is kept in the log so a later run
+  can still attribute the acceptance; only sessions that produced an outcome
+  (git-matched, or a review-only weak UNVERIFIED) are dropped, plus anything
+  past `PENDING_SESSION_TTL_SECONDS` (14d) so the log stays bounded. This used
+  to clear the WHOLE log whenever any session existed — so any neo invocation
+  between "neo suggests X" and "user applies X" silently destroyed the pending
+  suggestion. The multi-session read in `collect_outcomes` exists to prevent
+  exactly that loss and the unconditional clear defeated it one level up.
+  **Measured**: 30d of real traffic = 108 episodes, 58 stuck at
+  `suggested_pending_downstream_outcome`, **zero `accepted` outcomes ever** —
+  so the promote path (needs 2 git-verified acceptances) could never fire no
+  matter how correct its own gates were. The July drill only worked because the
+  operator applied the diff with no intervening run. Retention **rewrites** the
+  log (`_rewrite_session_log`, temp + `os.replace`) rather than appending, or
+  one suggestion would accrue a copy per invocation and bump its fact once per
+  copy. `_is_non_git_trackable` is shared by the weak-acceptance detector and
+  the retention rule so they can't disagree about what's still worth waiting on.
+  **Test footgun**: `outcomes.SESSIONS_DIR` is resolved at IMPORT time from
+  `Path.home()`, so conftest's per-test home patch does NOT redirect it — every
+  test shares one sessions dir. Tests must use a unique `project_id` or they
+  read each other's leftover session logs (this passed in isolation and failed
+  in the full suite until scoped).
 - Outcomes (`memory.outcomes` + `store.detect_implicit_feedback`):
   ACCEPTED/MODIFIED act on the linked original fact when present — confidence
   +0.2 / −0.2 (both ±arch_mod); ACCEPTED also bumps `success_count` and sets

--- a/src/neo/memory/outcomes.py
+++ b/src/neo/memory/outcomes.py
@@ -13,6 +13,7 @@ import datetime
 import enum
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -598,6 +599,9 @@ class OutcomeTracker:
 
         all_outcomes: list[Outcome] = []
         merged_fact_ids: dict[str, str] = {}
+        # Sessions whose suggestions are still awaiting a user action. Retained
+        # rather than cleared — see the note at the clearing step below.
+        pending: list[SessionRecord] = []
 
         for prev in sessions:
             if prev.project_id != self.project_id:
@@ -611,6 +615,7 @@ class OutcomeTracker:
 
             changed_files = self._get_changed_files_since(prev.timestamp)
             if not changed_files:
+                pending.append(prev)
                 continue
 
             suggested = [s.get("file_path", "") for s in prev.suggestions]
@@ -632,9 +637,29 @@ class OutcomeTracker:
         # the same fact from a single user action.
         all_outcomes = self._dedup_outcomes(all_outcomes)
 
-        # Clear processed sessions from the log
-        if clear_processed and (all_outcomes or sessions):
-            self._clear_session_log()
+        # Clear PROCESSED sessions, keep the ones still waiting on the user.
+        #
+        # This used to delete the whole log whenever any session existed, even
+        # when nothing had changed and no outcome was produced. That silently
+        # destroyed every pending suggestion the moment neo was invoked again
+        # before the user acted — which is the normal way people use it. The
+        # multi-session read directly above was added to prevent exactly that
+        # loss, and the unconditional clear defeated it one level up.
+        #
+        # Measured consequence over 30 days of real traffic: 108 episodes, 58
+        # stuck at `suggested_pending_downstream_outcome`, and ZERO `accepted`
+        # outcomes ever recorded — so the promote path, which needs two
+        # git-verified acceptances, could never fire no matter how correct its
+        # own gates were.
+        #
+        # A session is processed once its files have changed (git-matched) or
+        # it produced a non-git outcome; anything else is still pending.
+        if clear_processed:
+            keep = [
+                s for s in pending
+                if self._session_awaits_user_action(s) and not self._session_expired(s)
+            ]
+            self._rewrite_session_log(keep)
 
         accepted = sum(1 for o in all_outcomes if o.outcome_type == OutcomeType.ACCEPTED)
         modified = sum(1 for o in all_outcomes if o.outcome_type == OutcomeType.MODIFIED)
@@ -786,6 +811,85 @@ class OutcomeTracker:
                 best[key] = o
         return list(best.values())
 
+    # A pending suggestion is kept alive across invocations, but not forever:
+    # a suggestion nobody acted on in this long is abandoned, not pending, and
+    # retaining it would grow the log without bound.
+    PENDING_SESSION_TTL_SECONDS = 14 * 24 * 3600
+
+    _NON_TRACKABLE_PATHS = frozenset({"/dev/null"})
+
+    def _is_non_git_trackable(self, file_path: str, normalized: str) -> bool:
+        """True when git can never show us what the user did with this path.
+
+        Shared by the non-git weak-acceptance detector and the pending-session
+        retention rule, so the two cannot disagree about which suggestions are
+        still worth waiting on.
+        """
+        return (
+            file_path in self._NON_TRACKABLE_PATHS
+            or normalized.startswith("docs/")
+            or "/docs/" in normalized
+            or self._is_review_only_path(file_path)
+        )
+
+    def _session_awaits_user_action(self, session: SessionRecord) -> bool:
+        """True when this session still has a suggestion git could confirm.
+
+        Sessions whose suggestions are all review-only have already produced
+        their (weak, UNVERIFIED) outcome and must not be replayed. A session
+        with no suggestions at all has nothing to wait for.
+        """
+        for sugg in session.suggestions:
+            file_path = sugg.get("file_path", "")
+            normalized = normalize_suggestion_path(
+                file_path, session.codebase_root or self.codebase_root
+            )
+            if not self._is_non_git_trackable(file_path, normalized):
+                return True
+        return False
+
+    def _session_expired(self, session: SessionRecord) -> bool:
+        return (time.time() - session.timestamp) > self.PENDING_SESSION_TTL_SECONDS
+
+    def _rewrite_session_log(self, keep: list[SessionRecord]) -> None:
+        """Replace the log with `keep`, atomically.
+
+        Writes through a temp file so a crash mid-rewrite cannot leave a
+        truncated log — losing pending suggestions is the exact failure this
+        whole change exists to stop.
+        """
+        log_path = self._session_log_path
+        if not log_path:
+            return
+        # The single-session file is a backward-compat fallback that
+        # `_load_unprocessed_sessions` reads only when the log is absent.
+        # Always drop it: its content is either represented in `keep` or has
+        # been processed.
+        session_path = self._session_path
+        if session_path and session_path.exists():
+            try:
+                session_path.unlink()
+            except OSError:
+                pass
+
+        if not keep:
+            if log_path.exists():
+                try:
+                    log_path.unlink()
+                except OSError:
+                    pass
+            return
+
+        try:
+            tmp = log_path.with_name(log_path.name + ".tmp")
+            with open(tmp, "w") as f:
+                for session in keep:
+                    f.write(json.dumps(asdict(session)) + "\n")
+            os.replace(tmp, log_path)
+            logger.info("Retained %d pending session(s) awaiting user action", len(keep))
+        except OSError as e:
+            logger.warning(f"Failed to rewrite session log: {e}")
+
     def _detect_non_git_outcomes(
         self, sessions: list[SessionRecord]
     ) -> list[Outcome]:
@@ -806,7 +910,6 @@ class OutcomeTracker:
             return []
 
         outcomes: list[Outcome] = []
-        non_trackable = {"/dev/null"}
 
         for prev in sessions:
             for sugg in prev.suggestions:
@@ -817,13 +920,7 @@ class OutcomeTracker:
                     file_path, prev.codebase_root or self.codebase_root
                 )
 
-                is_non_trackable = (
-                    file_path in non_trackable
-                    or normalized.startswith("docs/")
-                    or "/docs/" in normalized
-                    or self._is_review_only_path(file_path)
-                )
-                if not is_non_trackable:
+                if not self._is_non_git_trackable(file_path, normalized):
                     continue
 
                 # User came back and ran neo again — weak acceptance signal.

--- a/tests/test_pending_session_retention.py
+++ b/tests/test_pending_session_retention.py
@@ -1,0 +1,204 @@
+"""Pending suggestions must survive a neo invocation that resolves nothing.
+
+`collect_outcomes` used to delete the entire session log whenever any session
+existed, even when nothing had changed and no outcome was produced. So any neo
+run between "neo suggests X" and "user applies X" silently destroyed the
+pending suggestion, and the acceptance could never be attributed.
+
+The multi-session read in `collect_outcomes` was added to prevent exactly that
+loss; the unconditional clear defeated it one level up. Measured over 30 days
+of real traffic: 108 episodes, 58 stuck at
+`suggested_pending_downstream_outcome`, and **zero** `accepted` outcomes ever —
+so the promote path, which requires two git-verified acceptances, could never
+fire regardless of how correct its own gates were.
+"""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from neo.memory.outcomes import OutcomeTracker, OutcomeType
+
+# `git log --since` is second-granular, so a commit made in the same wall-clock
+# second as a session timestamp is reported as "changed since" it. Separate the
+# steps or the test measures clock rounding rather than retention.
+TICK = 2
+
+
+def _git(root, *args):
+    subprocess.run(["git", *args], cwd=root, check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    root = tmp_path / "repo"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "foo.py").write_text("def f():\n    return 1\n")
+    _git(root, "init", "-q", ".")
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "T")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "init")
+    time.sleep(TICK)
+    return root
+
+
+class _Suggestion:
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.unified_diff = (
+            "--- a/src/foo.py\n+++ b/src/foo.py\n@@\n"
+            "-    return 1\n+    if True:\n+        return 1\n"
+        )
+        self.description = "guard the return"
+        self.confidence = 0.9
+        self.suggestion_id = "sug-1"
+        self.code_block = ""
+
+
+def _tracker(repo, project_id=None):
+    """One tracker per test, scoped to a unique project_id.
+
+    `outcomes.SESSIONS_DIR` is resolved at import time from `Path.home()`, so
+    conftest's per-test home patch cannot redirect it — every test in the run
+    shares one sessions directory. A fixed project_id would therefore let one
+    test read another's leftover session log, which is exactly what happened:
+    these tests passed in isolation and failed in the full suite, because a
+    stale pending session from the previous test carried a timestamp old enough
+    to match the next test's repo-init commit.
+    """
+    if project_id is None:
+        # tmp_path is unique per test, so its leaf name is a safe scope key.
+        project_id = f"pending-{repo.parent.name}-{repo.name}"
+    return OutcomeTracker(codebase_root=str(repo), project_id=project_id)
+
+
+def _apply_the_suggestion(repo):
+    (repo / "src" / "foo.py").write_text("def f():\n    if True:\n        return 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "applied")
+    time.sleep(TICK)
+
+
+def test_acceptance_survives_intervening_runs(repo):
+    """The regression itself: neo runs twice before the user acts, and the
+    acceptance must still be detected afterwards."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo",
+                         {"src/foo.py": "fact-1"})
+    time.sleep(TICK)
+
+    for _ in range(2):
+        outcomes, _ = tracker.detect_outcomes()
+        assert outcomes == [], "nothing has changed yet"
+
+    _apply_the_suggestion(repo)
+
+    outcomes, fact_ids = tracker.detect_outcomes()
+    assert any(o.outcome_type is OutcomeType.ACCEPTED for o in outcomes)
+    assert fact_ids.get("src/foo.py") == "fact-1", "the fact link must survive too"
+
+
+def test_pending_session_is_retained_not_deleted(repo):
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo", {})
+    time.sleep(TICK)
+    log = Path(tracker._session_log_path)
+
+    tracker.detect_outcomes()
+
+    assert log.exists(), "the pending session was deleted"
+    assert len(log.read_text().strip().splitlines()) == 1
+
+
+def test_a_pending_session_is_not_duplicated_by_repeated_runs(repo):
+    """Retention must rewrite the log, not append to it — otherwise one
+    suggestion accrues a fresh copy per invocation and its fact gets bumped
+    once per copy when it finally lands."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo", {})
+    time.sleep(TICK)
+    log = Path(tracker._session_log_path)
+
+    for _ in range(3):
+        tracker.detect_outcomes()
+
+    assert len(log.read_text().strip().splitlines()) == 1
+
+
+def test_the_log_is_cleared_once_the_session_resolves(repo):
+    """Retention must not become a leak: a processed session goes away."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo", {})
+    time.sleep(TICK)
+    _apply_the_suggestion(repo)
+
+    tracker.detect_outcomes()
+
+    assert not Path(tracker._session_log_path).exists()
+
+
+def test_review_only_sessions_are_not_retained(repo):
+    """Their weak UNVERIFIED outcome fires on the first pass; keeping them
+    would replay the same signal on every later invocation."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("/review/commit-abc.md")], "review this", {})
+    time.sleep(TICK)
+
+    outcomes, _ = tracker.detect_outcomes()
+
+    assert any(o.outcome_type is OutcomeType.UNVERIFIED for o in outcomes)
+    assert not Path(tracker._session_log_path).exists()
+
+
+def test_sessions_with_no_suggestions_are_not_retained(repo):
+    """An advise-only run has nothing to wait for."""
+    tracker = _tracker(repo)
+    tracker.save_session([], "just explain this", {})
+    time.sleep(TICK)
+
+    tracker.detect_outcomes()
+
+    assert not Path(tracker._session_log_path).exists()
+
+
+def test_abandoned_suggestions_expire(repo):
+    """Retention is bounded: a suggestion nobody acted on for two weeks is
+    abandoned, not pending, and must not grow the log forever."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo", {})
+    log = Path(tracker._session_log_path)
+
+    # Age the record past the TTL.
+    record = json.loads(log.read_text().strip())
+    record["timestamp"] -= tracker.PENDING_SESSION_TTL_SECONDS + 60
+    log.write_text(json.dumps(record) + "\n")
+
+    tracker.detect_outcomes()
+
+    assert not log.exists()
+
+
+def test_retention_survives_many_pending_sessions(repo):
+    """Several distinct suggestions can be outstanding at once; each must be
+    kept until its own file moves."""
+    tracker = _tracker(repo)
+    (repo / "src" / "bar.py").write_text("def g():\n    return 2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add bar")
+    time.sleep(TICK)
+
+    tracker.save_session([_Suggestion("src/foo.py")], "fix foo", {})
+    time.sleep(1)
+    tracker.save_session([_Suggestion("src/bar.py")], "fix bar", {})
+    time.sleep(TICK)
+
+    tracker.detect_outcomes()
+
+    log = Path(tracker._session_log_path)
+    assert log.exists()
+    assert len(log.read_text().strip().splitlines()) == 2


### PR DESCRIPTION
## Description

**The interactive learning loop has never recorded a single acceptance. This is why.**

`collect_outcomes` cleared the *entire* session log whenever any session existed — including when nothing had changed and no outcome was produced:

```python
if clear_processed and (all_outcomes or sessions):
    self._clear_session_log()
```

So any neo invocation between *"neo suggests X"* and *"user applies X"* destroyed the pending suggestion. The user then applies the change, neo runs again, and there is nothing left to attribute it to.

The multi-session read directly above that line exists to prevent exactly this loss. The unconditional clear defeated it one level up.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None — found by reading `neo memory learning-stats` against 30 days of real traffic.

## Motivation and Context

Measured **before** the fix, across 30 days:

| | |
|---|---|
| episodes / projects | 108 / 9 |
| `suggested_pending_downstream_outcome` | **58** |
| `accepted` | **0** |
| promotions | **0** |

Promotion requires **two git-verified acceptances**. There had never been *one*. So the promote path could never fire no matter how correct its own gates were — and those gates had already been found and fixed twice, most recently in July.

The July drill that "proved" the loop worked applied the diff with **no intervening neo run**, which happens to be the single sequence that avoids this bug.

### Design of the fix

Sessions whose files have not changed are **retained**. They are dropped only when they produce an outcome (git-matched, or a review-only weak `UNVERIFIED`), or when they pass `PENDING_SESSION_TTL_SECONDS` (14 days) — something nobody acted on for two weeks is abandoned, not pending, and retaining it forever would grow the log without bound.

**Retention rewrites the log rather than appending.** Appending would give one suggestion a fresh copy per invocation and bump its linked fact once per copy when it finally landed. The rewrite goes through a temp file and `os.replace`, because a truncated log loses pending suggestions — the exact failure this change exists to stop.

`_is_non_git_trackable` is now shared by the weak-acceptance detector and the retention rule, so the two cannot disagree about which suggestions are still worth waiting on.

## How Has This Been Tested?

- [x] `pytest` — **1643 passed, 8 skipped** (+8 new)
- [x] `ruff check src/ tests/ tools/` — clean
- [x] **Reproduced against pre-fix code in a real git repo**: with two intervening runs, acceptance is never detected. With the fix, the same sequence detects `ACCEPTED` and *then* correctly clears the log.
- [x] Retention is bounded and non-duplicating: repeated runs keep exactly one copy; a processed session is removed; review-only and empty sessions are not retained; aged-out sessions expire.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**A test-isolation landmine worth knowing about:** `outcomes.SESSIONS_DIR` is resolved at *import time* from `Path.home()`, so conftest's per-test home patch does **not** redirect it — every test in the run shares one sessions directory. These tests passed in isolation and failed in the full suite until each was scoped to a unique `project_id`; they were reading each other's leftover session logs. Documented in CLAUDE.md. Making `SESSIONS_DIR` lazy would fix the class of problem but touches several modules, so it is deliberately not in this PR.

**This does not retroactively recover the 58 stranded episodes** — their session records are already gone. It stops the loss from here on.