### PR TITLE
docs(ship-release): the --continue path could tag an unmerged main

### DIFF
--- a/.claude/commands/ship-release.md
+++ b/.claude/commands/ship-release.md
@@ -80,9 +80,17 @@ Then run: `/ship-release {version} --continue`
 
 ### Phase 5: Create Tag (after PR merge)
 
+**Verify the release PR actually merged before tagging.** This phase only pulls
+`main` and tags it, so running `--continue` early tags a tree with no version
+bump — and Phase 6 then publishes anyway, leaving PyPI carrying `{version}` while
+the tag points at a commit that still says the previous one. Nothing downstream
+catches that.
+
 ```bash
+gh pr view {pr-number} --json state -q .state   # must print MERGED
 git checkout main
 git pull origin main
+grep '^version' pyproject.toml                  # must print {version}
 git tag v{version}
 git push origin v{version}
 ```
@@ -96,7 +104,19 @@ gh release create v{version} \
   dist/neo_reasoner-{version}*
 ```
 
-This triggers the GitHub Actions workflow (.github/workflows/publish.yml) which publishes to PyPI.
+This triggers `.github/workflows/publish.yml`, which publishes to PyPI.
+
+**The attached files are not what gets published.** The workflow's `build` job
+checks out the tag, runs `python -m build` itself, and `publish-pypi` uploads
+*that* artifact via Trusted Publishers. The Phase 1 `dist/` build is a local
+verification step and the attachments are convenience copies for the release
+page. Two consequences worth knowing: a stale `dist/` cannot corrupt what lands
+on PyPI, but a missing one makes `gh release create` fail on the glob — likely
+when `--continue` runs in a fresh clone or after `make clean`. Re-run
+`python -m build` in that case.
+
+The distinction is easy to miss because both builds normally produce
+byte-identical artifacts, so a mismatch would not be visible on the release page.
 
 ### Phase 7: Verify Publication
 
@@ -108,8 +128,27 @@ Report status and provide link to new release.
 
 ## Options
 
-- `--continue`: Resume after PR is merged (skips phases 1-4)
-- `--dry-run`: Show what would happen without making changes
+- `--continue`: Resume after the release PR is merged, skipping phases 1-4.
+  Confirm the merge landed before tagging — see Phase 5.
+- `--dry-run`: Report each phase and the commands it would run, changing nothing:
+  no version edit, no CHANGELOG entry, no branch, no PR, no tag, no release.
+
+## Dry-running the publish workflow
+
+`publish-testpypi` exists for this and is gated to manual dispatch:
+
+```bash
+gh workflow run publish.yml
+```
+
+**Its publish step fails today.** No Trusted Publisher is configured for this
+repo on TestPyPI, so the OIDC exchange returns `invalid-publisher` (last
+attempted 2026-07-26). `ci-check`, `build` and the artifact round-trip still run,
+which is most of what a workflow change needs smoke-tested — so a dispatch is
+still worth doing, you just cannot read the upload as a signal. Configure at
+<https://test.pypi.org/manage/account/publishing/> (owner `Parslee-ai`, repo
+`neo`, workflow `publish.yml`) to make the publish half work. See also the NOTE
+above `publish-testpypi` in the workflow, and CONTRIBUTING.md.
 
 ## Error Handling
 


### PR DESCRIPTION
## Description

Follow-up to #173. Checked `/ship-release`'s `--continue` flag and the `publish-testpypi` job against the workflow they drive, rather than against the doc's own description. Three corrections.

**Phase 5 could tag an unmerged `main`.** It pulled `main` and tagged it with no check that the release PR had landed. Run `--continue` early and the tag sits on a tree with no version bump, while Phase 6 publishes regardless — PyPI ends up carrying the new version while the tag points at a commit still declaring the old one, and nothing downstream catches it. Phase 5 now verifies `MERGED` and greps the version out of `pyproject.toml` before tagging.

**Phase 6 misstated what gets published.** It said attaching `dist/` "triggers the workflow which publishes to PyPI", which reads as though the attached files are the published ones. They are not: the `build` job checks out the tag, runs `python -m build` itself, and `publish-pypi` uploads *that* artifact via Trusted Publishers. The Phase 1 build is local verification and the attachments are convenience copies for the release page. Consequences now spelled out — a stale `dist/` cannot corrupt PyPI, but a missing one fails `gh release create` on the glob, which is exactly what `--continue` in a fresh clone produces.

**`--dry-run` had no defined behaviour, and the TestPyPI dry-run was documented everywhere except here.** `publish-testpypi` is real and correctly gated to `workflow_dispatch` — it was rightly skipped during v0.43.0 — but its publish step fails today: no Trusted Publisher is configured for this repo on TestPyPI, so the OIDC exchange returns `invalid-publisher`. That was already recorded in `publish.yml` and CONTRIBUTING.md by #149, just not in the file a releaser actually opens.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

No tracking issue — follow-up to #173, found while verifying the v0.43.0 release path.

## Motivation and Context

The tag/publish ordering hazard is the one that matters. It does not announce itself: the release page looks correct, PyPI looks correct, and only the tag is wrong. v0.43.0 avoided it because the phases were run in order and the PR was merged before tagging — that was sequence, not a safeguard.

## How Has This Been Tested?

Docs, so the test is whether each claim matches the workflow:

- [x] `publish-testpypi` gating: `if: github.event_name == 'workflow_dispatch'` confirmed in `publish.yml`
- [x] `publish-pypi` gating: `if: github.event_name == 'release'` confirmed
- [x] `build` rebuilds from source (`python -m build`) and `publish-pypi` consumes it via `download-artifact` — confirmed, which is what makes the Phase 6 correction true
- [x] `invalid-publisher` failure reproduced from the actual run log (dispatch run 30180615076, 2026-07-26): `valid token, but no corresponding publisher`
- [x] The new Phase 5 commands run clean: `gh pr view 172 --json state -q .state` → `MERGED`; `grep '^version' pyproject.toml` → `version = "0.43.0"`
- [x] Full suite green via pre-commit hook: 1723 passed, 8 skipped

**Test Configuration**:
- Python version: 3.12.13 (hook)
- OS: macOS (darwin 25.6.0)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Docs only. These commands are prompt-driven markdown with nothing to assert against, which is exactly why the claims were verified against `publish.yml` by hand.

## Additional Notes

Not fixed here, because it is a repo-settings change rather than a docs one: configuring the TestPyPI Trusted Publisher at <https://test.pypi.org/manage/account/publishing/> (owner `Parslee-ai`, repo `neo`, workflow `publish.yml`) would make `gh workflow run publish.yml` a genuine end-to-end dry run instead of a partial one.