### PR TITLE
fix(engine): make a crashed run diagnosable instead of just typed

### DIFF
--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -1092,10 +1092,19 @@ def main():
         except ImportError:
             pass
 
-        # Generic error handler
+        # Generic error handler. The message is scrubbed on the way out: this
+        # goes to a HOST, which may log or forward it, and an exception string
+        # is a common place for a credential to surface (a failed auth call
+        # renders the key). Redacting the copy we write to a local episode while
+        # shipping the same string raw to a peer would be the wrong way round.
+        from neo.memory.episodes import redact_sensitive_text
+
         error_output = {
             "error": "ProcessingError",
-            "message": f"Unexpected error during processing: {str(e)}",
+            "message": (
+                "Unexpected error during processing: "
+                f"{redact_sensitive_text(str(e))}"
+            ),
             "error_type": type(e).__name__,
             "suggestions": [
                 "Check Neo's logs for detailed stack trace",

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -16,6 +16,7 @@ import re
 import textwrap
 import threading
 import time
+import traceback
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -62,6 +63,46 @@ if TYPE_CHECKING:
 
 # Initialize logger
 logger = logging.getLogger(__name__)
+
+# Caps on the failure evidence stored in an episode's outcome_details.
+#
+# NOT for eviction: `LearningEpisodeStore._enforce_limit` prunes by FILE COUNT
+# (500 per project, oldest mtime first) and never looks at bytes, so an
+# oversized record evicts nothing. The real reasons are that
+# `LearningEpisodeStore.list()` JSON-parses every episode file in every project
+# on each `neo memory learning-stats` run, that `memory.explain` dumps
+# `outcome_details` verbatim into its output, and that a smaller record is a
+# smaller privacy blast radius. Disk is not a concern — the live ledger measures
+# 2.6 MB with the busiest project at 46 files against the 500 cap.
+_ERROR_MESSAGE_CHARS = 500
+_ERROR_TRACEBACK_CHARS = 4000
+# Share of the traceback budget kept from the FRONT on overflow. Both ends are
+# kept: `raise X from Y` renders the original cause first and the outer
+# exception last, and the outer one is already stored twice over in
+# `error_type` and `error_message` — so keeping only the tail spends the whole
+# budget restating what we have and discards the sole new fact.
+_ERROR_TRACEBACK_HEAD_CHARS = 1600
+
+
+def _elide_middle(text: str, budget: int) -> str:
+    """Trim `text` to `budget` by removing the MIDDLE, marking what was cut.
+
+    Keeping only the tail loses the wrong end. With `raise X from Y` the render
+    puts the original cause first and the outer exception last, and that outer
+    exception is already recorded twice in `error_type` and `error_message` — so
+    a tail-only cut spends the entire budget restating what we already have and
+    throws away `ValueError: database is locked`, the one new fact in the record.
+
+    The marker is not decoration: a silently truncated traceback presented as a
+    whole one is the same class of defect this evidence exists to fix.
+    """
+    if len(text) <= budget:
+        return text
+    marker = "\n... [{} characters elided] ...\n"
+    head = min(_ERROR_TRACEBACK_HEAD_CHARS, budget)
+    tail = max(budget - head - len(marker.format(len(text))), 0)
+    elided = len(text) - head - tail
+    return text[:head] + marker.format(elided) + (text[-tail:] if tail else "")
 
 
 class EngineBusyError(RuntimeError):
@@ -427,7 +468,10 @@ class NeoEngine:
             if episode is not None:
                 episode.completed_at = time.time()
                 episode.final_outcome = "engine_error"
-                episode.outcome_details = {"error_type": type(exc).__name__}
+                episode.outcome_details = {
+                    "error_type": type(exc).__name__,
+                    **self._error_evidence(exc),
+                }
                 try:
                     self.episode_store.save(episode)
                 except Exception as save_exc:
@@ -436,6 +480,59 @@ class NeoEngine:
         finally:
             overseer.stop()
             self._log_action("process.end", "")
+
+    @staticmethod
+    def _error_evidence(exc: Exception) -> dict[str, str]:
+        """Message and traceback for a failed run, redacted and bounded.
+
+        `error_type` alone is not diagnosable after the fact. Two genuine
+        failures sat in a live ledger for eleven days as a bare `ValueError`
+        with nothing to say what raised them, which is the whole reason this
+        exists.
+
+        Redacted because this is persisted state that `memory.explain` also
+        exports — the same reason `redact_sensitive_text` guards facts. Redact
+        happens BEFORE truncation deliberately: the other order can split a
+        secret across the cut and leave the tail half unscrubbed. Two limits of
+        that scrubbing are worth knowing when reading the result. It renders
+        code, and its `key=value` pattern rewrites source lines that were never
+        secrets — measured at 22 of 35,870 lines across this repo, none of them
+        credentials, turning `if secret == None:` into `if secret=[REDACTED]
+        None:`. So a `[REDACTED]` in a traceback may mean "there was an `==`
+        here", not "a credential was removed". Conversely it MISSES a secret
+        inside a rendered mapping (`KeyError: {'api_key': 'sk-live-...'}`),
+        where only the vendor-prefix pattern saves you. Damage is bounded to one
+        token on one line, never the structure. Note stdlib `format_exception`
+        does not render frame locals, so what is captured is paths and source
+        lines, not argument values.
+
+        The two fields are captured INDEPENDENTLY. A hostile `__str__` must not
+        cost the traceback: `format_exception` is already hardened against one
+        and renders `<exception str() failed>`, so sharing a try block would
+        discard recoverable evidence.
+
+        Never raises. This runs on the failure path, where an exception would
+        replace a diagnosable error with an undiagnosable one.
+        """
+        from neo.memory.episodes import redact_sensitive_text
+
+        detail: dict[str, str] = {}
+        try:
+            message = redact_sensitive_text(str(exc)).strip()
+            if message:
+                detail["error_message"] = message[:_ERROR_MESSAGE_CHARS]
+        except Exception as detail_exc:
+            logger.debug("error-message capture failed: %s", detail_exc)
+        try:
+            rendered = "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
+            text = redact_sensitive_text(rendered).rstrip()
+            if text:
+                detail["traceback"] = _elide_middle(text, _ERROR_TRACEBACK_CHARS)
+        except Exception as detail_exc:
+            logger.debug("error-traceback capture failed: %s", detail_exc)
+        return detail
 
     def _begin_learning_episode(self, neo_input: NeoInput):
         """Create the in-memory evidence record for one request."""

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -1154,6 +1154,15 @@ class FactStore:
             # comparison. Half the record describing a different event than the
             # other half is worse than either half alone.
             if supersedes:
+                # Drop the crash evidence first. "engine_error" is not an
+                # OutcomeType, so it ranks lowest and ANY later outcome
+                # supersedes it — and `.update()` alone would leave a traceback
+                # sitting beside `final_outcome: "accepted"`. That is the same
+                # self-contradicting half-record this rank guard exists to
+                # prevent; the keys describe the run that failed, not the
+                # outcome now replacing it.
+                for stale in ("error_type", "error_message", "traceback"):
+                    episode.outcome_details.pop(stale, None)
                 episode.outcome_details.update({
                     "suggestion_id": outcome.suggestion_id,
                     "file_path": outcome.file_path,

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -3244,3 +3244,42 @@ class TestTombstoneTextStrip:
         store._facts.append(old)
         assert store.strip_tombstone_embeddings(save=False) == 1
         assert old.body == ""
+
+
+class TestCrashEvidenceSupersession:
+    def test_a_superseding_outcome_clears_the_crash_evidence(self, store):
+        """"engine_error" is not an OutcomeType, so it ranks 0 and any later
+        outcome supersedes it. Without clearing, `.update()` leaves a traceback
+        beside `final_outcome: "accepted"` — the self-contradicting half-record
+        the rank guard exists to prevent."""
+        from neo.memory.episodes import LearningEpisode, LearningEpisodeStore
+
+        episode_store = LearningEpisodeStore(store.project_id)
+        episode = LearningEpisode(episode_id="crashed", project_id=store.project_id,
+                                  final_outcome="engine_error")
+        episode.outcome_details = {
+            "error_type": "ValueError",
+            "error_message": "boom",
+            "traceback": "Traceback (most recent call last): ...",
+        }
+        episode_store.save(episode)
+
+        # A candidate_id is required to reach the attribution path: an ACCEPTED
+        # outcome with neither a linked fact nor a candidate falls past both
+        # branches and never touches the episode.
+        outcome = Outcome(
+            outcome_type=OutcomeType.ACCEPTED, file_path="src/a.py",
+            suggestion_id="s1", learning_episode_id="crashed",
+            candidate_id="c1", candidate_subject="bugfix: guard [a.py]",
+            candidate_body="Suggestion: guard it", candidate_kind="pattern",
+        )
+        with patch.object(store._outcome_tracker, "detect_outcomes",
+                          return_value=([outcome], {})):
+            store.detect_implicit_feedback({"prompt": "next"}, [])
+
+        saved = episode_store.load("crashed")
+        assert saved.final_outcome == "accepted"
+        assert saved.outcome_details["file_path"] == "src/a.py"
+        for stale in ("error_type", "error_message", "traceback"):
+            assert stale not in saved.outcome_details, (
+                f"{stale} outlived the crash it described")

--- a/tests/test_orchestrator_events.py
+++ b/tests/test_orchestrator_events.py
@@ -678,3 +678,101 @@ def test_every_surfaceable_beat_declares_its_wording():
     for beat in engine.beat_deck["beats"]:
         if beat.get("surface") == "orchestrator":
             assert beat.get("orchestrator_line"), beat["beat_id"]
+
+
+def test_a_failed_run_records_why_not_just_the_type():
+    """`error_type` alone is not diagnosable after the fact. Two genuine failures
+    sat in a live ledger for eleven days as a bare `ValueError` with nothing to
+    say what raised them."""
+    class Exploding:
+        model = "fake"
+        provider = "fake"
+
+        def generate(self, messages, **kwargs):
+            raise RuntimeError("model exploded on token 7")
+
+        def name(self):
+            return "fake-lm"
+
+    engine = NeoEngine(lm_adapter=Exploding(), enable_persistent_memory=False)
+    with pytest.raises(RuntimeError, match="model exploded"):
+        engine.process(NeoInput(prompt="fix the parser", task_type=TaskType.BUGFIX))
+
+    episode = engine.current_learning_episode
+    assert episode is not None and episode.final_outcome == "engine_error"
+    details = episode.outcome_details
+    assert details["error_type"] == "RuntimeError"
+    assert "model exploded on token 7" in details["error_message"]
+    # The tail is what matters: it names the frame that actually raised.
+    assert "raise RuntimeError" in details["traceback"]
+
+
+def test_failure_evidence_is_redacted_and_bounded():
+    """A traceback renders frame content and is persisted state, so it gets the
+    same credential scrubbing facts do; the ledger is a fixed-size ring buffer,
+    so it is capped rather than allowed to evict real learning history."""
+    from neo.engine import _ERROR_MESSAGE_CHARS, _ERROR_TRACEBACK_CHARS, NeoEngine
+
+    secret = "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+    try:
+        raise ValueError(f"auth failed: api_key={secret} " + "x" * 4000)
+    except ValueError as exc:
+        detail = NeoEngine._error_evidence(exc)
+
+    assert secret not in detail["error_message"]
+    assert secret not in detail["traceback"]
+    assert len(detail["error_message"]) <= _ERROR_MESSAGE_CHARS
+    assert len(detail["traceback"]) <= _ERROR_TRACEBACK_CHARS
+
+
+def test_a_hostile_str_costs_the_message_but_not_the_traceback():
+    """The two fields are captured independently. `format_exception` is already
+    hardened against a bad `__str__` and renders `<exception str() failed>`, so
+    a shared try block would throw away perfectly good evidence to avoid an
+    error it had already survived."""
+    from neo.engine import NeoEngine
+
+    class Hostile(Exception):
+        def __str__(self):
+            raise RuntimeError("__str__ exploded")
+
+    try:
+        raise Hostile()
+    except Hostile as exc:
+        detail = NeoEngine._error_evidence(exc)
+
+    assert "error_message" not in detail       # unreachable, correctly dropped
+    assert "raise Hostile()" in detail["traceback"]   # still recovered
+
+
+def test_chained_traceback_keeps_both_the_cause_and_the_failure():
+    """Overflow must not discard the original cause. `raise X from Y` renders Y
+    first and X last, and X is already stored in `error_type` and
+    `error_message` — so a tail-only cut spends the whole budget restating what
+    we have and drops the one new fact."""
+    from neo.engine import _ERROR_TRACEBACK_CHARS, NeoEngine
+
+    # Padded rather than deeply recursive: Python collapses repeated frames
+    # ("[Previous line repeated N times]"), so recursion does not overflow.
+    try:
+        try:
+            raise ValueError("database is locked: /var/db/neo.sqlite " + "x" * 5000)
+        except ValueError as cause:
+            raise RuntimeError("reasoning panel failed") from cause
+    except RuntimeError as exc:
+        detail = NeoEngine._error_evidence(exc)
+
+    tb = detail["traceback"]
+    assert len(tb) <= _ERROR_TRACEBACK_CHARS
+    assert "database is locked" in tb, "the original cause was truncated away"
+    assert "reasoning panel failed" in tb, "the outer failure was truncated away"
+    assert "characters elided" in tb, "truncation must announce itself"
+
+
+def test_untruncated_traceback_carries_no_elision_marker():
+    from neo.engine import NeoEngine
+
+    try:
+        raise ValueError("small")
+    except ValueError as exc:
+        assert "elided" not in NeoEngine._error_evidence(exc)["traceback"]


### PR DESCRIPTION
## Description

A failed run recorded `outcome_details = {"error_type": ...}` and nothing else. Two genuine failures sat in a live ledger for eleven days as a bare `ValueError` with no way to learn what raised them.

`_error_evidence` now captures `error_message` and the traceback alongside the type, both redacted and bounded. Three design points that are not obvious from the diff:

**Redact before truncate.** The other order can split a secret across the cut and leave the tail half unscrubbed.

**The two fields are captured independently.** `format_exception` is already hardened against a hostile `__str__` and renders `<exception str() failed>`, so a shared try block would discard a perfectly good traceback to avoid an error it had already survived. My first version did exactly that, *and* shipped a test asserting the empty result — pinning the weaker behaviour as though it were correct.

**Truncation removes the middle and says so.** Keeping only the tail loses the wrong end: `raise X from Y` renders the original cause first and the outer exception last, and the outer one is already stored twice in `error_type` and `error_message`. A tail-only cut spends the entire budget restating what we have and drops `ValueError: database is locked` — the one new fact in the record.

The caps are **not** about eviction. `LearningEpisodeStore._enforce_limit` prunes by file count, never bytes, so an oversized record evicts nothing. The real costs are that `list()` JSON-parses every episode file on each `learning-stats` run, that `memory.explain` exports `outcome_details` verbatim, and privacy blast radius. My comment claimed the opposite and would have been the next reader's premise.

Two adjacent defects this made conspicuous, both fixed here rather than deferred:

- `engine_error` is not an `OutcomeType`, so it ranks 0 and any later outcome supersedes it — while `.update()` left the traceback in place, producing a record reading `final_outcome: accepted` with a crash attached. That is precisely the self-contradicting half-record the rank guard at `store.py:1150` was added to prevent.
- `cli.py` shipped `str(e)` to the host **unredacted**. Redacting the copy written to a local file while sending the same string raw to a peer that may log or forward it was the wrong way round.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

No tracking issue — found during a health check of a live install, where the two undiagnosable `ValueError` records surfaced.

## Motivation and Context

`outcome_details` is the right home rather than the metrics stream or the FAILED event, and the precedent is in-tree: `store.py:1162` already does redact-bound-store of failure evidence into the same dict. The alternatives fail concretely — `metrics.jsonl` is `NEO_PROFILE`-gated, rotates at 32MB keeping one generation, and has no join key back to an episode; events are stderr JSONL and never persisted. The episode record for a crashed run already exists; the only question was whether it describes itself.

## How Has This Been Tested?

- [x] Full suite: 1729 passed, 8 skipped; ruff clean (pre-commit runs the same commands as CI)
- [x] Redaction verified to actually fire rather than truncation masquerading as it: `api_key=[REDACTED]` at 36 chars, well inside the 500-char cap
- [x] Elision verified end to end on a chained overflow — head keeps `ValueError: database is locked`, tail keeps `RuntimeError: reasoning panel failed`, marker reads `... [1339 characters elided] ...`, total exactly 4000
- [x] Serialization round-trip through `LearningEpisode.to_dict`/`from_dict` preserves both new keys; a typical error episode is 852 bytes
- [x] `neo.cli` still imports cleanly with the new lazy import inside the except block

**Test Configuration**:
- Python version: 3.14.6 (local), 3.12.13 (hook)
- OS: macOS (darwin 25.6.0)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Reviewed by `@linus` and `@neo`; the independent-capture bug, the tail-vs-middle decision and the false eviction rationale all came out of that round.

Known limits, written onto the code rather than left implicit: the `key=value` redaction pattern rewrites source lines that were never secrets — measured at 22 of 35,870 lines across this repo, none of them credentials, turning `if secret == None:` into `if secret=[REDACTED] None:`. So a `[REDACTED]` in a traceback may mean "there was an `==` here". It conversely misses a secret inside a rendered mapping, where only the vendor-prefix pattern helps. Damage is bounded to one token on one line. `format_exception` does not render frame locals, so what is captured is paths and source lines, not argument values.

Not addressed: episodes have no age-based expiry (500 files per project, pruned by mtime), so a traceback persists indefinitely in a low-traffic project — facts get a 30-day tombstone purge and episodes have no equivalent. Worth its own change.