### PR TITLE
fix(learning): read the file you were asked about, and mean it by "independent"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,29 @@
     tunable independently.
   - Episode-derived promotion correlation (`store._episode_signature` /
     `_global_signature`): a candidate promotes to a durable fact only when ≥2
-    independent verified-accepted episodes share a **correlation signature**. That
+    verified-accepted episodes share a **correlation signature** AND those
+    episodes span ≥2 distinct `repository_revision`s
+    (`_supporting_episodes_span_distinct_revisions`). The revision requirement is
+    what "independent" actually means here: distinct episode ids alone is no test
+    at all, since every invocation mints a fresh one, so one operator applying the
+    same patch twice minutes apart at the same HEAD promoted a durable PATTERN
+    whose content was wrong (reproduced live). **A session-id fallback for non-git
+    projects was written and REMOVED — do not reintroduce it.**
+    `LearningEpisode.session_id` is a per-episode `uuid4()` that nothing ever
+    assigns from a real session (121 episodes on a live ledger → 121 distinct
+    ids), so "≥2 distinct sessions" was the very gate being replaced, renamed;
+    and since acceptance detection is entirely git-based, a genuinely non-git
+    project can never record an ACCEPTED outcome and could not reach the fallback
+    anyway. Its only reachable trigger was a transient `rev-parse` failure, which
+    made BOTH failing promote while ONE failing blocked — load-dependent
+    non-determinism in the durable memory path. It now fails closed on a blank
+    revision. Two accepted costs, documented on the predicate: the revision is
+    captured when the episode BEGINS (HEAD when advice was asked for, not the
+    commit the fix landed in), and applying one lesson across several files in a
+    single sitting records ONE revision and promotes nothing (40% of
+    revision-bearing episodes share a HEAD with another). Keying on the
+    acceptance-carrying sha — already walked by `_get_changed_files_since` — is
+    the obvious improvement. That
     signature is keyed on the candidate SUBJECT, never the body — the body is the
     LM's run-varying Reasoning/Suggestion prose, and including it (the old
     `generalize(subject+body)`) gave two acceptances of one task different
@@ -123,8 +145,8 @@
     vs 29 raw), and every run multiplied the whole corpus by 0.97. A live census
     also showed zero ≥3-member clusters at cosine 0.85 across all 1152 valid
     REVIEWs, so it could not fire on real data anyway. The git-verified episode
-    ledger (`_promote_repeatedly_supported_candidate`, ≥2 independent verified
-    acceptances) is the learning path that remains — do not reintroduce an
+    ledger (`_promote_repeatedly_supported_candidate`, ≥2 verified acceptances
+    spanning ≥2 revisions) is the learning path that remains — do not reintroduce an
     unverified similarity-clustered route beside it. Facts minted before the
     removal keep their `synthesized` tag and prune immunity; nothing mints it
     now. `SUPERSESSION_THRESHOLD` (0.85) and canonical-signature dedup are
@@ -151,9 +173,35 @@
     from a real new file and is admitted. That asymmetry is deliberate —
     `kind` is frozen at mint, so under-admitting permanently kills a real
     lesson, while over-admitting only leaves a candidate pending.
-    `neo memory learning-stats` reports the verifiable/total ratio and says
-    STARVED (rather than IDLE) when nothing is verifiable, so a starved loop is
-    distinguishable from a broken one.
+    `neo memory learning-stats` buckets recorded suggestions FOUR ways
+    (`subcommands._classify_suggestion`): `verifiable`, `advisory`,
+    `unattributable` (the bug signal) and `root_unavailable`. The fourth exists
+    because every resolution test runs against the LIVE filesystem, so a recorded
+    `codebase_root` that no longer exists — mostly deleted Claude Code agent
+    worktrees — makes them all meaningless; counted as unattributable those
+    buried the one number the report exists to make actionable. **Ordering rule**:
+    only the empty-input test is decidable from the arguments alone, so the root
+    check runs immediately after it and every filesystem-dependent branch runs
+    below. Placing the prose-suffix/sentinel/`docs/` branches above it looked
+    string-decidable and was not — under a dead root all three degrade to "does
+    not exist" and silently return advisory, which under-reported the integrity
+    signal by 43% (8 against 14 real) and inflated `measurable` by the difference.
+    Verdicts (ACTIVE / UNMEASURABLE / STARVED / IDLE) are computed over
+    `measurable = total - root_unavailable`, never against a content bucket: the
+    first version compared `root_unavailable > verifiable`, so a single dead root
+    suppressed STARVED entirely and claimed "most recorded suggestions" off a
+    count of one. An integrity note discloses the unmeasured share in EVERY
+    branch, ACTIVE included. The bug signal is keyed on `_SOURCE_SUFFIXES`, not on
+    a leading slash — slash-keying split `/review/x.json` from `review/x.json` on
+    LM formatting alone and buried two real defects (a model-emitted
+    `<placeholder>` segment and a new module in a new directory). This classifier
+    is **reporting-only and deliberately stricter than
+    `suggestion_is_verifiable`**, which stays untouched: its bias toward admitting
+    a doubtful path is correct because `kind` is frozen at mint, while
+    over-admitting in a report costs only an inaccurate number. Measured: the
+    prose-suffix-before-verifiable ordering corrected `verifiable` from 21 to 10,
+    11 of which were invented review docs (`/ARCHITECTURAL_REVIEW.md`) that the
+    plausible-new-file rule had granted because their parent IS the repo root.
   - Probation: new non-curated facts enter with a `probation` tag and a 3-day stale window
     (vs 7/14); promoted automatically on access_count ≥2 or success_count >0.
   - Independent-outcome facts capped at 5/session (`MAX_INDEPENDENT_OUTCOMES` in
@@ -469,7 +517,42 @@
 - Debugging: `neo --dry-run "your query"` assembles the full context (file selection,
   fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
   the LM, then exits without making the LLM call. Faster iteration on context-gatherer
-  and retrieval changes than waiting for an inference round trip.
+  and retrieval changes than waiting for an inference round trip. **Use it before
+  believing any claim about what Neo "saw"** — the two defects below were both
+  invisible from the outside and presented as the model being unhelpful.
+- Context selection (`context_gatherer`): **a path named in the prompt is pinned**
+  (`EXPLICIT_PATH_BOOST=10.0`, chosen to exceed every organic signal combined —
+  filename overlap caps at +1.8, the re-rank boosts at +1.0 and +1.2). Without it a
+  spelled-out path competed on generic filename-token overlap and lost:
+  `src/neo/subcommands.py` ranked **163rd of 296** on a prompt naming it, below its
+  own test file, because an 86KB file takes a heavy size penalty. The file never
+  reached context, so the model correctly refused to patch code it had not seen and
+  emitted NO diff — and a suggestion with no diff text can never be git-verified,
+  which is a major reason only ~32% of suggestions were verifiable.
+  `matches_explicit_path` tests containment in BOTH directions (an absolute path —
+  what tracebacks, IDE copy-path and Neo's own output emit — must match the
+  repo-relative candidate) and anchors on `/` so bare `subcommands.py` hits
+  `src/neo/subcommands.py` but NOT `tests/test_subcommands.py`. A named path that
+  matched nothing emits a WARNING; silence there is indistinguishable from "no path
+  mentioned".
+  `select_chunks` ranks windows by **per-file document frequency** and **matched-token
+  length**, not file order or match count. It used to take `matching_idxs[:5]` — the
+  first five matching lines in FILE ORDER — and since matching is a substring test and
+  `extract_prompt_tokens` emits every 3+ character word, `"in"` matched
+  `int`/`using`/`point` and virtually every line qualified. "First five matches"
+  therefore meant **lines 1-5 for any prompt against any large file**: every large file
+  contributed its import block, twice, as overlapping near-duplicates that consumed
+  both slots of `MAX_CHUNKS_PER_FILE`. A length cutoff for "discriminative" is
+  INVERTED on real prompts (English stopwords are long, identifiers are short — it
+  keeps `does`/`here` and drops `db`/`fs`/`os`), hence document frequency
+  (`DISCRIMINATIVE_MAX_LINE_FRACTION=0.25`). Length weighting matters because match
+  COUNT let a keyword-bearing module docstring tie with the function body and win on
+  the file-order tie-break. Window merging is bounded by `MAX_MERGED_WINDOW_LINES`:
+  unbounded chain-merging measured **8.3× over `max_chunk_bytes`**, and because the
+  caller admits a chunk all-or-nothing, an oversized chunk that no longer fits the
+  global budget is DROPPED — the original bug returning through a different door.
+  `_fit_to_budget` shrinks outward from the window's best line so truncation can never
+  discard the line that earned the window.
 - Host communication (`neo.events` + `models.OrchestratorMessage`): the engine
   reports lifecycle facts so a host (Claude Code, MCP, an IDE) doesn't have to
   reverse-engineer presentation from raw plans. **Governing rule: Neo reports

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -25,6 +25,9 @@ from neo import progress
 # Constants
 MIN_SCORE_THRESHOLD = 0.2  # Filter files with very low relevance (was 0.3, reduced for broad prompts)
 MAX_CHUNKS_PER_FILE = 2    # Cap chunks per file so one large file doesn't dominate the budget
+MAX_CHUNK_CENTERS = 20     # Best-scoring lines considered as window centers before merging
+MAX_MERGED_WINDOW_LINES = 200   # Ceiling on a merged window so one file can't eat the budget
+DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is noise in it
 
 
 @dataclass
@@ -213,6 +216,70 @@ def extract_prompt_tokens(prompt: str) -> set[str]:
     return tokens
 
 
+# Enough to clear any organic score (filename overlap caps at +1.8, the two
+# re-rank boosts at +1.0 and +1.2). Naming a path is the least ambiguous signal
+# a prompt can carry, so it outranks every heuristic rather than competing with
+# them.
+EXPLICIT_PATH_BOOST = 10.0
+
+# Loose: real filtering is "does this match a file we actually found", which no
+# amount of prose punctuation can fake.
+_PATH_LIKE = re.compile(r'[A-Za-z0-9_][A-Za-z0-9_./\\-]*\.[A-Za-z][A-Za-z0-9]{0,5}')
+
+
+def extract_explicit_paths(prompt: str) -> set[str]:
+    """Path-like tokens in the prompt, normalized to forward slashes.
+
+    These are candidates only — `matches_explicit_path` decides whether one
+    names a file that exists, so "e.g." and "0.42.0" cost nothing.
+
+    Leading "./" is stripped as a PREFIX, never with `str.strip("./")`: that
+    strips a character *set* from both ends, so an absolute
+    "/Users/me/repo/src/app.py" lost its leading slash and silently stopped
+    being recognizable as absolute.
+    """
+    found = set()
+    for raw in _PATH_LIKE.findall(prompt):
+        token = raw.replace("\\", "/")
+        while token.startswith("./"):
+            token = token[2:]
+        if token:
+            found.add(token.lower())
+    return found
+
+
+def matches_explicit_path(rel_path: str, explicit: set[str]) -> bool:
+    """Does `rel_path` name one of the paths the prompt spelled out?
+
+    Containment is tested in BOTH directions on a path boundary:
+
+    * the prompt gives a repo-relative or bare name ("subcommands.py") and the
+      candidate is longer ("src/neo/subcommands.py"), and
+    * the prompt gives an ABSOLUTE path ("/Users/me/repo/src/neo/subcommands.py")
+      and the candidate is the shorter repo-relative form.
+
+    The second direction was missing, which killed the highest-value input:
+    tracebacks, IDE "copy path", and neo's own suggestion output all emit
+    absolute paths.
+
+    Matching is anchored on "/" so a bare "subcommands.py" hits
+    "src/neo/subcommands.py" but NOT "tests/test_subcommands.py" — matching the
+    neighbour would re-bury the named file under its own test, which is the
+    failure this exists to fix.
+    """
+    if not rel_path or not explicit:
+        return False
+    candidate = rel_path.replace("\\", "/").lower()
+    for token in explicit:
+        if not token:
+            continue
+        if (candidate == token
+                or candidate.endswith("/" + token)
+                or token.endswith("/" + candidate)):
+            return True
+    return False
+
+
 def calculate_adaptive_limit(prompt: str, default_max: int = 30) -> int:
     """
     Calculate adaptive file limit based on prompt specificity.
@@ -342,32 +409,122 @@ def select_chunks(content: str, prompt_tokens: set[str], max_chunk_bytes: int = 
     if len(content) <= max_chunk_bytes:
         return [(content, 1, len(lines))]
 
-    # Find lines with keyword matches
-    matching_idxs = [
-        i for i, line in enumerate(lines)
-        if any(token in line.lower() for token in prompt_tokens)
-    ]
+    # Rank lines by the total length of the DISCRIMINATIVE tokens they carry.
+    #
+    # This used to take the first five matching lines in FILE ORDER. Matching is
+    # a substring test, and `extract_prompt_tokens` emits every 3+ character word
+    # — "the", "in", "is", "py", "src" — so "in" matches `int`, `using`, `point`
+    # and virtually every line qualified. "First five matches" therefore meant
+    # "lines 1-5" for any prompt against any large file, and with a 40-line
+    # window that is the module docstring and imports. Asked to fix a named
+    # function in an 86KB file, neo received that file's import block twice and
+    # answered that the function body was not provided — so it emitted no patch,
+    # and a suggestion with no diff text can never be verified or learned from.
+    #
+    # Two properties matter, and BOTH are load-bearing — the merge below does
+    # not rescue a bad ranking, it only hides it on the cases that happen to
+    # tie:
+    #
+    # 1. "Discriminative" is measured PER FILE, by document frequency. A length
+    #    cutoff was tried and is inverted on real prompts: English stopwords are
+    #    long and identifiers are short, so `len >= 4` keeps "does" and "here"
+    #    while discarding "db", "fs", "os" and "api" — frequently the entire
+    #    subject of the prompt. A token matching most lines of THIS file is
+    #    noise regardless of its length.
+    # 2. Lines are weighted by matched token LENGTH, not match count. Counting
+    #    made a specific prompt degenerate: `_classify_suggestion` and
+    #    `subcommands` both scored 1, so the module docstring tied with the
+    #    function body and won on the file-order tie-break — still returning
+    #    lines 1-43 as the first chunk. Length weighting prefers the line
+    #    carrying the longer, more specific token.
+    lowered_lines = [line.lower() for line in lines]
+    line_count = len(lines) or 1
+    frequency = {
+        token: sum(1 for line in lowered_lines if token in line)
+        for token in prompt_tokens
+    }
+    present = {token for token, hits in frequency.items() if hits}
+    discriminative = {
+        token for token in present
+        if frequency[token] <= DISCRIMINATIVE_MAX_LINE_FRACTION * line_count
+    } or present
 
-    if not matching_idxs:
+    scored_lines = []
+    for i, line in enumerate(lowered_lines):
+        weight = sum(len(token) for token in discriminative if token in line)
+        if weight:
+            scored_lines.append((weight, i))
+
+    if not scored_lines:
         # No matches, return header + first N lines
         header_size = min(200, len(lines))
         chunk = '\n'.join(lines[:header_size])
         return [(chunk, 1, header_size)]
 
-    # Build windows around matches
-    chunks = []
+    scored_lines.sort(key=lambda pair: (-pair[0], pair[1]))
     window_size = 40
+    best_by_index = {index: weight for weight, index in scored_lines[:MAX_CHUNK_CENTERS]}
 
-    for idx in matching_idxs[:5]:  # Limit to 5 windows
-        start = max(0, idx - window_size)
-        end = min(len(lines), idx + window_size)
-        chunk = '\n'.join(lines[start:end])
-        chunks.append((chunk, start + 1, end))
+    # Merge overlapping windows instead of emitting near-duplicates. Two centers
+    # a couple of lines apart previously produced two chunks differing by two
+    # lines, each consuming a slot of the per-file cap.
+    #
+    # Merging is bounded. Unbounded, ~20 centers spaced just under 2*window_size
+    # chain into one window measured at 8.3x `max_chunk_bytes` — and because the
+    # caller admits a chunk all-or-nothing, an oversized one that no longer fits
+    # the global budget is DROPPED, so the explicitly-named file contributes
+    # nothing. That is the original bug returning through a different door.
+    merged: list[list[int]] = []
+    for index in sorted(best_by_index):
+        start = max(0, index - window_size)
+        end = min(len(lines), index + window_size)
+        if (merged and start <= merged[-1][1]
+                and end - merged[-1][0] <= MAX_MERGED_WINDOW_LINES):
+            merged[-1][1] = max(merged[-1][1], end)
+            if best_by_index[index] > merged[-1][2]:
+                merged[-1][2] = best_by_index[index]
+                merged[-1][3] = index
+        else:
+            # Refusing a merge must not emit an overlapping range: clamp the new
+            # window to start where the previous one ended.
+            start = max(start, merged[-1][1]) if merged else start
+            if start < end:
+                merged.append([start, end, best_by_index[index], index])
 
+    # Strongest window first, so the per-file cap keeps the most relevant region
+    # rather than whichever happens to appear earliest in the file.
+    merged.sort(key=lambda window: window[2], reverse=True)
+
+    chunks = []
+    for start, end, _weight, center in merged[:MAX_CHUNKS_PER_FILE]:
+        start, end = _fit_to_budget(lines, start, end, center, max_chunk_bytes)
+        chunks.append(('\n'.join(lines[start:end]), start + 1, end))
         if sum(len(c[0]) for c in chunks) >= max_chunk_bytes:
             break
 
     return chunks
+
+
+def _fit_to_budget(
+    lines: list[str], start: int, end: int, center: int, max_bytes: int
+) -> tuple[int, int]:
+    """Shrink [start, end) to fit `max_bytes`, growing outward from `center`.
+
+    Truncating from the front would be simpler and wrong: the center is the line
+    that earned the window, so it is the one line that must survive.
+    """
+    if len('\n'.join(lines[start:end])) <= max_bytes:
+        return start, end
+    low = high = min(max(center, start), end - 1)
+    size = len(lines[low])
+    while size < max_bytes and (low > start or high < end - 1):
+        if low > start:
+            low -= 1
+            size += len(lines[low]) + 1
+        if high < end - 1 and size < max_bytes:
+            high += 1
+            size += len(lines[high]) + 1
+    return low, high + 1
 
 
 def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
@@ -559,12 +716,37 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # Entry point filenames to boost
     entry_points = {'main', 'app', 'server', 'index', 'login', 'auth', '__init__'}
 
+    # A path the prompt named outright must be in the bundle. Without this it
+    # competed on generic filename overlap and lost: asked to fix a function in
+    # `src/neo/subcommands.py`, neo ranked that file 163rd of 296 — below its own
+    # test file — because filename hits cap at 3 and an 86KB file takes a large
+    # size penalty. It never reached the context, so the model correctly refused
+    # to write a patch for code it had not seen, and the suggestion was recorded
+    # with no diff text and could never be verified or learned from.
+    explicit_paths = extract_explicit_paths(config.prompt)
+
     # Score all candidates
     scored = []
+    explicit_hits = 0
     for abs_path, rel_path, size in candidates:
         score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points)
+        if matches_explicit_path(rel_path, explicit_paths):
+            score += EXPLICIT_PATH_BOOST
+            explicit_hits += 1
         if score > 0:
             scored.append((abs_path, rel_path, size, score))
+    if explicit_hits:
+        progress.note(
+            f"Prompt names {explicit_hits} file(s) explicitly - pinned to context")
+    elif explicit_paths:
+        # A named path that matched nothing is the single highest-value
+        # diagnostic here, and staying silent makes it indistinguishable from
+        # "no path mentioned". Causes: a typo, a path outside the scan root, or
+        # one filtered out by --exclude/--exts.
+        progress.note(
+            "Warning: prompt names a path but no scanned file matched "
+            f"({', '.join(sorted(explicit_paths)[:3])}) - check spelling, "
+            "--exclude and --exts")
 
     # Sort by score descending
     scored.sort(key=lambda x: x[3], reverse=True)

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1522,6 +1522,46 @@ class FactStore:
             logger.warning("Failed to record later regression: %s", exc)
             return None
 
+    @staticmethod
+    def _supporting_episodes_span_distinct_revisions(revisions: list[str]) -> bool:
+        """Do these supporting episodes come from at least two repo snapshots?
+
+        Distinct episode ids alone is too weak a test: every neo invocation mints
+        a fresh one, so ONE operator applying the SAME patch twice minutes apart
+        at the same HEAD already satisfied it. A live drill promoted a durable
+        PATTERN exactly that way, and the lesson it encoded was wrong — a
+        measured gap, not a hypothetical.
+
+        Fails closed when no revision is recorded. A session-id fallback was
+        tried and removed: `LearningEpisode.session_id` is a per-episode uuid4
+        that nothing ever assigns from a real session (121 episodes on a live
+        ledger, 121 distinct ids), so `>=2 distinct sessions` was the very gate
+        being replaced, wearing a different name. Worse, acceptance detection is
+        entirely git-based, so a genuinely non-git project can never record an
+        ACCEPTED outcome and could not reach the fallback anyway — the only way
+        in was a transient `rev-parse` failure, which made BOTH failing promote
+        while ONE failing blocked. Load-dependent non-determinism in the durable
+        memory path is worse than the permissiveness it came with.
+
+        Two honest limits, chosen deliberately rather than papered over:
+
+        * This tests "not the same repository snapshot", which is narrower than
+          independence. The revision is captured when the episode BEGINS — HEAD
+          when the advice was asked for, not the commit the fix landed in — so
+          committing between two attempts satisfies it even though committing
+          only shows that time passed. Keying on the acceptance-carrying sha
+          (already walked by `_get_changed_files_since`) would be strictly
+          better and is the obvious next move.
+        * It blocks a real flow: applying the same lesson across several files
+          in one sitting and committing once records ONE revision and promotes
+          nothing. 40% of revision-bearing episodes on a live ledger share a HEAD
+          with another, so this is the common shape, not an edge case. Accepted
+          because a delayed durable fact is recoverable and a wrong one needs a
+          contradiction to retract — the same fail-safe direction as the kind
+          gate.
+        """
+        return len({revision for revision in revisions if revision}) >= 2
+
     def _promote_repeatedly_supported_candidate(self, outcome) -> Optional[Fact]:
         """Promote only repeated, independently accepted ordinary patterns."""
         if outcome.candidate_kind != FactKind.PATTERN.value or not outcome.candidate_id:
@@ -1533,7 +1573,9 @@ class FactStore:
                 self.project_id or "unscoped", base_dir=self._episodes_dir
             )
             target_signature = self._episode_signature(outcome.candidate_subject)
-            supporting_ids: list[str] = []
+            # episode_id -> repository_revision. Keyed by episode so the
+            # independence evidence stays aligned with the deduped id list.
+            supporting: dict[str, str] = {}
             for episode in episode_store.list():
                 for candidate in episode.memory_candidates:
                     if candidate.kind != FactKind.PATTERN.value:
@@ -1542,11 +1584,17 @@ class FactStore:
                         continue
                     signature = self._episode_signature(candidate.subject)
                     if signature == target_signature:
-                        supporting_ids.append(episode.episode_id)
+                        supporting.setdefault(
+                            episode.episode_id, episode.repository_revision
+                        )
                         break
 
-            supporting_ids = list(dict.fromkeys(supporting_ids))
+            supporting_ids = list(supporting)
             if len(supporting_ids) < 2:
+                return None
+            if not self._supporting_episodes_span_distinct_revisions(
+                list(supporting.values())
+            ):
                 return None
 
             # Respect a prior rollback: if this signature was already rolled back

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -988,8 +988,14 @@ def _handle_learning_stats(args) -> None:
     buckets = _suggestion_verifiability()
     total_sugg = sum(buckets.values())
     verifiable = buckets["verifiable"]
+    # Verdicts are computed over what could actually be classified. Comparing an
+    # unmeasurable count against a content bucket mixes unlike quantities: it let
+    # a single dead root suppress STARVED entirely and print "most recorded
+    # suggestions" off a count of one.
+    unavailable = buckets["root_unavailable"]
+    measurable = total_sugg - unavailable
     if total_sugg:
-        print(f"  recorded suggestions (all time, all projects): {total_sugg}")
+        print(f"  recorded suggestions (latest session per project): {total_sugg}")
         print(f"    {'verifiable (real edit target)':<40} {verifiable:>5}"
               f"   {verifiable * 100 // total_sugg}%")
         print(f"    {'advisory (no edit target by design)':<40} "
@@ -997,6 +1003,9 @@ def _handle_learning_stats(args) -> None:
         print(f"    {'unattributable (looks real, unresolved)':<40} "
               f"{buckets['unattributable']:>5}   "
               f"{buckets['unattributable'] * 100 // total_sugg}%")
+        if unavailable:
+            print(f"    {'unmeasurable (recorded root unavailable)':<40} "
+                  f"{unavailable:>5}   {unavailable * 100 // total_sugg}%")
 
     if active:
         # Include demotions: `active` counts them, so omitting them here printed
@@ -1004,11 +1013,19 @@ def _handle_learning_stats(args) -> None:
         print(f"  => interactive loop is ACTIVE: {promotions} promoted, "
               f"{rollbacks} rolled back, {demotions} demoted, "
               f"{reinforcements} reinforced")
-    elif total_sugg and verifiable == 0:
+    elif total_sugg and measurable == 0:
+        # Checked before STARVED: "never measured" and "measured and empty" have
+        # opposite remedies. The predicate is exact — every recorded suggestion
+        # is unclassifiable — rather than a ratio against a content bucket.
+        print("  => interactive loop is UNMEASURABLE: every recorded suggestion "
+              "points at a codebase root that no longer exists, so acceptance "
+              "could never be detected. Usual cause is neo being run inside an "
+              "ephemeral worktree that was deleted before the attributing run.")
+    elif measurable and verifiable == 0:
         print("  => interactive loop is STARVED, not broken: no recorded "
               "suggestion could be git-verified, so no acceptance is detectable. "
               "Advisory/planning prompts produce pseudo-paths, not edit targets.")
-    elif total_sugg and buckets["unattributable"] > verifiable:
+    elif measurable and buckets["unattributable"] > verifiable:
         print("  => interactive loop is IDLE, and more suggestions were "
               "unattributable than verifiable — that skew is a bug signal, not a "
               "usage one. Check that paths resolve under the recorded root.")
@@ -1017,6 +1034,14 @@ def _handle_learning_stats(args) -> None:
               "promotion / reinforcement yet — suggestions aren't being accepted "
               "downstream. (Does NOT mean neo isn't learning: transcript mining "
               "mints facts on a separate path this doesn't count.)")
+    if unavailable:
+        # Every branch, ACTIVE included: measurement integrity is orthogonal to
+        # the verdict, so a partially-unmeasured corpus must qualify a healthy
+        # reading as much as an unhealthy one.
+        print(f"  note: {unavailable} of {total_sugg} recorded suggestion(s) could "
+              "not be classified because the recorded codebase root is gone; the "
+              "verdict above is computed over the remaining "
+              f"{measurable}.")
 
 
 # Extensions that mean "this suggestion was prose, not a code edit". A path that
@@ -1024,51 +1049,135 @@ def _handle_learning_stats(args) -> None:
 # attribution — the distinction the report exists to make.
 _ADVISORY_SUFFIXES = frozenset({".md", ".txt", ".rst", ".adoc"})
 
+# Extensions that make an unresolved path a real BUG SIGNAL rather than an
+# advisory answer. Deliberately an allowlist of code: the bucket's claim is "a
+# genuine code suggestion we failed to attribute", so only a path that could
+# plausibly BE code earns it. A missing entry (some new language) merely
+# under-reports into `advisory`, the same rot direction _ADVISORY_SUFFIXES
+# already has.
+#
+# Keyed on extension rather than on a leading slash. An earlier version treated
+# any unrelativizable "/foo/bar" as advisory, which buried two real defects: a
+# model-emitted placeholder segment ("/dotnet/src/<entitlements>/Store.cs") and
+# a genuine new module in a new directory ("/src/newpkg/handler.py") — both code,
+# both invisible to `suggestion_is_verifiable`, both exactly what this bucket
+# exists to surface. It also split "/review/x.json" from "review/x.json", which
+# mean the same thing to a human, on nothing but LM formatting.
+_SOURCE_SUFFIXES = frozenset({
+    ".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".cs", ".java", ".kt", ".go",
+    ".rb", ".rs", ".c", ".h", ".cc", ".cpp", ".hpp", ".m", ".mm", ".swift",
+    ".php", ".scala", ".sh", ".bash", ".zsh", ".sql", ".vue", ".svelte",
+    # Markup/config that is still an edit target. `.razor` is not speculative:
+    # it appears in the live suggestion corpus, so omitting it would have turned
+    # a real unresolved component path into "advisory".
+    ".razor", ".cshtml", ".xaml", ".html", ".scss", ".css", ".lua", ".dart",
+    ".ps1", ".proto", ".gradle", ".tf", ".toml", ".yaml", ".yml",
+})
+
 
 def _classify_suggestion(file_path: str, has_change_text: bool, root: str) -> str:
-    """One of "verifiable" | "advisory" | "unattributable".
+    """One of "verifiable" | "advisory" | "unattributable" | "root_unavailable".
 
     Reporting-only: deliberately does NOT reuse `OutcomeTracker._is_review_only_path`,
     which drives real weak-acceptance behavior and is narrow on purpose. Widening
-    it to make a stat look tidier would change what neo learns.
+    it to make a stat look tidier would change what neo learns. For the same
+    reason it does not touch `suggestion_is_verifiable`, whose bias toward
+    ADMITTING a doubtful path is deliberate (kind is frozen at mint, so
+    under-admitting there permanently kills a real lesson). Over-admitting in a
+    *report* costs nothing but an inaccurate number, so this is stricter.
+
+    Ordering rule: anything decidable from the arguments alone is decided BEFORE
+    the filesystem is consulted, so a dead root cannot change an answer that
+    never needed the disk. Only the empty-input test qualifies — every other
+    branch stats the disk, including the prose-suffix one, which must ask
+    whether the file exists (see below). An earlier version placed three
+    stat-ing branches above the root check on the theory that they were
+    string-decidable; they are not, and under a dead root all three degrade to
+    "does not exist" and silently return advisory. Measured: that reported 8 of
+    14 dead-root suggestions as unavailable and absorbed the other 6 into
+    advisory, so the integrity note under-counted by 43% and `measurable`
+    over-counted by the same 6.
     """
     from neo.memory.outcomes import normalize_suggestion_path, suggestion_is_verifiable
 
     if not file_path or not has_change_text:
         return "advisory"
-    # Sentinel check runs BEFORE the verifiable test: an all-caps, extension-less
-    # name that resolves to nothing ("NO_MODIFY", "NO_CODE_PLANNING_ONLY") passes
-    # the plausible-new-file rule at repo root, but it is the model saying "no
-    # code change here". Requiring ALL-CAPS keeps real extension-less files
-    # (Makefile, Dockerfile) out of this bucket.
+
+    # Everything below needs the live filesystem, so a root that no longer exists
+    # makes all of it meaningless — the path was very likely resolvable when the
+    # suggestion was recorded. With the tree gone we genuinely cannot tell an
+    # edit to an existing README from an invented one, and saying so is more
+    # honest than guessing advisory.
+    # NOTE the check is one-sided: a root that exists today may be a re-clone or
+    # a reused temp path, so this detects definite invalidity and never certifies
+    # validity.
+    if not root or not Path(root).is_dir():
+        return "root_unavailable"
+
+    suffix = Path(file_path).suffix.lower()
+    # Sentinel: an all-caps, extension-less name that resolves to nothing
+    # ("NO_MODIFY", "NO_CODE_PLANNING_ONLY") passes the plausible-new-file rule
+    # at repo root, but it is the model saying "no code change here". Requiring
+    # ALL-CAPS keeps real extension-less files (Makefile, Dockerfile) out.
     stem = Path(file_path).name
-    if (not Path(file_path).suffix and stem
-            and stem.replace("_", "").isupper()
+    if (not suffix and stem and stem.replace("_", "").isupper()
             and not (Path(root) / normalize_suggestion_path(file_path, root)).is_file()):
         return "advisory"
-    if suggestion_is_verifiable(file_path, has_change_text, root):
-        return "verifiable"
+    # Prose suffix that names no existing file. This runs BEFORE the verifiable
+    # test on purpose: a bare-slash doc at repo root ("/ARCHITECTURAL_REVIEW.md")
+    # normalizes to a name whose parent IS the root, so the plausible-new-file
+    # rule inside `suggestion_is_verifiable` grants it "verifiable". Measured: 11
+    # of 21 supposedly verifiable suggestions were review prose that does not
+    # exist on disk, which made the headline number — and every threshold below
+    # it — wrong. Editing a real README.md still counts; inventing one does not.
+    if suffix in _ADVISORY_SUFFIXES and not _resolves_to_file(file_path, root):
+        return "advisory"
     normalized = normalize_suggestion_path(file_path, root)
     if normalized.startswith("docs/") or "/docs/" in normalized:
         return "advisory"
-    suffix = Path(file_path).suffix.lower()
-    if suffix in _ADVISORY_SUFFIXES:
-        # A doc-shaped or extension-less path that resolves to nothing is the
-        # model saying "no code change here" (/REVIEW_ONLY/..., NO_MODIFY,
-        # /planning/critique.md), not an edit we failed to find.
+
+    if suggestion_is_verifiable(file_path, has_change_text, root):
+        return "verifiable"
+    # Unresolved and not code-shaped: an advisory answer's invented path
+    # ("/review/wave2_residual_bugs.json", "/dev/null"), not an edit we failed to
+    # find. Code-shaped paths fall through to "unattributable" so genuine
+    # defects stay visible there.
+    if suffix not in _SOURCE_SUFFIXES:
         return "advisory"
     return "unattributable"
+
+
+def _resolves_to_file(file_path: str, root: str) -> bool:
+    """Does this suggestion path name a file that exists right now?"""
+    from neo.memory.outcomes import normalize_suggestion_path
+
+    try:
+        normalized = normalize_suggestion_path(file_path, root)
+        path = Path(normalized)
+        if not path.is_absolute():
+            if not root:
+                return False
+            path = Path(root) / normalized
+        return path.is_file()
+    except (OSError, ValueError):
+        return False
 
 
 def _suggestion_verifiability() -> dict[str, int]:
     """Bucket recorded session suggestions by whether learning could ever attach.
 
-    Three outcomes, because collapsing them makes the number unactionable: a
-    prompt that legitimately had no edit target is a usage property, while a real
-    code suggestion we failed to attribute is a bug worth chasing.
+    Four outcomes, because collapsing them makes the number unactionable: a
+    prompt that legitimately had no edit target is a usage property, a real code
+    suggestion we failed to attribute is a bug worth chasing, and a suggestion
+    whose recorded root is gone is neither — it is simply unmeasurable.
+
+    Known limit: `session_<project_id>.json` is OVERWRITTEN on each save, so this
+    reads the most recent session per project, not full history.
     """
     sessions_dir = Path.home() / ".neo" / "sessions"
-    counts = {"verifiable": 0, "advisory": 0, "unattributable": 0}
+    counts = {
+        "verifiable": 0, "advisory": 0, "unattributable": 0, "root_unavailable": 0,
+    }
     try:
         session_files = sorted(sessions_dir.glob("session_*.json"))
     except OSError:

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -102,3 +102,214 @@ class TestLargeFilePenalty:
             "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY
         )
         assert big > non_main_big
+
+
+class TestExplicitPathPinning:
+    """A path the prompt names outright must reach the context bundle.
+
+    Regression: asked to fix a named function in `src/neo/subcommands.py`, neo
+    ranked that file 163rd of 296 candidates (score 0.838) while an unrelated
+    file ranked 1st — filename-token overlap caps at 3 hits and an 86KB file
+    takes a large size penalty. The file never entered the context, the model
+    answered that the function body was not provided and emitted no patch, and a
+    suggestion carrying no diff text can never be git-verified or learned from.
+    """
+
+    def test_named_path_outranks_an_organically_strong_file(self):
+        from neo.context_gatherer import (
+            EXPLICIT_PATH_BOOST, extract_explicit_paths, matches_explicit_path,
+        )
+        explicit = extract_explicit_paths(
+            "Fix _classify_suggestion in src/neo/subcommands.py please")
+        assert matches_explicit_path("src/neo/subcommands.py", explicit)
+        # The boost must exceed every organic signal combined: filename overlap
+        # caps at +1.8, the two re-rank boosts at +1.0 and +1.2.
+        assert EXPLICIT_PATH_BOOST > 1.8 + 1.0 + 1.2
+
+    def test_bare_filename_matches_but_a_neighbour_does_not(self):
+        from neo.context_gatherer import extract_explicit_paths, matches_explicit_path
+        explicit = extract_explicit_paths("look at subcommands.py")
+        assert matches_explicit_path("src/neo/subcommands.py", explicit)
+        # Matching the test file would re-bury the named file under its own
+        # neighbours, which is the failure this exists to fix.
+        assert not matches_explicit_path("tests/test_subcommands.py", explicit)
+
+    def test_prose_and_versions_are_not_paths(self):
+        from neo.context_gatherer import matches_explicit_path, extract_explicit_paths
+        explicit = extract_explicit_paths(
+            "Upgrade to 0.42.0, e.g. the parser, cf. the docs")
+        # Junk tokens may be extracted, but nothing real can match them.
+        for path in ("src/neo/engine.py", "README.md", "pyproject.toml"):
+            assert not matches_explicit_path(path, explicit)
+
+    def test_empty_prompt_pins_nothing(self):
+        from neo.context_gatherer import extract_explicit_paths, matches_explicit_path
+        assert extract_explicit_paths("") == set()
+        assert not matches_explicit_path("src/neo/engine.py", set())
+
+
+class TestSelectChunksRelevance:
+    """`select_chunks` used to take the first five matching lines in FILE ORDER.
+
+    Matching is a substring test and `extract_prompt_tokens` emits every 3+
+    character word, so "in" matched `int`/`using`/`point` and virtually every
+    line qualified. "First five matches" therefore meant "lines 1-5" for any
+    prompt against any large file — the module docstring and imports — emitted
+    as two overlapping near-duplicate windows that consumed both slots of the
+    per-file cap.
+    """
+
+    @staticmethod
+    def _big_file(target_line: str, target_at: int = 500, total: int = 900) -> str:
+        lines = ["import os", "import sys", '"""Module docstring."""']
+        lines += [f"    value_{i} = compute(i)  # padding using a point" for i in range(total)]
+        lines[target_at] = target_line
+        return "\n".join(lines)
+
+    def test_window_centers_on_the_named_symbol_with_a_realistic_token_set(self):
+        """Uses the REAL tokenizer rather than a hand-picked clean set. That
+        distinction is the whole bug: with only discriminative tokens the old
+        file-order code also found the symbol, so a clean set proves nothing.
+        `extract_prompt_tokens` always emits the short words too."""
+        from neo.context_gatherer import extract_prompt_tokens, select_chunks
+        content = self._big_file("def _classify_suggestion(file_path, root):")
+        tokens = extract_prompt_tokens(
+            "Fix the bug in _classify_suggestion in src/neo/subcommands.py")
+        assert "in" in tokens, "tokenizer no longer emits short noise words"
+        chunks = select_chunks(content, tokens)
+        assert chunks, "expected at least one window"
+        top, start, _end = chunks[0]
+        assert "def _classify_suggestion" in top
+        assert start > 100, f"window started at {start} — that is the file header again"
+
+    def test_short_noise_tokens_do_not_drag_windows_to_the_header(self):
+        from neo.context_gatherer import select_chunks
+        content = self._big_file("def target_function(arg):")
+        # "in"/"is"/"py" are the tokens that matched nearly every line before.
+        chunks = select_chunks(content, {"in", "is", "py", "target_function"})
+        assert "def target_function" in chunks[0][0]
+
+    def test_overlapping_windows_are_merged(self):
+        from neo.context_gatherer import select_chunks
+        # Must exceed max_chunk_bytes (12_000) or the whole file comes back as a
+        # single chunk and the assertion below is vacuous.
+        lines = [f"line {i} filler padding to grow the file" for i in range(1200)]
+        lines[300] = "needle alpha here"
+        lines[303] = "needle alpha again"
+        content = "\n".join(lines)
+        assert len(content) > 12_000, "fixture too small to exercise chunking"
+        chunks = select_chunks(content, {"needle", "alpha"})
+        ranges = [(s, e) for _c, s, e in chunks]
+        assert len(ranges) == 1, f"centers 3 lines apart must merge, got {ranges}"
+        # And two centers far apart must NOT merge.
+        lines[900] = "needle alpha distant"
+        far = select_chunks("\n".join(lines), {"needle", "alpha"})
+        far_ranges = sorted((s, e) for _c, s, e in far)
+        assert len(far_ranges) == 2
+        for i, (s1, e1) in enumerate(far_ranges):
+            for s2, e2 in far_ranges[i + 1:]:
+                assert e1 < s2 or e2 < s1, f"overlapping windows {(s1,e1)} {(s2,e2)}"
+
+    def test_small_file_returned_whole(self):
+        from neo.context_gatherer import select_chunks
+        content = "def f():\n    return 1\n"
+        assert select_chunks(content, {"anything"}) == [(content, 1, 2)]
+
+    def test_no_match_falls_back_to_the_header(self):
+        from neo.context_gatherer import select_chunks
+        content = "\n".join(f"line {i}" for i in range(2000))
+        chunks = select_chunks(content, {"zzzznomatchzzzz"})
+        assert len(chunks) == 1 and chunks[0][1] == 1
+
+
+class TestExplicitPathSpellings:
+    """Absolute paths are the highest-value input and were silently unmatched:
+    `str.strip("./")` strips a character SET from both ends, so a leading "/"
+    was eaten, and containment was tested in one direction only. Tracebacks,
+    IDE copy-path and neo's own suggestion output all emit absolute paths."""
+
+    @staticmethod
+    def _explicit(text):
+        from neo.context_gatherer import extract_explicit_paths
+        return extract_explicit_paths(text)
+
+    def test_absolute_path_matches_repo_relative_candidate(self):
+        from neo.context_gatherer import matches_explicit_path
+        explicit = self._explicit(
+            "fix the bug in /Users/me/repo/src/neo/subcommands.py now")
+        assert matches_explicit_path("src/neo/subcommands.py", explicit)
+
+    def test_windows_spelling_normalizes(self):
+        from neo.context_gatherer import matches_explicit_path
+        explicit = self._explicit(r"look at src\neo\subcommands.py")
+        assert matches_explicit_path("src/neo/subcommands.py", explicit)
+
+    def test_neighbour_still_excluded_under_both_directions(self):
+        from neo.context_gatherer import matches_explicit_path
+        for text in ("see subcommands.py",
+                     "see /Users/me/repo/src/neo/subcommands.py"):
+            assert not matches_explicit_path("tests/test_subcommands.py",
+                                             self._explicit(text))
+
+    def test_empty_rel_path_never_matches(self):
+        from neo.context_gatherer import matches_explicit_path
+        assert not matches_explicit_path("", self._explicit("src/neo/x.py"))
+
+
+class TestSelectChunksBudget:
+    def test_chain_merge_cannot_blow_the_byte_cap(self):
+        """Unbounded merging chained ~20 centers into one window measured at
+        8.3x max_chunk_bytes. The caller admits a chunk all-or-nothing, so an
+        oversized chunk that no longer fits the global budget is DROPPED and the
+        named file contributes nothing — the original bug, new door."""
+        from neo.context_gatherer import select_chunks
+        lines = ["x" * 55 for _ in range(2000)]
+        for i in range(0, 1600, 75):
+            lines[i] = "needle_token_here alpha"
+        chunks = select_chunks("\n".join(lines), {"needle_token_here", "alpha"})
+        assert chunks
+        for chunk, _s, _e in chunks:
+            assert len(chunk) <= 12_000, f"chunk of {len(chunk)} exceeds the cap"
+
+    def test_truncation_keeps_the_line_that_earned_the_window(self):
+        from neo.context_gatherer import select_chunks
+        lines = ["y" * 80 for _ in range(600)]
+        lines[300] = "the_unique_target_symbol lives here"
+        chunks = select_chunks("\n".join(lines), {"the_unique_target_symbol"})
+        assert "the_unique_target_symbol" in chunks[0][0]
+
+    def test_emitted_ranges_are_one_based_and_round_trip(self):
+        from neo.context_gatherer import select_chunks
+        lines = [f"line {i} padding text to grow the file" for i in range(1500)]
+        lines[400] = "alpha_needle one"
+        lines[1100] = "alpha_needle two"
+        content = "\n".join(lines)
+        for chunk, start, end in select_chunks(content, {"alpha_needle"}):
+            assert "\n".join(lines[start - 1:end]) == chunk
+
+    def test_header_does_not_win_when_a_better_region_exists(self):
+        """Direct regression for the original defect: keyword-bearing module
+        docstring must not beat the function body."""
+        from neo.context_gatherer import extract_prompt_tokens, select_chunks
+        lines = ['"""Handlers for CLI subcommands and classification."""']
+        lines += [f"    filler_{i} = compute(i) using a point in time" for i in range(900)]
+        lines[500] = "def _classify_suggestion(file_path, root):"
+        chunks = select_chunks("\n".join(lines), extract_prompt_tokens(
+            "fix _classify_suggestion in src/neo/subcommands.py"))
+        assert "def _classify_suggestion" in chunks[0][0]
+        assert chunks[0][1] > 100
+
+    def test_single_match_at_each_boundary_clamps(self):
+        from neo.context_gatherer import select_chunks
+        for at in (0, 1499):
+            lines = [f"line {i} padding text to grow the file" for i in range(1500)]
+            lines[at] = "edge_needle here"
+            chunks = select_chunks("\n".join(lines), {"edge_needle"})
+            assert chunks and "edge_needle" in chunks[0][0]
+            assert chunks[0][1] >= 1 and chunks[0][2] <= 1500
+
+    def test_empty_token_set_falls_back_to_header(self):
+        from neo.context_gatherer import select_chunks
+        content = "\n".join(f"line {i} padding" for i in range(2000))
+        chunks = select_chunks(content, set())
+        assert len(chunks) == 1 and chunks[0][1] == 1

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -1001,7 +1001,8 @@ class TestOutcomeLinkage:
             MemoryCandidateEvidence,
         )
 
-        episode = LearningEpisode(episode_id="ep-one", project_id=store.project_id)
+        episode = LearningEpisode(episode_id="ep-one", project_id=store.project_id,
+                                  repository_revision="rev-ep-one")
         episode.memory_candidates.append(MemoryCandidateEvidence(
             candidate_id="candidate-one",
             suggestion_id="suggestion-one",
@@ -1042,7 +1043,8 @@ class TestOutcomeLinkage:
             episode_id = f"ep-{suffix}"
             candidate_id = f"candidate-{suffix}"
             suggestion_id = f"suggestion-{suffix}"
-            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{episode_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=candidate_id,
                 suggestion_id=suggestion_id,
@@ -1075,15 +1077,25 @@ class TestOutcomeLinkage:
         assert "durable" in promoted[0].tags
         assert "probation" not in promoted[0].tags
 
-    def _accept_episode(self, store, ep_id, subject, body, kind="pattern"):
+    def _accept_episode(self, store, ep_id, subject, body, kind="pattern",
+                        revision=None):
         """Record one ACCEPTED outcome for a fresh episode (drives the real
-        detect_implicit_feedback promotion path)."""
+        detect_implicit_feedback promotion path).
+
+        `revision` defaults to a value unique per episode — the ordinary shape,
+        where each acceptance is observed at its own HEAD. Tests exercising the
+        promotion independence gate pass it explicitly (a shared value, or ""
+        for the blank a repo-less or failed `rev-parse` produces).
+        """
+        if revision is None:
+            revision = f"rev-{ep_id}"
         from neo.memory.episodes import (
             LearningEpisode, LearningEpisodeStore, MemoryCandidateEvidence,
         )
         episode_store = LearningEpisodeStore(store.project_id)
         cand_id = f"{ep_id}-cand"
-        episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+        episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                  repository_revision=revision)
         episode.memory_candidates.append(MemoryCandidateEvidence(
             candidate_id=cand_id, suggestion_id=f"{ep_id}-sug",
             subject=subject, body=body, kind=kind,
@@ -1119,6 +1131,81 @@ class TestOutcomeLinkage:
         # fingerprint survives in the frozen correlation signature.
         assert "[fp:" not in promoted[0].subject
         assert promoted[0].canonical_signature.endswith("deadbeef1234")
+
+    def test_same_revision_acceptances_do_not_promote(self, store):
+        """The drill regression. Two acceptances at the SAME HEAD are one
+        operator applying one patch twice, not a lesson that recurred — distinct
+        episode ids alone let that mint a durable PATTERN whose content was
+        wrong. Promotion claims recurrence, so it must span two revisions."""
+        subject = "bugfix: narrow the stderr handler [progress.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "same-rev-0", subject, "Reasoning: catch OSError.",
+                             revision="d83659cea51676124f2488f6629e0957302e1c1f")
+        self._accept_episode(store, "same-rev-1", subject, "Reasoning: catch OSError.",
+                             revision="d83659cea51676124f2488f6629e0957302e1c1f")
+
+        assert [f for f in store.entries if "episode-derived" in f.tags] == []
+        from neo.memory.episodes import LearningEpisodeStore
+        es = LearningEpisodeStore(store.project_id)
+        # Not rejected — still supported_once, so a later acceptance at a NEW
+        # revision promotes it. Under-promotion delays; it does not discard.
+        assert es.load("same-rev-1").memory_candidates[0].status == "supported_once"
+
+    def test_distinct_revision_acceptances_promote(self, store):
+        """The same lesson accepted at two different points in the repo's history
+        IS recurrence — that must still promote, or the gate has killed learning
+        rather than tightened it."""
+        subject = "bugfix: narrow the stderr handler [progress.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "diff-rev-0", subject, "Reasoning: catch OSError.",
+                             revision="1111111111111111111111111111111111111111")
+        self._accept_episode(store, "diff-rev-1", subject, "Reasoning: catch OSError.",
+                             revision="2222222222222222222222222222222222222222")
+
+        promoted = [f for f in store.entries if "episode-derived" in f.tags]
+        assert len(promoted) == 1
+        assert "durable" in promoted[0].tags
+
+    def test_missing_revisions_fail_closed(self, store):
+        """No revision recorded is no independence evidence. There is
+        deliberately no session-id fallback: `session_id` is a per-episode uuid4
+        that nothing assigns from a real session, so falling back to "distinct
+        sessions" would have restored the exact gate being replaced. The
+        reachable cause of a blank revision is a transient `rev-parse` failure,
+        and promoting on that made a flaky subprocess decide whether a durable
+        fact got minted."""
+        subject = "bugfix: guard the parse [parser.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "norev-0", subject, "Reasoning: guard it.",
+                             revision="")
+        self._accept_episode(store, "norev-1", subject, "Reasoning: guard it.",
+                             revision="")
+
+        assert [f for f in store.entries if "episode-derived" in f.tags] == []
+
+    def test_mixed_revision_evidence_fails_closed(self, store):
+        """One episode with a revision and one without is not two revisions.
+        Fail closed: a delayed durable fact is recoverable, a wrong one is not."""
+        subject = "bugfix: guard the parse [parser.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "mixed-0", subject, "Reasoning: guard it.",
+                             revision="1111111111111111111111111111111111111111")
+        self._accept_episode(store, "mixed-1", subject, "Reasoning: guard it.",
+                             revision="")
+
+        assert [f for f in store.entries if "episode-derived" in f.tags] == []
+
+    def test_promotion_is_not_decided_by_a_flaky_rev_parse(self, store):
+        """Regression for the inverted incentive the session fallback created:
+        two blank revisions must not be MORE permissive than one blank and one
+        present. Both shapes block; neither promotes."""
+        base = "bugfix: guard the parse [parser.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "flaky-0", base, "R.", revision="")
+        self._accept_episode(store, "flaky-1", base, "R.", revision="")
+        both_blank = [f for f in store.entries if "episode-derived" in f.tags]
+
+        other = "bugfix: widen the guard [parser.py] [fp:cafebabe5678]"
+        self._accept_episode(store, "flaky-2", other, "R.", revision="")
+        self._accept_episode(store, "flaky-3", other, "R.", revision="aaa111")
+        one_blank = [f for f in store.entries if "episode-derived" in f.tags]
+
+        assert both_blank == [] and one_blank == []
 
     def test_divergent_fingerprint_blocks_false_promotion(self, store):
         """Two accepted episodes sharing a task/prompt prefix but proposing
@@ -1157,7 +1244,8 @@ class TestOutcomeLinkage:
             episode_id = f"rollback-{index}"
             candidate_id = f"rollback-candidate-{index}"
             suggestion_id = f"rollback-suggestion-{index}"
-            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{episode_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=candidate_id,
                 suggestion_id=suggestion_id,
@@ -1234,7 +1322,8 @@ class TestOutcomeLinkage:
         for index in range(2):
             ep_id = f"{prefix}-{index}"
             cand_id = f"{prefix}-cand-{index}"
-            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{ep_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=cand_id, suggestion_id=f"{prefix}-sug-{index}",
                 subject=subject, body=body, kind="pattern",
@@ -1294,7 +1383,8 @@ class TestOutcomeLinkage:
         for index in range(2):
             ep_id = f"correct-{index}"
             cand_id = f"correct-cand-{index}"
-            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{ep_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=cand_id, suggestion_id=f"correct-sug-{index}",
                 subject=subject, body=body, kind="pattern",
@@ -1335,7 +1425,8 @@ class TestOutcomeLinkage:
         episode_store = LearningEpisodeStore(store.project_id)
         for index in range(2):
             ep_id = f"kill-{index}"
-            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{ep_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=f"kill-cand-{index}", suggestion_id=f"kill-sug-{index}",
                 subject=subject, body=body, kind="pattern",
@@ -1373,7 +1464,8 @@ class TestOutcomeLinkage:
         episode_store = LearningEpisodeStore(store.project_id)
         for index in range(2):
             ep_id = f"kill-{index}"
-            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{ep_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=f"kill-cand-{index}", suggestion_id=f"kill-sug-{index}",
                 subject=subject, body=body, kind="pattern",
@@ -1501,7 +1593,8 @@ class TestOutcomeLinkage:
             LearningEpisode, LearningEpisodeStore, MemoryCandidateEvidence,
         )
         episode_store = LearningEpisodeStore(store.project_id)
-        ep = LearningEpisode(episode_id="solo", project_id=store.project_id)
+        ep = LearningEpisode(episode_id="solo", project_id=store.project_id,
+                             repository_revision="rev-solo")
         ep.memory_candidates.append(MemoryCandidateEvidence(
             candidate_id="solo-cand", suggestion_id="solo-sug",
             subject="pattern: cache results [src/a.py]", body="memoize the call",
@@ -1533,7 +1626,8 @@ class TestOutcomeLinkage:
 
         def _accept(idx):
             ep_id, cand_id, sug_id = f"g{idx}", f"g{idx}c", f"g{idx}s"
-            ep = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+            ep = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{ep_id}")
             ep.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=cand_id, suggestion_id=sug_id,
                 subject=subject, body=body, kind="pattern"))
@@ -1572,7 +1666,8 @@ class TestOutcomeLinkage:
             episode_id = f"regression-{index}"
             suggestion_id = f"regression-suggestion-{index}"
             candidate_id = f"regression-candidate-{index}"
-            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{episode_id}")
             episode.suggestions.append(SuggestionEvidence(
                 suggestion_id=suggestion_id,
                 description="validate input before processing",
@@ -1645,7 +1740,8 @@ class TestOutcomeLinkage:
         for index in range(2):
             episode_id = f"failed-{index}"
             candidate_id = f"failed-candidate-{index}"
-            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{episode_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=candidate_id,
                 suggestion_id=f"failed-suggestion-{index}",
@@ -1695,7 +1791,8 @@ class TestOutcomeLinkage:
         for index in range(3):
             episode_id = f"arch-{index}"
             candidate_id = f"arch-candidate-{index}"
-            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id)
+            episode = LearningEpisode(episode_id=episode_id, project_id=store.project_id,
+                                      repository_revision=f"rev-{episode_id}")
             episode.memory_candidates.append(MemoryCandidateEvidence(
                 candidate_id=candidate_id,
                 suggestion_id=f"arch-suggestion-{index}",
@@ -1741,7 +1838,8 @@ class TestOutcomeLinkage:
             es = LearningEpisodeStore(st.project_id, base_dir=episodes_dir)
             for i in range(n_accepts):
                 ep_id, cid, sid = f"{name}-{i}", f"{name}-c-{i}", f"{name}-s-{i}"
-                ep = LearningEpisode(episode_id=ep_id, project_id=st.project_id)
+                ep = LearningEpisode(episode_id=ep_id, project_id=st.project_id,
+                                    repository_revision=f"rev-{ep_id}")
                 ep.memory_candidates.append(MemoryCandidateEvidence(
                     candidate_id=cid, suggestion_id=sid,
                     subject=subject, body=body, kind="pattern"))
@@ -1809,7 +1907,8 @@ class TestOutcomeLinkage:
         def _feed(st, prefix, n, otype):
             es = LearningEpisodeStore(st.project_id, base_dir=episodes_dir)
             for i in range(n):
-                ep = LearningEpisode(episode_id=f"{prefix}-{i}", project_id=st.project_id)
+                ep = LearningEpisode(episode_id=f"{prefix}-{i}", project_id=st.project_id,
+                                    repository_revision=f"rev-{prefix}-{i}")
                 ep.memory_candidates.append(MemoryCandidateEvidence(
                     candidate_id=f"{prefix}c{i}", suggestion_id=f"{prefix}s{i}",
                     subject=subject, body=body, kind="pattern"))
@@ -1861,7 +1960,8 @@ class TestOutcomeLinkage:
         def _feed(st, prefix, n, otype):
             es = LearningEpisodeStore(st.project_id, base_dir=episodes_dir)
             for i in range(n):
-                ep = LearningEpisode(episode_id=f"{prefix}-{i}", project_id=st.project_id)
+                ep = LearningEpisode(episode_id=f"{prefix}-{i}", project_id=st.project_id,
+                                    repository_revision=f"rev-{prefix}-{i}")
                 ep.memory_candidates.append(MemoryCandidateEvidence(
                     candidate_id=f"{prefix}c{i}", suggestion_id=f"{prefix}s{i}",
                     subject=subject, body=body, kind="pattern"))
@@ -1927,6 +2027,7 @@ class TestOutcomeLinkage:
                 episode = LearningEpisode(
                     episode_id=episode_id,
                     project_id=project_store.project_id,
+                    repository_revision=f"rev-{episode_id}",
                 )
                 episode.memory_candidates.append(MemoryCandidateEvidence(
                     candidate_id=candidate_id,
@@ -2018,7 +2119,8 @@ class TestOutcomeLinkage:
             for index in range(2):
                 ep_id = f"{project}-{index}"
                 cand_id = f"cand-{project}-{index}"
-                episode = LearningEpisode(episode_id=ep_id, project_id=project_store.project_id)
+                episode = LearningEpisode(episode_id=ep_id, project_id=project_store.project_id,
+                                          repository_revision=f"rev-{ep_id}")
                 episode.memory_candidates.append(MemoryCandidateEvidence(
                     candidate_id=cand_id, suggestion_id=f"sug-{project}-{index}",
                     subject=subject, body=body, kind="pattern",

--- a/tests/test_reconcile_teardown_aging.py
+++ b/tests/test_reconcile_teardown_aging.py
@@ -38,7 +38,11 @@ def _feed(store, episodes_dir, prefix, n, otype):
     es = LearningEpisodeStore(store.project_id, base_dir=episodes_dir)
     for i in range(n):
         ep_id, cid, sid = f"{prefix}-{i}", f"{prefix}c{i}", f"{prefix}s{i}"
-        ep = LearningEpisode(episode_id=ep_id, project_id=store.project_id)
+        # Distinct revision per episode: the ordinary shape, where each
+        # acceptance is observed at its own HEAD. Promotion requires the
+        # supporting episodes to span two snapshots.
+        ep = LearningEpisode(episode_id=ep_id, project_id=store.project_id,
+                             repository_revision=f"rev-{ep_id}")
         ep.memory_candidates.append(MemoryCandidateEvidence(
             candidate_id=cid, suggestion_id=sid,
             subject=SUBJECT, body=BODY, kind="pattern"))

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -177,10 +177,10 @@ def test_learning_stats_idle_when_no_promotions(capsys):
     assert out["interactive_loop_active"] is False
 
 
-def test_learning_stats_buckets_suggestions_three_ways(tmp_path, monkeypatch):
+def test_learning_stats_buckets_suggestions_four_ways(tmp_path, monkeypatch):
     """Collapsing these makes the number unactionable: a prompt that legitimately
     had no edit target is a usage property, a real code suggestion we failed to
-    attribute is a bug."""
+    attribute is a bug, and a vanished root is neither."""
     import json as _json
 
     from neo import subcommands
@@ -204,7 +204,7 @@ def test_learning_stats_buckets_suggestions_three_ways(tmp_path, monkeypatch):
     }))
     monkeypatch.setattr(subcommands.Path, "home", staticmethod(lambda: tmp_path))
     assert subcommands._suggestion_verifiability() == {
-        "verifiable": 1, "advisory": 4, "unattributable": 1,
+        "verifiable": 1, "advisory": 4, "unattributable": 1, "root_unavailable": 0,
     }
 
 
@@ -222,8 +222,163 @@ def test_learning_stats_verifiability_handles_missing_sessions(tmp_path, monkeyp
     from neo import subcommands
     monkeypatch.setattr(subcommands.Path, "home", staticmethod(lambda: tmp_path))
     assert subcommands._suggestion_verifiability() == {
-        "verifiable": 0, "advisory": 0, "unattributable": 0,
+        "verifiable": 0, "advisory": 0, "unattributable": 0, "root_unavailable": 0,
     }
+
+
+def test_vanished_root_is_unmeasurable_not_unattributable(tmp_path):
+    """Once a test needs the LIVE filesystem, a root that no longer exists makes
+    it meaningless. Measured: 8 of 10 "unattributable" suggestions were this — 7
+    from deleted Claude Code agent worktrees — burying the signal the bucket
+    exists to carry."""
+    from neo import subcommands
+    gone = str(tmp_path / "deleted-worktree")
+    assert subcommands._classify_suggestion(
+        "api/Svc.cs", True, gone) == "root_unavailable"
+    assert subcommands._classify_suggestion(
+        "/api/Svc.cs", True, gone) == "root_unavailable"
+    # No root recorded at all is equally unmeasurable, not advisory.
+    assert subcommands._classify_suggestion(
+        "api/Svc.cs", True, "") == "root_unavailable"
+    # A root that DOES exist still classifies normally.
+    assert subcommands._classify_suggestion(
+        "api/Svc.cs", True, str(tmp_path)) == "unattributable"
+
+
+def test_a_dead_root_makes_every_filesystem_answer_unavailable(tmp_path):
+    """Only the empty-input test is decidable without the disk. The prose-suffix,
+    sentinel and docs/ branches all stat, and under a dead root each degrades to
+    "does not exist" and would silently return advisory — under-counting the
+    integrity signal (measured 8 reported against 14 real) and inflating
+    `measurable` by the difference."""
+    from neo import subcommands
+    gone = str(tmp_path / "deleted-worktree")
+    # Decidable from the arguments alone: still advisory.
+    assert subcommands._classify_suggestion("", False, gone) == "advisory"
+    # Everything else is unknowable once the tree is gone. We cannot tell an
+    # edit to an existing README from an invented one.
+    assert subcommands._classify_suggestion("plan.md", True, gone) == "root_unavailable"
+    assert subcommands._classify_suggestion("NO_MODIFY", True, gone) == "root_unavailable"
+    assert subcommands._classify_suggestion("docs/x.py", True, gone) == "root_unavailable"
+    assert subcommands._classify_suggestion("README.md", True, gone) == "root_unavailable"
+
+
+def test_invented_non_code_path_is_advisory(tmp_path):
+    """An unresolved path that could not be code is an advisory answer's invented
+    target, not an edit we failed to find."""
+    from neo import subcommands
+    assert subcommands._classify_suggestion(
+        "/review/wave2_residual_bugs.json", True, str(tmp_path)) == "advisory"
+    # Same meaning without the leading slash -> same bucket. An earlier version
+    # keyed on the slash and split these on nothing but LM formatting.
+    assert subcommands._classify_suggestion(
+        "review/wave2_residual_bugs.json", True, str(tmp_path)) == "advisory"
+
+
+def test_unresolved_code_paths_stay_a_bug_signal(tmp_path):
+    """The cases a leading-slash rule wrongly buried. Both are code, both are
+    invisible to suggestion_is_verifiable, and both are exactly what the
+    unattributable bucket exists to surface."""
+    from neo import subcommands
+    # Model emitted an unexpanded placeholder segment.
+    assert subcommands._classify_suggestion(
+        "/dotnet/src/<entitlements>/Store.cs", True, str(tmp_path)) == "unattributable"
+    # Genuine new module in a directory that does not exist yet.
+    assert subcommands._classify_suggestion(
+        "/src/newpkg/handler.py", True, str(tmp_path)) == "unattributable"
+    assert subcommands._classify_suggestion(
+        "src/newpkg/handler.py", True, str(tmp_path)) == "unattributable"
+
+
+def test_invented_review_prose_is_not_counted_verifiable(tmp_path):
+    """A bare-slash doc at repo root normalizes to a name whose parent IS the
+    root, so `suggestion_is_verifiable`'s plausible-new-file rule granted it
+    "verifiable". Measured: 11 of 21 supposedly verifiable suggestions were
+    review prose that does not exist, making the headline number wrong."""
+    from neo import subcommands
+    assert subcommands._classify_suggestion(
+        "/ARCHITECTURAL_REVIEW.md", True, str(tmp_path)) == "advisory"
+    assert subcommands._classify_suggestion(
+        "REVIEW_TASK_1.md", True, str(tmp_path)) == "advisory"
+    # But EDITING a doc that really exists is still a real edit target.
+    (tmp_path / "README.md").write_text("hi")
+    assert subcommands._classify_suggestion(
+        "README.md", True, str(tmp_path)) == "verifiable"
+
+
+def test_real_new_file_in_existing_dir_stays_verifiable(tmp_path):
+    """Proposing a new file inside a directory that exists is a real suggestion
+    and shows up in git log once committed."""
+    from neo import subcommands
+    (tmp_path / "config").mkdir()
+    assert subcommands._classify_suggestion(
+        "config/settings.json", True, str(tmp_path)) == "verifiable"
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("x = 1")
+    assert subcommands._classify_suggestion(
+        "/src/app.py", True, str(tmp_path)) == "verifiable"
+
+
+def _write_session(name: str, root: str, paths: list[str]) -> None:
+    import json as _json
+    from pathlib import Path as _Path
+    sessions = _Path.home() / ".neo" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / f"session_{name}.json").write_text(_json.dumps({
+        "codebase_root": root,
+        "suggestions": [{"file_path": p, "suggested_code": "x"} for p in paths],
+    }))
+
+
+def _record_idle_episode() -> None:
+    """The bucket report is only reached once at least one episode exists."""
+    from neo.memory.episodes import LearningEpisode, LearningEpisodeStore
+    LearningEpisodeStore("proj").save(LearningEpisode(
+        episode_id="e1", started_at=1000.0,
+        final_outcome="suggested_pending_downstream_outcome"))
+
+
+def test_one_dead_root_does_not_suppress_the_starved_verdict(capsys):
+    """The regression both reviewers caught. Comparing the unmeasurable count
+    against a content bucket made `root_unavailable > verifiable` true at 1 > 0,
+    so a single stale worktree hid STARVED and claimed "most recorded
+    suggestions" off a count of one."""
+    from pathlib import Path as _Path
+    from types import SimpleNamespace
+
+    from neo.subcommands import _handle_learning_stats
+
+    _record_idle_episode()
+    live = _Path.home() / "repo"
+    live.mkdir(parents=True, exist_ok=True)
+    _write_session("live", str(live), ["plan.md", "notes.md", "summary.md"])
+    _write_session("dead", str(_Path.home() / "gone-worktree"), ["api/Svc.cs"])
+
+    _handle_learning_stats(SimpleNamespace(json=False, since=None))
+    out = capsys.readouterr().out
+    assert "STARVED" in out
+    assert "UNMEASURABLE" not in out
+    # And the integrity note still qualifies the reading.
+    assert "1 of 4 recorded suggestion(s) could not be classified" in out
+
+
+def test_unmeasurable_requires_every_suggestion_to_be_unclassifiable(capsys):
+    from pathlib import Path as _Path
+    from types import SimpleNamespace
+
+    from neo.subcommands import _handle_learning_stats
+
+    _record_idle_episode()
+    # Includes a doc path on purpose: it previously slipped past the root check
+    # into `advisory`, leaving measurable == 1 and silently defeating this
+    # verdict on a corpus that was 100% dead-root.
+    _write_session("dead", str(_Path.home() / "gone-worktree"),
+                   ["api/Svc.cs", "b.py", "plan.md"])
+
+    _handle_learning_stats(SimpleNamespace(json=False, since=None))
+    out = capsys.readouterr().out
+    assert "UNMEASURABLE" in out
+    assert "STARVED" not in out
 
 
 def test_real_extensionless_files_are_not_called_advisory(tmp_path):


### PR DESCRIPTION
## Description

The interactive learning loop could not mint facts, because most suggestions were never verifiable in the first place. Investigating that turned up three separate causes, each measured against live data in `~/.neo`.

**Context selection never showed the model the code it was asked about.** `score_candidate` had no explicit-path handling, so a path spelled out in the prompt competed on generic filename-token overlap (capped at 3 hits). Asked to fix a function in `src/neo/subcommands.py`, neo ranked that file **163rd of 296** candidates — below its own test file — because an 86KB file takes a heavy size penalty. The file never entered the context, so the model correctly refused to patch code it had not seen and emitted no diff. A suggestion carrying no diff text can never be git-verified, so it can never be learned from.

`select_chunks` compounded it by taking `matching_idxs[:5]` — the first five matching lines in *file order*. Matching is a substring test and `extract_prompt_tokens` emits every 3+ character word, so `"in"` matched `int`/`using`/`point` and virtually every line qualified. "First five matches" therefore meant **lines 1-5 for any prompt against any large file**: every large file contributed its import block, twice, as overlapping near-duplicate windows that consumed both slots of `MAX_CHUNKS_PER_FILE`.

**Promotion accepted evidence that was not independent.** It required two supporting episodes with distinct `episode_id`s, but every invocation mints a fresh one — so one operator applying the same patch twice, minutes apart, at the same HEAD promoted a durable PATTERN. Reproduced live, and the fact it minted was wrong.

**`learning-stats` misread its own data.** Suggestions whose recorded root no longer exists are unmeasurable, not unattributable, and they dominated the bucket that exists as a bug signal.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

No tracking issue — found by drilling the loop end-to-end on a live install after #166/#168/#170 landed.

## Motivation and Context

#166, #168 and #170 fixed pending-session retention but left the open question of whether `accepted` would ever move off zero. A live end-to-end drill in a durable repo confirmed the retention fix works — pending records now survive a second invocation, `accepted` fired for the first time, and a durable PATTERN promoted. That drill is also what exposed the three defects above, including one where the promoted fact's content was *wrong*.

Measured effect on the live corpus:

| bucket | before | after |
|---|---|---|
| verifiable | 21 | 10 |
| advisory | 34 | 40 |
| unattributable | 10 | **1** |
| root_unavailable | – | 14 |

The `verifiable` drop is a correction, not a regression: 11 of the original 21 were invented review docs (`/ARCHITECTURAL_REVIEW.md`) that the plausible-new-file rule admitted because their parent *is* the repo root. The single remaining `unattributable` is a genuine defect (a model-emitted `<placeholder>` path segment).

`suggestion_is_verifiable` is deliberately untouched. Its bias toward admitting a doubtful path is correct — `kind` is frozen at mint, so under-admitting there permanently kills a real lesson. Over-admitting in a *report* costs only an inaccurate number, so the reporting classifier is stricter.

## How Has This Been Tested?

- [x] Full suite: 1723 passed, 8 skipped; ruff clean (pre-commit hook runs the same commands as CI)
- [x] End-to-end live drill against real gpt-5.5: suggestion → pending retained across a second run → apply → `accepted` → `supported_once` → second acceptance → durable fact minted
- [x] Every new test verified non-vacuous by re-running it against the pre-fix algorithm — this caught two of my own tests that passed for the wrong reason
- [x] Re-measured against the real 65-suggestion corpus in `~/.neo/sessions` after each revision

**Test Configuration**:
- Python version: 3.14.6 (local), 3.12.13 (pre-commit hook)
- OS: macOS (darwin 25.6.0)
- Neo version: 0.42.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Reviewed across two rounds each by the `@linus` and `@neo` agents. Three findings from those rounds materially changed the design and are worth calling out, because each looked fine until measured:

1. **A session-id fallback I wrote for non-git projects was a no-op** — `LearningEpisode.session_id` is a per-episode `uuid4()` that nothing assigns from a real session (121 episodes on the live ledger → 121 distinct ids), so `>=2 distinct sessions` was the very gate being replaced, renamed. Worse, its only reachable trigger was a transient `rev-parse` failure, which made *both* failing promote while *one* failing blocked. Deleted; it now fails closed.
2. **My first bucket ordering was wrong in the opposite direction.** Placing the prose-suffix/sentinel/`docs/` branches above the root check looked string-decidable and was not — under a dead root all three degrade to "does not exist" and silently return advisory, under-reporting the integrity signal by 43%.
3. **Unbounded window merging measured 8.3× over `max_chunk_bytes`.** Since the caller admits a chunk all-or-nothing, an oversized chunk that no longer fits the global budget is *dropped* — the original bug returning through a different door.

Known limits, documented on the code rather than left implicit:

- The independence gate keys on `repository_revision` captured when the episode *begins* (HEAD when advice was asked for, not the commit the fix landed in). Keying on the acceptance-carrying sha — already walked by `_get_changed_files_since` — is the obvious improvement.
- Applying one lesson across several files before committing records one revision and will not promote. 40% of revision-bearing episodes share a HEAD, so this is the common shape, not an edge case. Accepted because a delayed durable fact is recoverable and a wrong one needs a contradiction to retract.
- No `learning-stats` bucket reaches `--json` consumers. Pre-existing; needs its own schema decision.
