### PR TITLE
docs: correct the release commands, which described a process that cannot work

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -23,10 +23,8 @@ Updates version numbers, CHANGELOG.md, and builds distributions for a new releas
 1. **Validates** the new version is higher than current and follows semver format
 2. **Reviews** commits since last release tag
 3. **Updates** CHANGELOG.md with new version section and categorized changes
-4. **Updates** version in:
-   - `pyproject.toml` (line 7)
-   - `src/neo/__init__.py` (line 5)
-   - `.claude-plugin/plugin.json` (line 3)
+4. **Updates** the version in `pyproject.toml` — the single source of truth — and
+   runs `make sync-version` to propagate it to the three derived files
 5. **Builds** wheel and sdist distributions
 6. **Reports** what was done and next steps
 
@@ -68,10 +66,23 @@ Add new section at top of `CHANGELOG.md`:
 
 ### Step 4: Update Versions
 
-Update version string in all three files:
-- `pyproject.toml`: Change `version = "X.Y.Z"`
-- `src/neo/__init__.py`: Change `__version__ = "X.Y.Z"`
-- `.claude-plugin/plugin.json`: Change `"version": "X.Y.Z"`
+**Edit ONE file, then propagate.** `pyproject.toml` is the source of truth:
+
+```bash
+# 1. Change `version = "X.Y.Z"` in pyproject.toml (the only hand edit)
+make sync-version        # propagates to the three derived files
+python tools/sync_version.py --check   # confirms all four in sync
+```
+
+`make sync-version` rewrites `src/neo/__init__.py`, `.claude-plugin/plugin.json`
+and `plugins/neo/.codex-plugin/plugin.json`. **Never hand-edit those three** —
+they are derived, and `tests/test_host_adapter_parity.py` fails if they drift
+from `pyproject.toml`.
+
+This step used to list the files for manual editing and named only three of the
+four, omitting the Codex manifest. That is precisely how the package and the two
+plugin manifests reached 0.41.0 / 0.37.0 / 0.19.0 — a documented step with no
+enforcement gets skipped. Do not reintroduce a hand-edit list here.
 
 ### Step 5: Build Distributions
 
@@ -87,12 +98,16 @@ Verify both files were created in `dist/` directory.
 
 Show what was updated and provide next steps:
 ```bash
-# Next steps:
-git add CHANGELOG.md pyproject.toml src/neo/__init__.py .claude-plugin/plugin.json
+git add CHANGELOG.md pyproject.toml src/neo/__init__.py \
+        .claude-plugin/plugin.json plugins/neo/.codex-plugin/plugin.json
 git commit -m "chore: bump version to {new_version}"
-git tag v{new_version}
-git push origin main --tags
 ```
+
+**Do not tag or push to main from here.** `main` is protected and requires a
+pull request plus one approving review, so `git push origin main --tags` — what
+this step used to say — fails outright. Tagging before the release PR merges
+also points the tag at a commit that may never reach `main`. Use
+`/ship-release` for the branch → PR → merge → tag → GitHub Release sequence.
 
 ## Error Handling
 

--- a/.claude/commands/ship-release.md
+++ b/.claude/commands/ship-release.md
@@ -37,7 +37,9 @@ Runs the complete release workflow for projects with protected main branches:
 
 Run `/prepare-release {version}` which:
 - Updates CHANGELOG.md
-- Updates version in pyproject.toml, src/neo/__init__.py, .claude-plugin/plugin.json
+- Updates the version in `pyproject.toml` (the only hand edit) and runs
+  `make sync-version` to propagate it to `src/neo/__init__.py` and both plugin
+  manifests
 - Builds distributions
 
 ### Phase 2: Create Release Branch
@@ -51,9 +53,14 @@ If branch already exists, check it out instead.
 ### Phase 3: Commit Changes
 
 ```bash
-git add CHANGELOG.md pyproject.toml src/neo/__init__.py .claude-plugin/plugin.json
+git add CHANGELOG.md pyproject.toml src/neo/__init__.py \
+        .claude-plugin/plugin.json plugins/neo/.codex-plugin/plugin.json
 git commit -m "chore: bump version to {version}"
 ```
+
+Four version files, not three — the Codex plugin manifest is the one that gets
+forgotten. `python tools/sync_version.py --check` should report all four in sync
+before committing.
 
 ### Phase 4: Push and Create PR
 
@@ -116,7 +123,12 @@ Report status and provide link to new release.
 
 ## Notes
 
-- Main branch must be protected (requires PR for merges)
+- Main branch is protected: it requires a PR **and one approving review**.
+  GitHub does not let an account approve its own PR, so a solo release needs
+  either a second reviewer or `gh pr merge --admin` (works because
+  `enforce_admins` is false). Plain `gh pr merge` fails with "the base branch
+  policy prohibits the merge" — that is the protection working, not a bug.
+- Fill the PR body from `.github/PULL_REQUEST_TEMPLATE.md`
 - Requires `gh` CLI authenticated with GitHub
 - Requires PyPI configured with Trusted Publishers in GitHub Actions
 - Safe to re-run - checks existing state at each phase


### PR DESCRIPTION
## Description

Both release commands drifted out of sync with the repo and now describe steps that fail or silently do the wrong thing. Found while cutting v0.43.0 — I followed the tooling rather than the docs, which is not a thing the next person should have to know to do.

`prepare-release` told the operator to hand-edit the version in three files and named only **three of the four** that restate it, omitting `plugins/neo/.codex-plugin/plugin.json`. That is exactly the drift which let the package and the two plugin manifests reach 0.41.0 / 0.37.0 / 0.19.0 before #163 — a documented step with no enforcement gets skipped. It now says to edit `pyproject.toml` alone and run `make sync-version`, and states that the derived files must never be hand-edited.

Its final step instructed `git push origin main --tags`. `main` is protected and requires a PR plus an approving review, so that fails outright; tagging there would also point the tag at a commit that may never reach `main`.

`ship-release` carried the same three-file list in two places and never mentioned `make sync-version`. Its notes said only that main "requires PR for merges" — omitting that it requires an approving review and that GitHub refuses self-approval, which is the thing that actually stops a solo release. Both docs now record the `--admin` escape and note that a rejected `gh pr merge` is the protection working, not a bug.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

No tracking issue — found while shipping v0.43.0.

## Motivation and Context

`tools/sync_version.py` and `tests/test_host_adapter_parity.py` already enforce version consistency, so the failure mode is no longer a broken release — it is an operator following written instructions that contradict the tooling, then wondering why `git push origin main --tags` is rejected.

## How Has This Been Tested?

- [x] `python tools/sync_version.py --check` reports all four files in sync, matching what the corrected docs now claim
- [x] Grepped both docs for the stale strings (`three files`, `push origin main --tags`, hardcoded line numbers) — the only remaining match is inside the new prose explaining what the step *used* to say
- [x] The corrected sequence is the one actually used to ship v0.43.0 end to end: `pyproject.toml` edit → `make sync-version` → build → release branch → PR → admin merge → tag → GitHub Release → PyPI
- [x] Full suite green via pre-commit hook: 1723 passed, 8 skipped

**Test Configuration**:
- Python version: 3.12.13 (hook)
- OS: macOS (darwin 25.6.0)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Docs only — no tests added. The version-consistency claim these docs now make is already enforced by `tools/sync_version.py --check` and `tests/test_host_adapter_parity.py`.

## Additional Notes

Not addressed here: `ship-release` still describes a `--continue` flag and a TestPyPI job whose behaviour I did not verify during this release. Worth a look, but I did not want to document either from inference.