### PR TITLE
fix(outcomes): merge on write so a peer's saved session is not erased

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,16 @@
   it's timestamp-independent, and re-forking it per retained session measured
   0.88s of pure `git` forking at 40 pending sessions, on the request hot path,
   growing linearly.
+  **The session log is merge-on-write, not last-writer-wins.**
+  `_rewrite_session_log` takes `store.scope_file_lock`, then RE-READS the log
+  under it and preserves every record whose `_session_key` is absent from
+  `_last_loaded_keys` — i.e. appended by a peer since our read. Locking the
+  write alone was NOT enough and the loss was reproduced: a second neo process
+  saving between one process's read and its `os.replace` was erased without
+  trace. `save_session` takes the same lock for its append. Merge-on-write
+  rather than a wider lock on purpose — holding the lock across the git and LM
+  work in `collect_outcomes`/`replay_linked_feedback` would let a slow
+  reasoning run block another process's save.
   **`replay_linked_feedback` must use `consume_sessions_keeping_pending()`**,
   never a wholesale delete — it is the documented repair command for a broken
   memory loop, so nuking the log there destroyed every pending suggestion the

--- a/src/neo/memory/outcomes.py
+++ b/src/neo/memory/outcomes.py
@@ -340,6 +340,10 @@ class OutcomeTracker:
         # Lets a caller that inspected with clear_processed=False consume the
         # log afterwards without re-running git or nuking pending work.
         self._last_pending: list[SessionRecord] = []
+        # Identities of the sessions that collect_outcomes actually read. The
+        # rewrite keeps anything NOT in this set, so a session appended by a
+        # peer process after the read survives instead of being erased.
+        self._last_loaded_keys: set[tuple] = set()
 
     def _get_session_path(self) -> Optional[Path]:
         if not self.project_id:
@@ -520,11 +524,19 @@ class OutcomeTracker:
         try:
             atomic_write_json(self._session_path, asdict(session), indent=2)
 
-            # Also append to session log so we don't lose prior sessions
+            # Also append to session log so we don't lose prior sessions.
+            # Locked: `_rewrite_session_log` replaces this file wholesale, so an
+            # unlocked append can land between that rewrite's re-read and its
+            # `os.replace` and vanish. The lock is held for one line of I/O.
             log_path = self._session_log_path
             if log_path:
-                with open(log_path, "a") as f:
-                    f.write(json.dumps(asdict(session)) + "\n")
+                from neo.memory.store import scope_file_lock
+
+                with scope_file_lock(log_path):
+                    with open(log_path, "a", encoding="utf-8") as f:
+                        f.write(json.dumps(asdict(session)) + "\n")
+                        f.flush()
+                        os.fsync(f.fileno())
 
             # Durable ledger for async transcript outcome mining (survives the
             # session-log clearing done by git-based outcome detection).
@@ -617,6 +629,7 @@ class OutcomeTracker:
             # back. Unreachable today only because replay gates on non-zero
             # stats — make it structural, not incidental.
             self._last_pending = []
+            self._last_loaded_keys = set()
             return [], {}
 
         all_outcomes: list[Outcome] = []
@@ -711,6 +724,9 @@ class OutcomeTracker:
         # Remembered so `replay_linked_feedback` can consume the log with the
         # same retention rule instead of deleting it wholesale.
         self._last_pending = pending
+        # Recorded from what we actually read, so the rewrite can distinguish
+        # "processed by us" from "appended by a peer since".
+        self._last_loaded_keys = {self._session_key(s) for s in sessions}
         if clear_processed:
             self._rewrite_session_log(pending)
 
@@ -920,22 +936,42 @@ class OutcomeTracker:
             remaining.append(sugg)
         return remaining
 
+    @staticmethod
+    def _session_key(session: SessionRecord) -> tuple:
+        """Stable identity for one saved session.
+
+        Used to tell "a record this process already read and processed" from
+        "a record some other process appended while we were working". No
+        `session_id` field exists on the record, and adding one would not help
+        for entries written by an older neo — `time.time()` is microsecond
+        resolution, so two sessions of the same project colliding here is not a
+        realistic possibility.
+        """
+        return (
+            round(session.timestamp, 6),
+            session.learning_episode_id,
+            session.prompt,
+        )
+
     def _session_expired(self, session: SessionRecord) -> bool:
         return (time.time() - session.timestamp) > self.PENDING_SESSION_TTL_SECONDS
 
     def _rewrite_session_log(self, keep: list[SessionRecord]) -> None:
         """Replace the log with `keep`.
 
-        Read-modify-write across processes, so it holds the same per-scope lock
-        `FactStore.save()` uses. That serializes rewrite against rewrite.
+        Read-modify-write across processes, so it takes the same per-scope lock
+        `FactStore.save()` uses — and, crucially, **re-reads the log under that
+        lock** and preserves anything it did not itself process.
 
-        It does NOT close the read-modify-write window: `_load_unprocessed_sessions`
-        reads without the lock and `save_session` appends without it, so a peer
-        process saving a session between another's read and its replace is still
-        erased. Closing that needs the lock extended over the read and taken by
-        `save_session` too — deliberately not done here, because it widens a
-        lock across LM-bound work in `replay_linked_feedback`. Documented rather
-        than silently overclaimed.
+        Locking the write alone was not enough. Between one process's read and
+        its replace, a peer's `save_session` append was erased without trace
+        (reproduced). The fix is merge-on-write rather than a wider lock: the
+        lock is held only for re-read + write, never across the git and LM work
+        in `collect_outcomes` / `replay_linked_feedback`, so a slow reasoning
+        run cannot block another process's save.
+
+        `save_session` takes the same lock for its append, so an append can
+        never interleave with this rewrite.
 
         Durability: temp file + `os.replace`, with `flush`+`fsync` before the
         rename so a machine crash can't leave a rename pointing at unwritten
@@ -956,9 +992,46 @@ class OutcomeTracker:
         with scope_file_lock(log_path):
             self._rewrite_session_log_locked(log_path, keep)
 
+    def _sessions_appended_since_read(self, log_path: Path) -> list[SessionRecord]:
+        """Records now in the log that this process never read.
+
+        Called under the lock, immediately before the rewrite. Anything whose
+        identity is absent from `_last_loaded_keys` arrived from a peer while we
+        were doing git and LM work, and must survive our write.
+        """
+        if not log_path.exists():
+            return []
+        fresh: list[SessionRecord] = []
+        try:
+            with open(log_path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = SessionRecord(**json.loads(line))
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if self._session_key(record) not in self._last_loaded_keys:
+                        fresh.append(record)
+        except OSError as e:
+            # Better to skip the merge than to lose the rewrite entirely; the
+            # worst case degrades to the previous behavior.
+            logger.warning(f"Could not re-read session log before rewrite: {e}")
+            return []
+        if fresh:
+            logger.info(
+                "Preserving %d session(s) appended by another process", len(fresh)
+            )
+        return fresh
+
     def _rewrite_session_log_locked(
         self, log_path: Path, keep: list[SessionRecord]
     ) -> None:
+        # Merge in anything a peer appended after our read. Without this the
+        # rewrite is a lost update: we would write back a view of the file that
+        # predates their save.
+        keep = list(keep) + self._sessions_appended_since_read(log_path)
         # The single-session file is a backward-compat fallback that
         # `_load_unprocessed_sessions` reads only when the log is absent.
         # Removed only AFTER the log is safely in place: unlinking first and

--- a/tests/test_pending_session_retention.py
+++ b/tests/test_pending_session_retention.py
@@ -305,6 +305,58 @@ def test_the_scan_anchor_advances_so_work_does_not_repeat(repo):
     assert "src/foo.py" in retained["resolved_paths"]
 
 
+def test_a_peer_process_save_is_not_erased_by_our_rewrite(repo):
+    """The lost update.
+
+    `collect_outcomes` reads the log, then does git and LM work, then rewrites.
+    A second neo process saving a session inside that window used to be erased
+    without trace — the rewrite wrote back a view of the file predating their
+    save. Locking only the write did not fix it; the rewrite has to re-read
+    under the lock and preserve what it never processed.
+
+    Fixed by merge-on-write rather than a wider lock: holding the lock across
+    the reasoning work would let a slow run block another process's save.
+    """
+    ours = _tracker(repo, project_id="peer-test-shared")
+    peer = _tracker(repo, project_id="peer-test-shared")
+
+    ours.save_session([_Suggestion("src/foo.py")], "ours", {})
+    time.sleep(1)
+
+    # Our read-modify-write begins.
+    sessions = ours._load_unprocessed_sessions()
+    ours._last_pending = list(sessions)
+    ours._last_loaded_keys = {ours._session_key(s) for s in sessions}
+
+    # A peer saves while we are still working.
+    peer.save_session([_Suggestion("src/peer.py")], "theirs", {})
+
+    # We complete our rewrite.
+    ours.consume_sessions_keeping_pending()
+
+    log = Path(ours._session_log_path)
+    survivors = sorted(
+        json.loads(line)["suggestions"][0]["file_path"]
+        for line in log.read_text().strip().splitlines()
+    )
+    assert "src/peer.py" in survivors, "the peer's session was erased"
+    assert "src/foo.py" in survivors, "our own pending session was dropped"
+    assert len(survivors) == len(set(survivors)), "merge duplicated a session"
+
+
+def test_the_merge_does_not_resurrect_processed_sessions(repo):
+    """The other direction: a session we DID process must not come back just
+    because it is still in the file when we re-read."""
+    tracker = _tracker(repo)
+    tracker.save_session([_Suggestion("docs/guide.md")], "review only", {})
+    time.sleep(TICK)
+
+    tracker.detect_outcomes()  # review-only resolves and is not retained
+
+    log = Path(tracker._session_log_path)
+    assert not log.exists(), "a processed session was written back by the merge"
+
+
 def test_a_weak_outcome_cannot_overwrite_a_verified_one():
     """`final_outcome` must report the strongest evidence in the batch.
 


### PR DESCRIPTION
## Description

The session log is a cross-process read-modify-write: `collect_outcomes` reads it, does git and LM work, then rewrites. **A second neo process saving inside that window was erased without trace.**

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

The gap #168 documented rather than fixed.

## Motivation and Context

Reproduced before the fix — process A reads, peer B saves `src/fresh.py`, A rewrites:

```
survivors: ['src/old.py']
=> peer's session survived: False
```

Locking the write alone did not close it, which #168's docstring admitted: the read and `save_session`'s append were both unlocked, so the lock only serialized rewrite-against-rewrite.

### Merge-on-write, not a wider lock

`_rewrite_session_log` now **re-reads the log under the lock** and preserves every record whose `_session_key` is absent from `_last_loaded_keys` — anything a peer appended since our read. `save_session` takes the same lock for its append, so an append can never interleave with a rewrite.

The obvious alternative — hold the lock across the whole read-modify-write — spans git subprocesses in `collect_outcomes` and a full `FactStore.save()` with embeddings in `replay_linked_feedback`. A slow reasoning run would then block an unrelated process from saving its session, trading a rare lost update for a routine stall. The lock here is held for one re-read and one write.

`_session_key` is `(timestamp rounded to microseconds, learning_episode_id, prompt)`. No `session_id` field exists, and adding one wouldn't help records written by an older neo; `time.time()` resolution makes a collision within one project unrealistic.

## How Has This Been Tested?

- [x] `pytest` — **1691 passed, 8 skipped** (+2)
- [x] `ruff check src/ tests/ tools/` — clean under pinned 0.16.0
- [x] **Reproduced the loss against pre-fix code**, then verified after: peer's session survives, our pending survives, no duplicates
- [x] Opposite direction covered too — a session we *did* process is not resurrected by the merge just because it's still in the file when we re-read

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This closes the last item either reviewer flagged as a correctness hole. What remains from their reports is architectural rather than broken: Neo's recommendation to make the append-only suggestion ledger the authoritative lifecycle store with the pending set as a rebuildable projection, and the unhandled rename / branch-switch cases under 14-day retention.