### PR TITLE
fix(index,engine): stop silently discarding most of the repo, and say so when a cap fires (#158, #159, #176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,6 +559,22 @@
      files; `MAX_CHUNKS_PER_REPO` is fixed at 1000 while `--max-files` is not,
      so `files_with_chunks` reports the shortfall — `truncated` is False there,
      because the FILE cap genuinely was not the constraint.
+     **And the corollary the first version of this report broke: never blame a
+     cap for an absence it did not cause.** A selected file is missing from the
+     index for one of TWO unrelated reasons, and the console must not guess
+     between them. Either it produced no chunks at all — no function, class,
+     interface or struct for the grammar to match, as in an empty
+     `__init__.py`, an enum-only `.cs`, a type-alias-only `.ts` — which no cap
+     setting changes and which therefore gets a bare statement with NO remedy
+     attached; or the cap took every chunk it produced, which gets the cap
+     named and `lower --max-files`. `files_producing_chunks` is measured
+     BEFORE `_cap_chunks` precisely so the two stay separable; subtracting the
+     post-cap `files_with_chunks` from `selected` conflates them and is what
+     printed "the 1000-chunk cap is below the 25 files selected" for a build
+     that kept 559 of 559 chunks, with `chunks_capped` False on the same
+     report. It fired on this repo, on any repo with an `__init__.py`. A report
+     that invents a cause is worse than the silence it replaced, because
+     silence at least does not send the operator to the wrong knob.
   **Query footgun** (`language_parser.py`; incident detail in the tree-sitter
   doc's "Why queries break silently"): a query that fails to compile is
   indistinguishable from one that matches nothing — `_get_query` returns None

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,58 @@
   and retrieval changes than waiting for an inference round trip. **Use it before
   believing any claim about what Neo "saw"** — the two defects below were both
   invisible from the outside and presented as the model being unhelpful.
+- Project index (`index/project_index.py`, `index/language_parser.py`; full
+  notes in `docs/tree-sitter-setup.md`). Three invariants, each of which was
+  violated and each of which produced an index that could not answer a question
+  about its own repository:
+  1. **Budgets are apportioned, never sliced.** `_select_files` groups eligible
+     files by language and hands each a share of `--max-files` proportional to
+     repo composition, floor of one slot per language (`_allocate_slots`); then
+     `_cap_chunks` round-robins `MAX_CHUNKS_PER_REPO` across FILES so each keeps
+     a chunk before any keeps a second. Both exist because a list slice is not a
+     ranking: globbing `**/*.py` before `**/*.cs` and slicing gave a .NET repo of
+     4,272 C# files an index of 83 Python files (95 from an in-repo worktree) and
+     zero C#, exit 0. Fixing only the file cut left `chunks[:1000]` re-creating it
+     one function later — chunks arrive grouped by file and files by language, so
+     the slice kept 1000 C# chunks and dropped every other language, with 37 of
+     the 100 selected files contributing nothing.
+  2. **Exclusion is two layers and `bin`/`build`/`out`/`target`/`dist`/`vendor`
+     belong to neither by name.** `EXCLUDED_DIR_NAMES` covers what repos forget to
+     ignore (`.worktrees`, `.claude`, `node_modules`, `obj`, virtualenvs);
+     `_build_exclusion_filter` layers the repo's own `.gitignore` on top via
+     `context_gatherer.load_gitignore_patterns`. **Footgun**: `should_ignore` only
+     tests the path handed to it, so ancestor directories must be walked
+     separately — `iter_paths` gets this via `os.walk` pruning, which the index
+     has no equivalent of. Matching is exact and case-sensitive, against
+     directory components only. The ambiguous names stay out because each is real
+     source somewhere (`src/bin/main.rs`, vendored trees; 254 tracked files under
+     `bin/`+`vendor/` across three local repos) and the asymmetry is one-sided:
+     over-excluding hides code permanently, over-including only spends slots.
+  3. **A cap that fired must be reported.** `selection_report` carries eligible /
+     selected / excluded / duplicates / chunk counts and the CLI prints them.
+     `truncated` means THE CAP BOUND US and is `examined < eligible` — whether
+     any candidate went unlooked-at, which the per-language iterators already
+     know. Both cheaper predicates name the wrong knob: `selected < eligible`
+     made dedup print "2 of 7 eligible files (capped at --max-files=1000)", and
+     `selected >= max_files` did the same whenever `--max-files` landed exactly
+     on the unique-file count. Raising a cap that never bound fixes nothing.
+     Separately, round-robin only represents every file while chunk slots ≥
+     files; `MAX_CHUNKS_PER_REPO` is fixed at 1000 while `--max-files` is not,
+     so `files_with_chunks` reports the shortfall — `truncated` is False there,
+     because the FILE cap genuinely was not the constraint.
+  **Query footgun** (`language_parser.py`; incident detail in the tree-sitter
+  doc's "Why queries break silently"): a query that fails to compile is
+  indistinguishable from one that matches nothing — `_get_query` returns None
+  and `parse_file` moves on; edge failures log at DEBUG. Four were broken at
+  once, so TS interfaces and ALL C# inheritance edges were absent from every
+  index since they shipped. Three rules follow. Compile results are cached
+  INCLUDING failures (the uncached retry warned per query *per file* — 9,699
+  lines in one run). C# bases need `[(identifier) (generic_name (identifier))]`
+  across class/interface/record/struct, since an identifier-only, class-only
+  pattern compiles fine and silently drops `: Repository<Order>` and
+  `interface IX : IY`. And `test_every_chunk_query_compiles` /
+  `test_every_edge_query_compiles` prove compilation ONLY, so a new query still
+  needs its own behavioural assertion.
 - Context selection (`context_gatherer`): **a path named in the prompt is pinned**
   (`EXPLICIT_PATH_BOOST=10.0`, chosen to exceed every organic signal combined —
   filename overlap caps at +1.8, the re-rank boosts at +1.0 and +1.2). Without it a
@@ -553,6 +605,33 @@
   global budget is DROPPED — the original bug returning through a different door.
   `_fit_to_budget` shrinks outward from the window's best line so truncation can never
   discard the line that earned the window.
+- Prompt-side file rendering (`engine._render_context_files`): the REPOSITORY
+  CONTEXT block caps each file at `_CONTEXT_FILE_CHARS` (3000), or
+  `_IMPORTANT_FILE_CHARS` (8000) when the path contains one of
+  `_IMPORTANT_FILE_PATTERNS`, and shows at most `_MAX_CONTEXT_FILES` (20).
+  **Every cut MUST be marked and the banner MUST count post-truncation
+  characters** — that is the whole contract, and both halves were broken.
+  `content_preview = content[:char_limit]` appended nothing, so `--- path ---`
+  followed by text that just stops was indistinguishable from a file that ends
+  there, and the model answered questions about absence ("X is never called",
+  "there is no null check") from a fragment. The dangerous case is not an
+  obvious clip but a cut landing just past a method signature: enough to look
+  answerable, not enough to be right — measured live, a claim confirmed at 0.90
+  that moved to 0.99 *and reversed* once the body was supplied. Marked
+  truncation converts that into a refusal, which neo already does well.
+  Meanwhile the banner summed `len(f.content)` BEFORE the cut and called the
+  result bytes, so "12 files, 340000 bytes" described a payload the model never
+  received. It now reads `sent of total chars` — **chars, not bytes**: `len()`
+  on a `str` counts code points and the caps are character counts, so claiming
+  bytes was a second lie on any non-ASCII source. **Footgun**: the function
+  returns THREE values — `(sections, banner, visible)`. `visible` is each shown
+  file cut to what the model actually got, and `code_smells.scan_files` MUST be
+  fed it rather than the originals. Scanning full content emitted findings like
+  `src/Service.cs:401 [todo/warn] HACK: ...` for a file the model saw to line
+  ~215: an unmarked cut invites a wrong inference about unseen code, but a
+  line-numbered finding about unseen code asserts one. `neo.agent_context`
+  marks its truncation (`PER_FILE_CAP_BYTES` + `... [truncated]`) — copy that
+  shape for any new path that cuts text. Use `neo --dry-run` to see the block.
 - Host communication (`neo.events` + `models.OrchestratorMessage`): the engine
   reports lifecycle facts so a host (Claude Code, MCP, an IDE) doesn't have to
   reverse-engineer presentation from raw plans. **Governing rule: Neo reports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,10 +582,15 @@
   once, so TS interfaces and ALL C# inheritance edges were absent from every
   index since they shipped. Three rules follow. Compile results are cached
   INCLUDING failures (the uncached retry warned per query *per file* — 9,699
-  lines in one run). C# bases need `[(identifier) (generic_name (identifier))]`
-  across class/interface/record/struct, since an identifier-only, class-only
-  pattern compiles fine and silently drops `: Repository<Order>` and
-  `interface IX : IY`. And `test_every_chunk_query_compiles` /
+  lines in one run). C# bases need all four of `identifier`, `generic_name`,
+  and `qualified_name` with either as its `name:` field — across
+  class/interface/record/struct — since a narrower pattern compiles fine and
+  silently drops `: Repository<Order>`, `: System.Exception` and
+  `interface IX : IY`. That query is GENERATED from `_CS_BASE_TYPES` over the
+  four declaration kinds rather than written out four times: the hand-copied
+  version is what left `interface_declaration` uncovered, and each widening
+  since has had to be applied everywhere at once or not at all. And
+  `test_every_chunk_query_compiles` /
   `test_every_edge_query_compiles` prove compilation ONLY, so a new query still
   needs its own behavioural assertion.
 - Context selection (`context_gatherer`): **a path named in the prompt is pinned**

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Neo is one binary with a plain-text prompt plus a handful of subcommands. Run
 | `--index` / `--update` / `--languages CSV` | Build, incrementally refresh, and scope the per-project semantic index |
 | `--semantic` | Use the semantic index for file selection (requires `.neo/index.json`) |
 | `--max-bytes N` | Hard cap on total context bytes (default 300000) |
-| `--max-files N` | Cap on files: context gathering (default 30), or the index build when passed with `--index` (default 100) |
+| `--max-files N` | Cap on files: context gathering (default 30), or the index build when passed with `--index` (default 100). The index build apportions this budget across languages by repo composition and reports what the cap left out |
 | `--include GLOB` / `--exclude GLOB` | Allow/block file patterns; both repeatable |
 | `--exts CSV` | Restrict context to these file extensions |
 | `--diff-since REV` | Prioritize files changed since a git rev or duration |
@@ -1130,6 +1130,8 @@ The context gatherer picks files using three signals:
 - **EPISODE-history feedback loop**: each Neo run stashes touched file paths as `file:<rel>` tags on EPISODE facts. On the next run, the gatherer queries for similar past prompts and gives those files up to +0.5 boost — past file selections measurably influence future ones.
 
 A per-file chunk cap of 2 prevents large files from eating the budget; a one-time first-run hint fires if the index is missing.
+
+The index build itself apportions its budget rather than truncating whatever globbed first: files are grouped by language and given a share of `--max-files` proportional to how much of the repo they are, with a floor of one slot per language, and the `MAX_CHUNKS_PER_REPO` cut round-robins across files so every indexed file keeps a chunk. Non-source paths (`.worktrees`, `node_modules`, `.claude`, virtualenvs, plus anything the repo's own `.gitignore` names) are excluded, and byte-identical duplicates are indexed once. When a cap bites, `neo --index` says so — a capped build no longer looks the same as a complete one. See [tree-sitter setup](docs/tree-sitter-setup.md#operational-notes).
 
 
 ### Learning Feedback Loop

--- a/docs/tree-sitter-setup.md
+++ b/docs/tree-sitter-setup.md
@@ -87,12 +87,25 @@ Per-subsystem coverage isn't uniform. For example, `code_smells` empty-catch det
 2. Confirm `tree-sitter-language-pack` ships the grammar: `python -c "from tree_sitter_language_pack import get_parser; get_parser('YOUR_LANG')"`.
 3. Add chunk-extraction queries to `language_parser.py` (functions, classes, methods) and register them in `QUERIES` — `architecture_metrics.py` walks files only when `lang in QUERIES`.
 4. If the language has try/catch-style error handling, register a detector in `code_smells._ERROR_SWALLOW_DETECTORS`; otherwise empty-catch detection is silently no-op for it.
+5. Add a behavioural assertion, not just a compile check. `test_every_chunk_query_compiles` and `test_every_edge_query_compiles` will catch a query that does not compile, but a query that compiles and matches nothing looks identical to a file with nothing in it. Assert that a fixture containing the construct produces the chunk or edge you expect.
+
+### Why queries break silently
+
+A query that fails to compile is not an error anywhere the operator can see it. `_get_query` returns `None` and `parse_file` moves to the next query; `_extract_edges` logs at DEBUG. The construct is simply absent from the index.
+
+Four queries were in this state at once: `typescript`/`tsx` `interfaces` (grammar renamed the interface body from `object_type` to `interface_body`), `c_sharp` `inheritance` (`bases:` was never a field name), and a `python` `module_doc` that also had no consumer. TypeScript interfaces and C# inheritance edges had been missing from every index since the queries shipped, with no signal but a warning line — one per query *per parsed file*, which is how a single run produced 9,699 of them. Compile results, failures included, are now cached per parser instance, so a broken query warns once.
+
+Grammars move. `test_every_chunk_query_compiles` / `test_every_edge_query_compiles` are parametrized over every entry in `QUERIES` and `EDGE_QUERIES` so the next rename fails a test instead of quietly shrinking the index.
 
 ## Operational Notes
 
 - Use `neo --update` instead of `--index` after the first build — it re-embeds only changed files.
 - The index build caps at **100 files** per run by default. Override it with `neo --index --max-files N`; the same flag caps *context gathering* at 30 by default when used without `--index`, so each subsystem keeps its own floor.
-- Neo honors `.gitignore` by default; double-check large generated dirs aren't tracked.
+- **The cut is apportioned, not sliced.** `ProjectIndex._select_files` groups eligible files by language and gives each a share of `--max-files` proportional to how much of the repo it is, with a floor of one slot per language present (`_allocate_slots`). Before this, patterns were globbed in list order and concatenated, so whichever language globbed first ate the budget — a .NET repo of 4,272 C# files produced an index of 83 Python files and zero C#, and exited 0. Within a language, files are ordered shallowest-path-first; that is a weak heuristic, not centrality ranking.
+- **`MAX_CHUNKS_PER_REPO` (1000) is applied the same way.** `_cap_chunks` round-robins across files, so every indexed file keeps a chunk before any file keeps a second. A plain slice re-created the bug one layer down, since chunks arrive grouped by file and files grouped by language.
+- **Exclusions are two layers.** `EXCLUDED_DIR_NAMES` in `project_index.py` names directories that are never source (`.git`, `.worktrees`, `node_modules`, `.claude`, `obj`, `__pycache__`, virtualenvs, IDE dirs); matching is exact and case-sensitive against directory components only, so a *file* named `build.py` is kept. On top of that the repo's own `.gitignore` is honored via `context_gatherer.load_gitignore_patterns`, walking ancestor directories so files under an ignored directory are excluded too. Ambiguous names — `bin`, `build`, `out`, `target`, `dist`, `vendor` — are deliberately **not** hardcoded, because each is real source in some repo (`src/bin/main.rs`, vendored trees); repos that generate into them gitignore them.
+- Byte-identical files are indexed once. A duplicate does not consume a slot, and the freed slot is refilled — across languages if the original language has nothing unique left.
+- **Anything left out is reported.** Each line is conditional — a build that indexed everything prints none of them, so their presence is the signal. `neo --index` adds: how many of the eligible files were indexed with a per-language breakdown (only when the file cap actually bound), a capped chunk total, how many selected files ended up with no chunks at all, and counts for skipped duplicates and excluded paths. "Built index" on its own no longer means the index represents the repository.
 - `MAX_CHUNK_LENGTH` is set to **2000 characters** (defined in both `language_parser.py` and `project_index.py` — keep them in sync if you change one).
 - Malformed code returns empty chunks by design (better than half-parsed garbage propagating into embeddings).
 

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -587,18 +587,40 @@ def _format_selection_report(report: Optional[dict]) -> list[str]:
             f"chunks (cap {report['max_chunks']}); each indexed file keeps its "
             f"first chunks before any file keeps a second"
         )
-    # Only possible when the file count exceeds the chunk cap, which the
-    # `truncated` line above cannot describe — it reports the FILE budget.
+    # A selected file can be absent from the index for two unrelated reasons,
+    # and they get separate lines because they have separate remedies — one of
+    # them has none at all. Reporting both as the chunk cap was the original
+    # form of this block, and it named a cap that had not fired: 25 files, 559
+    # of 559 chunks kept, and still "the 1000-chunk cap is below the 25 files
+    # selected; lower --max-files". The culprit was an empty `__init__.py`, and
+    # lowering --max-files would only have indexed less.
+    #
     # Keyed on presence, not on a 0 default: a selection-only report has no
     # chunk phase, and treating "absent" as "zero files represented" would
     # claim every file was dropped.
     if 'files_with_chunks' in report:
-        missing = report['selected'] - report['files_with_chunks']
-        if missing > 0:
+        # `files_producing_chunks` is measured before the cap, so this
+        # subtraction isolates the files the cap alone emptied. Falling back to
+        # the post-cap count makes `starved` zero for a report predating the
+        # key, which is the safe direction: silence, not a false accusation.
+        produced = report.get('files_producing_chunks', report['files_with_chunks'])
+        starved = produced - report['files_with_chunks']
+        if starved > 0:
             lines.append(
-                f"[Neo] {missing} selected files contributed no chunks — the "
-                f"{report['max_chunks']}-chunk cap is below the "
+                f"[Neo] {starved} indexed files lost every chunk to the "
+                f"{report['max_chunks']}-chunk cap, which is below the "
                 f"{report['selected']} files selected; lower --max-files"
+            )
+        # Stated as a fact about the source, with no remedy attached, because
+        # there is no setting that makes a constructs-free file produce a
+        # chunk. It is reported at all so that "Indexed 100 of 4,000" is not
+        # read as "100 files' worth of chunks are in the index".
+        barren = report['selected'] - produced
+        if barren > 0:
+            noun = "file" if barren == 1 else "files"
+            lines.append(
+                f"[Neo] {barren} selected {noun} yielded no chunks (no "
+                f"functions, classes or interfaces for the parser to extract)"
             )
     if report.get('duplicates'):
         lines.append(

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -17,6 +17,7 @@ import os
 import select
 import sys
 from dataclasses import asdict
+from typing import Optional
 
 # Disable tokenizer parallelism warning (fastembed uses HuggingFace tokenizers)
 os.environ.setdefault('TOKENIZERS_PARALLELISM', 'false')
@@ -548,6 +549,70 @@ def read_prompt_from_argv_or_stdin(args):
     sys.exit(2)
 
 
+def _format_selection_report(report: Optional[dict]) -> list[str]:
+    """Render what the index cap left out, as `[Neo] ` console lines.
+
+    Silent truncation is what made a broken index look like a successful one:
+    `--index` printed "Built index" and exited 0 whether it had indexed the
+    repository or 83 Python files from a stale worktree copy. An operator who
+    is told 100 of 4,344 files were indexed can raise --max-files; an operator
+    told only "Built index" has no reason to think anything is wrong.
+    """
+    if not report:
+        return []
+
+    lines: list[str] = []
+    if report.get('truncated'):
+        lines.append(
+            f"[Neo] Indexed {report['selected']} of {report['eligible']} "
+            f"eligible files (capped at --max-files={report['max_files']})"
+        )
+        per_language = report.get('per_language') or {}
+        # Biggest languages first — that is the order an operator scans for
+        # "is my primary language actually in here?"
+        ranked = sorted(
+            per_language.items(),
+            key=lambda item: (-item[1]['eligible'], item[0]),
+        )
+        breakdown = ", ".join(
+            f"{lang} {counts['selected']}/{counts['eligible']}"
+            for lang, counts in ranked
+        )
+        if breakdown:
+            lines.append(f"[Neo]   {breakdown}")
+
+    if report.get('chunks_capped'):
+        lines.append(
+            f"[Neo] Kept {report['chunks_kept']} of {report['chunks_extracted']} "
+            f"chunks (cap {report['max_chunks']}); each indexed file keeps its "
+            f"first chunks before any file keeps a second"
+        )
+    # Only possible when the file count exceeds the chunk cap, which the
+    # `truncated` line above cannot describe — it reports the FILE budget.
+    # Keyed on presence, not on a 0 default: a selection-only report has no
+    # chunk phase, and treating "absent" as "zero files represented" would
+    # claim every file was dropped.
+    if 'files_with_chunks' in report:
+        missing = report['selected'] - report['files_with_chunks']
+        if missing > 0:
+            lines.append(
+                f"[Neo] {missing} selected files contributed no chunks — the "
+                f"{report['max_chunks']}-chunk cap is below the "
+                f"{report['selected']} files selected; lower --max-files"
+            )
+    if report.get('duplicates'):
+        lines.append(
+            f"[Neo] Skipped {report['duplicates']} files with content "
+            f"identical to an already-indexed file"
+        )
+    if report.get('excluded'):
+        lines.append(
+            f"[Neo] Skipped {report['excluded']} paths under excluded "
+            f"directories (worktrees, node_modules, build output, ...)"
+        )
+    return lines
+
+
 def _configure_logging(args) -> None:
     """Configure logging based on CLI flags, env var, or config.
 
@@ -706,6 +771,8 @@ def main():
             index.build_index(languages=languages, max_files=max_files)
             status = index.status()
             print(f"[Neo] Built index: {status['total_chunks']} chunks, {status.get('total_edges', 0)} edges from {status['total_files']} files")
+            for line in _format_selection_report(index.selection_report):
+                print(line)
             print(f"[Neo] Index stored in {codebase_root}/.neo/")
             print("[Neo] Supported languages: Python, C#, TypeScript, JavaScript, Java, Go, Rust, C/C++")
             print("[Neo] Use '--semantic' flag to enable semantic search")

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -83,6 +83,25 @@ _ERROR_TRACEBACK_CHARS = 4000
 # budget restating what we have and discards the sole new fact.
 _ERROR_TRACEBACK_HEAD_CHARS = 1600
 
+# Caps on the REPOSITORY CONTEXT block in the reasoning prompt.
+#
+# These are token-overflow guards, not relevance judgements — the gatherer has
+# already decided which files matter by the time they get here. 3000 characters
+# is roughly 40-75 lines of C#, so for a compiled-language repo the model
+# routinely sees the usings, the fields and the first method or two of a file
+# and nothing below that.
+#
+# Whatever the numbers are, the cut must be MARKED (see
+# `_render_context_files`). An unmarked cut is the dangerous case: the model
+# cannot distinguish "the file ends here" from "the file was clipped", so it
+# answers questions about absence from a fragment.
+_MAX_CONTEXT_FILES = 20
+_CONTEXT_FILE_CHARS = 3000
+_IMPORTANT_FILE_CHARS = 8000
+# Substrings that earn the larger cap. Matched against the whole lowercased
+# path, so a source file under a directory named `architecture` also qualifies.
+_IMPORTANT_FILE_PATTERNS = ('readme.md', 'claude.md', 'architecture')
+
 
 def _elide_middle(text: str, budget: int) -> str:
     """Trim `text` to `budget` by removing the MIDDLE, marking what was cut.
@@ -2006,6 +2025,87 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
             return None, None, None, None
         return result.plan, result.simulation_traces, result.code_suggestions, result
 
+    @staticmethod
+    def _render_context_files(files: list) -> tuple[list[str], str, list]:
+        """Render the REPOSITORY CONTEXT block, marking every cut it makes.
+
+        Returns ``(sections, banner, visible)``. The banner is deliberately
+        built from what was actually included rather than from what was
+        offered, and `visible` carries each shown file cut down to the text
+        the model received, so downstream passes cannot describe source the
+        model was never given.
+
+        Two failures this fixes, both of which let a reader believe they had
+        more than they did:
+
+        1. The model was handed a bare slice. `--- path ---` followed by text
+           that simply stops is indistinguishable from a file that ends there,
+           so the model reasons about absence — "X is not called here", "there
+           is no null check" — from a fragment. The dangerous case is not the
+           obvious clip; it is a cut landing just past a method signature,
+           where there is enough context to look answerable and not enough to
+           be right. Marking the cut converts that into a refusal, which is
+           behaviour neo already handles well.
+        2. The operator was handed a pre-truncation byte count. A banner
+           reading "12 files, 340000 bytes" described bytes that were never
+           sent: with these caps the model saw at most a fifth of that, and
+           nothing in the output said so.
+
+        Mirrors `neo.agent_context._read_doc`, which marks its truncation;
+        this path was the one that did not.
+        """
+        from dataclasses import replace
+
+        shown = files[:_MAX_CONTEXT_FILES]
+        sections: list[str] = []
+        visible: list = []
+        sent_chars = 0
+        truncated_count = 0
+
+        for f in shown:
+            original = f.content or ''
+            lowered = f.path.lower()
+            limit = (
+                _IMPORTANT_FILE_CHARS
+                if any(pat in lowered for pat in _IMPORTANT_FILE_PATTERNS)
+                else _CONTEXT_FILE_CHARS
+            )
+            content = original[:limit]
+            # Counts the file's own text, not our marker or the `--- path ---`
+            # header, because the question it answers is "how much of my
+            # source did the model see".
+            sent_chars += len(content)
+            visible.append(replace(f, content=content) if len(original) > limit else f)
+
+            if len(original) > limit:
+                truncated_count += 1
+                content += (
+                    f"\n... [truncated: {len(original) - limit} of "
+                    f"{len(original)} characters not shown]"
+                )
+            sections.append(f"\n--- {f.path} ---\n{content}")
+
+        total_chars = sum(len(f.content or '') for f in files)
+        file_part = (
+            f"{len(shown)} of {len(files)} files"
+            if len(shown) < len(files)
+            else f"{len(files)} file{'' if len(files) == 1 else 's'}"
+        )
+        # "chars", not "bytes": `len()` on a str counts code points, and the
+        # old banner said bytes while summing exactly this.
+        size_part = (
+            f"{sent_chars} of {total_chars} chars"
+            if sent_chars < total_chars
+            else f"{sent_chars} chars"
+        )
+        note = ""
+        if truncated_count:
+            noun = "file" if truncated_count == 1 else "files"
+            note = f"; {truncated_count} {noun} truncated, marked inline"
+        banner = f"\nREPOSITORY CONTEXT ({file_part}, {size_part}{note}):"
+
+        return sections, banner, visible
+
     def _format_combined_prompt(self, context: dict[str, Any]) -> tuple[str, "MemorySignal"]:
         """Format the combined prompt and return it alongside the memory signal.
 
@@ -2077,24 +2177,25 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
 
         # Add context files if provided
         files = context.get('files', [])
+        visible_files: list = []
         if files:
-            parts.append(f"\nREPOSITORY CONTEXT ({len(files)} files, {sum(len(f.content or '') for f in files)} bytes):")
-            for f in files[:20]:  # Limit to 20 files to avoid token overflow
-                # Allow more content for important files (README, docs)
-                is_important = any(pat in f.path.lower() for pat in ['readme.md', 'claude.md', 'architecture'])
-                char_limit = 8000 if is_important else 3000
-                content_preview = (f.content or '')[:char_limit]
-                parts.append(f"\n--- {f.path} ---\n{content_preview}")
+            rendered, banner, visible_files = self._render_context_files(files)
+            parts.append(banner)
+            parts.extend(rendered)
 
         if exemplars:
             parts.append("\nSimilar Past Tasks:")
             parts.extend(f"- {ex}" for ex in exemplars[:3])
 
         # Surface code smells in the gatherer-picked files so the model sees
-        # known issues alongside the source. Scoped to `files[:20]` to match
-        # what we actually showed the model above.
+        # known issues alongside the source. Scanned against the TRUNCATED
+        # content, not the originals: scanning the full text emitted
+        # citations like `src/Service.cs:401 [todo/warn] HACK: ...` for a
+        # file the model was shown to line ~215. An unmarked cut invites a
+        # wrong inference about unseen code; a line-numbered finding about
+        # unseen code asserts one, which is worse.
         from neo.code_smells import format_for_prompt, scan_files
-        smells_section = format_for_prompt(scan_files(files[:20]))
+        smells_section = format_for_prompt(scan_files(visible_files))
         if smells_section:
             parts.append(smells_section)
 

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -2075,6 +2075,13 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
             # header, because the question it answers is "how much of my
             # source did the model see".
             sent_chars += len(content)
+            # `replace` rewrites ONLY `content`, which is correct exactly while
+            # the incoming type carries no field derived from content length.
+            # The live path satisfies that: `cli` converts the gatherer's
+            # `ContextFile` — which does carry a `bytes` — into
+            # `models.ContextFile` (path / content / line_range) before the
+            # engine sees it. Route a size-carrying type here and that field
+            # silently disagrees with the content sitting beside it.
             visible.append(replace(f, content=content) if len(original) > limit else f)
 
             if len(original) > limit:

--- a/src/neo/index/language_parser.py
+++ b/src/neo/index/language_parser.py
@@ -264,6 +264,44 @@ QUERIES = {
 # TSX uses same queries as TypeScript
 QUERIES['tsx'] = QUERIES['typescript']
 
+# Every shape a C# base type can take, capturing the simple name in each.
+#
+# The alternation is not decoration — each arm was found missing by probing
+# the grammar with real .NET source, and each absent arm drops edges silently:
+#
+#   : IFoo                      -> identifier
+#   : Repository<Order>         -> generic_name        (everyday .NET)
+#   : System.Exception          -> qualified_name      (everyday .NET)
+#   : My.Ns.Repo<Order>         -> qualified_name whose `name:` is generic_name
+#   : global::Foo.Bar           -> qualified_name over alias_qualified_name
+#
+# `qualified_name` exposes the rightmost segment as its `name:` field, so the
+# last two arms capture `Exception` and `Repo` rather than the namespace —
+# matching what the identifier and generic_name arms yield, so consumers see
+# one naming convention rather than two.
+_CS_BASE_TYPES = """[(identifier) @base
+                     (generic_name (identifier) @base)
+                     (qualified_name name: (identifier) @base)
+                     (qualified_name name: (generic_name (identifier) @base))]"""
+
+# `base_list` hangs off four declaration kinds, and every one of them needs the
+# identical alternation above. Generated rather than copied four times because
+# the copy is what failed before: the original pattern covered
+# `class_declaration` alone, so `interface IX : IY` produced nothing, and a
+# hand-maintained fourfold duplicate invites the next widening to be applied to
+# three of the four. `test_every_edge_query_compiles` covers the generation.
+_CS_INHERITANCE = "[\n" + "\n".join(
+    f"""  ({declaration}
+      name: (identifier) @class_name
+      (base_list {_CS_BASE_TYPES}))"""
+    for declaration in (
+        'class_declaration',
+        'interface_declaration',
+        'record_declaration',
+        'struct_declaration',
+    )
+) + "\n] @class_def"
+
 # Edge queries for relationship extraction (imports, inheritance)
 EDGE_QUERIES = {
     'python': {
@@ -292,36 +330,10 @@ EDGE_QUERIES = {
         # `bases:` field name did not exist in the grammar, so this never
         # compiled and every C# inheritance edge was silently dropped.
         #
-        # The alternations are not decoration. A base written `Base<T>` parses
-        # as `generic_name`, not `identifier`, so an identifier-only pattern
-        # drops `: Repository<Order>` and `: IEnumerable<T>` — everyday .NET.
-        # Interfaces, records and structs carry their own `base_list` under
-        # their own node types, and matching only `class_declaration` meant
-        # `interface IX : IY` produced nothing.
-        'inheritance': """
-            [
-              (class_declaration
-                  name: (identifier) @class_name
-                  (base_list
-                      [(identifier) @base
-                       (generic_name (identifier) @base)]))
-              (interface_declaration
-                  name: (identifier) @class_name
-                  (base_list
-                      [(identifier) @base
-                       (generic_name (identifier) @base)]))
-              (record_declaration
-                  name: (identifier) @class_name
-                  (base_list
-                      [(identifier) @base
-                       (generic_name (identifier) @base)]))
-              (struct_declaration
-                  name: (identifier) @class_name
-                  (base_list
-                      [(identifier) @base
-                       (generic_name (identifier) @base)]))
-            ] @class_def
-        """,
+        # Built from _CS_INHERITANCE rather than written out: see the note
+        # there for why the four declaration kinds are generated instead of
+        # copied.
+        'inheritance': _CS_INHERITANCE,
     },
     'typescript': {
         'imports': """

--- a/src/neo/index/language_parser.py
+++ b/src/neo/index/language_parser.py
@@ -86,11 +86,15 @@ QUERIES = {
                 name: (identifier) @name
                 body: (block) @body) @class
         """,
-        'module_doc': """
-            (module
-                . (expression_statement
-                    (string) @doc))
-        """
+        # No `module_doc` query. One existed, matching a module docstring
+        # wrapped in an `expression_statement` — a shape the grammar does not
+        # produce, so it failed to compile and warned once per Python file
+        # parsed. Correcting it to the real shape (a bare `string` directly
+        # under `module`) only exposed that nothing consumed it either:
+        # `_process_captures` builds chunks from construct captures
+        # (function/class/method/interface/struct) and drops a lone `@doc`.
+        # It has never produced a chunk in any released version, so it is
+        # gone rather than fixed into something still inert.
     },
     'c_sharp': {
         'functions': """
@@ -125,7 +129,7 @@ QUERIES = {
         'interfaces': """
             (interface_declaration
                 name: (type_identifier) @name
-                body: (object_type) @body) @interface
+                body: (interface_body) @body) @interface
         """
     },
     'javascript': {
@@ -284,11 +288,39 @@ EDGE_QUERIES = {
             (using_directive
                 (qualified_name) @module) @import
         """,
+        # `base_list` is an unnamed child of the declaration — the older
+        # `bases:` field name did not exist in the grammar, so this never
+        # compiled and every C# inheritance edge was silently dropped.
+        #
+        # The alternations are not decoration. A base written `Base<T>` parses
+        # as `generic_name`, not `identifier`, so an identifier-only pattern
+        # drops `: Repository<Order>` and `: IEnumerable<T>` — everyday .NET.
+        # Interfaces, records and structs carry their own `base_list` under
+        # their own node types, and matching only `class_declaration` meant
+        # `interface IX : IY` produced nothing.
         'inheritance': """
-            (class_declaration
-                name: (identifier) @class_name
-                bases: (base_list
-                    (identifier) @base)) @class_def
+            [
+              (class_declaration
+                  name: (identifier) @class_name
+                  (base_list
+                      [(identifier) @base
+                       (generic_name (identifier) @base)]))
+              (interface_declaration
+                  name: (identifier) @class_name
+                  (base_list
+                      [(identifier) @base
+                       (generic_name (identifier) @base)]))
+              (record_declaration
+                  name: (identifier) @class_name
+                  (base_list
+                      [(identifier) @base
+                       (generic_name (identifier) @base)]))
+              (struct_declaration
+                  name: (identifier) @class_name
+                  (base_list
+                      [(identifier) @base
+                       (generic_name (identifier) @base)]))
+            ] @class_def
         """,
     },
     'typescript': {
@@ -408,7 +440,10 @@ class TreeSitterParser:
         """Initialize parser with lazy loading."""
         self.parsers: Dict[str, Any] = {}  # Lazy-loaded parsers per language
         self.languages: Dict[str, Any] = {}  # Language objects
-        self.compiled_queries: Dict[str, Dict[str, Any]] = {}  # Compiled queries
+        # "<language>:<query_name>" -> compiled Query, or None when the query
+        # does not compile against the installed grammar. The None entries are
+        # load-bearing: see _compile_cached.
+        self.compiled_queries: Dict[str, Optional[Any]] = {}
 
     def supports_extension(self, ext: str) -> bool:
         """Check if file extension is supported."""
@@ -424,39 +459,60 @@ class TreeSitterParser:
         if language not in self.parsers:
             try:
                 parser_name = _resolve_parser_name(language)
-                self.parsers[language] = get_parser(parser_name)
-                self.languages[language] = get_language(parser_name)
+                # Both locals first, then publish together. Assigning
+                # `self.parsers` before `get_language` returns would leave the
+                # two dicts disagreeing if the second call raised: the retry
+                # returns early on `language not in self.parsers` and every
+                # reader of `self.languages[language]` then hits a KeyError
+                # that has nothing to do with the real failure.
+                loaded_parser = get_parser(parser_name)
+                loaded_language = get_language(parser_name)
+                self.parsers[language] = loaded_parser
+                self.languages[language] = loaded_language
                 logger.debug(f"Loaded tree-sitter parser for {language}")
             except Exception as e:
                 logger.error(f"Failed to load parser for {language}: {e}")
                 raise
         return self.parsers[language]
 
+    def _compile_cached(self, cache_key: str, language: str, query_text: str):
+        """Compile `query_text` once per parser instance, caching the outcome.
+
+        Failures are cached as None, not just logged. A query that fails to
+        compile against the installed grammar fails identically for every
+        subsequent file, so recompiling per file re-pays the cost and re-emits
+        the warning: one run over 175 TypeScript files buried its answer under
+        9,699 identical lines. Caching the failure makes it one line per
+        (language, query) per process, which is what the operator needs to see.
+        """
+        if cache_key in self.compiled_queries:
+            return self.compiled_queries[cache_key]
+
+        lang_obj = self.languages.get(language)
+        if not lang_obj:
+            # Ensure language is loaded
+            self._get_parser(language)
+            lang_obj = self.languages[language]
+
+        try:
+            # tree-sitter 0.23+: Query(language, text). Older
+            # Language.query(text) is deprecated and removed in
+            # newer versions.
+            self.compiled_queries[cache_key] = Query(lang_obj, query_text)
+            logger.debug(f"Compiled query {cache_key}")
+        except Exception as e:
+            self.compiled_queries[cache_key] = None
+            logger.warning(f"Failed to compile query {cache_key}: {e}")
+
+        return self.compiled_queries[cache_key]
+
     def _get_query(self, language: str, query_name: str):
         """Get or compile query for language."""
-        cache_key = f"{language}:{query_name}"
-        if cache_key not in self.compiled_queries:
-            if language not in QUERIES or query_name not in QUERIES[language]:
-                return None
-
-            query_text = QUERIES[language][query_name]
-            lang_obj = self.languages.get(language)
-            if not lang_obj:
-                # Ensure language is loaded
-                self._get_parser(language)
-                lang_obj = self.languages[language]
-
-            try:
-                # tree-sitter 0.23+: Query(language, text). Older
-                # Language.query(text) is deprecated and removed in
-                # newer versions.
-                self.compiled_queries[cache_key] = Query(lang_obj, query_text)
-                logger.debug(f"Compiled query {cache_key}")
-            except Exception as e:
-                logger.warning(f"Failed to compile query {cache_key}: {e}")
-                return None
-
-        return self.compiled_queries.get(cache_key)
+        if language not in QUERIES or query_name not in QUERIES[language]:
+            return None
+        return self._compile_cached(
+            f"{language}:{query_name}", language, QUERIES[language][query_name]
+        )
 
     @staticmethod
     def _run_query(query, root_node) -> List[Tuple[Any, str]]:
@@ -588,13 +644,15 @@ class TreeSitterParser:
         content_bytes = content.encode('utf8')
 
         for query_name, query_text in EDGE_QUERIES[language].items():
-            try:
-                lang_obj = self.languages.get(language)
-                if not lang_obj:
-                    self._get_parser(language)
-                    lang_obj = self.languages[language]
+            # Cache-keyed separately from QUERIES: a language can define both
+            # a chunk query and an edge query under the same name.
+            query = self._compile_cached(
+                f"{language}:edge:{query_name}", language, query_text
+            )
+            if query is None:
+                continue
 
-                query = Query(lang_obj, query_text)
+            try:
                 captures = self._run_query(query, tree.root_node)
             except Exception as e:
                 logger.debug(f"Edge query {query_name} failed for {language}: {e}")

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -55,6 +55,50 @@ STALENESS_THRESHOLD = 0.1  # 10% of files changed triggers full reindex warning
 REFRESH_BUDGET_MS = 5000  # Max 5s for opportunistic refresh
 REFRESH_MAX_CHUNKS = 100  # Max chunks to update during opportunistic refresh
 
+# Directory names that never contain source worth indexing. Matched against
+# every path component, so `a/node_modules/b/c.js` is excluded by the second
+# component alone.
+#
+# `.worktrees` and `.claude` are here for the same reason as `node_modules`,
+# and they are the ones that actually bit: a git worktree checked out inside
+# the repo is a *second copy of the repository*, so without this its files
+# compete for index slots against the originals they duplicate. One .NET repo
+# indexed 83 files, all of them Python, all of them from a worktree.
+EXCLUDED_DIR_NAMES = frozenset({
+    # VCS internals and nested checkouts
+    '.git', '.hg', '.svn', '.worktrees', 'worktrees',
+    # Agent tooling scratch space (worktrees, review corpora, caches)
+    '.claude', '.neo', '.codex', '.car',
+    # Dependency trees
+    'node_modules', 'bower_components', 'site-packages', 'Pods', 'Carthage',
+    # Build output whose names are not plausible source directories
+    'obj', '__pycache__',
+    '.next', '.nuxt', '.svelte-kit', '.output',
+    # Virtualenvs and tool caches
+    '.venv', 'venv', '.tox', '.nox', '.eggs',
+    '.mypy_cache', '.pytest_cache', '.ruff_cache',
+    # Editor / IDE
+    '.idea', '.vscode', '.vs',
+})
+
+# Matching is exact and case-sensitive, so `Bin/` and `Build/` (VS-era .NET
+# layouts) are not matched by name. That is deliberate rather than an
+# oversight: a case-insensitive rule would also swallow a `Build/` package
+# that is real source, and the gitignore filter below catches the generated
+# ones under whatever casing the repo actually uses.
+#
+# Deliberately NOT in the set above: `bin`, `build`, `out`, `target`, `dist`,
+# `vendor`. Every one of them is real source somewhere — `bin/` holds
+# checked-in helper scripts and Rust binary crates (`src/bin/main.rs`),
+# `target` and `out` are ordinary package names outside Cargo, `vendor` is
+# source the user may well be asking about. A sweep of three repos on the
+# machine this was written on found 254 git-tracked source files under `bin/`
+# or `vendor/`. Repos that generate into those directories gitignore them, and
+# the gitignore filter below already catches that case. The asymmetry decides
+# it: excluding a real source directory hides code permanently and invisibly,
+# while indexing some generated code only spends slots, and the build report
+# now shows that.
+
 
 @dataclass
 class CodeChunk:
@@ -164,6 +208,9 @@ class ProjectIndex:
         self.faiss_index: Optional[Any] = None
         self.embedding_model: Optional[TextEmbedding] = None
         self.parser: Optional[TreeSitterParser] = None  # Lazy-initialized
+        # Populated by build_index; describes what the cap left out. Not
+        # persisted — it describes one build, not the index on disk.
+        self.selection_report: Optional[Dict[str, Any]] = None
 
         # Load existing index if available
         if self.snapshot_path.exists():
@@ -291,6 +338,306 @@ class ProjectIndex:
             os.unlink(tmp_name)
             raise
 
+    def _build_exclusion_filter(self):
+        """Return a predicate deciding whether a path is unfit to index.
+
+        Two independent filters, because neither alone is enough:
+
+        - `EXCLUDED_DIR_NAMES`, which catches what a repo forgot to ignore.
+          `.claude/` tooling corpora and in-repo worktrees are routinely
+          untracked-but-not-gitignored, and a worktree is a second copy of
+          the repository competing with the originals for index slots.
+        - The repo's own `.gitignore`, read with the same helper
+          `context_gatherer` already uses, so prompt assembly and the index
+          agree on what counts as source rather than each having a private
+          opinion.
+
+        `should_ignore` only ever tests the path it is handed, so a file
+        under a gitignored directory does not match on its own — the walk in
+        `context_gatherer.iter_paths` prunes those directories separately.
+        This reproduces that by testing each ancestor directory, memoized so
+        a directory is judged once no matter how many files sit under it.
+
+        Inherits one limitation from the shared helper: negation patterns
+        (`!keep.py`) are ignored, so a re-included file stays excluded.
+        """
+        from neo.context_gatherer import load_gitignore_patterns, should_ignore
+
+        patterns = load_gitignore_patterns(str(self.repo_root))
+        verdicts: Dict[tuple, bool] = {}
+
+        def dir_excluded(parts: tuple) -> bool:
+            if parts in verdicts:
+                return verdicts[parts]
+            verdicts[parts] = (
+                (len(parts) > 1 and dir_excluded(parts[:-1]))
+                or parts[-1] in EXCLUDED_DIR_NAMES
+                or should_ignore("/".join(parts), patterns, is_dir=True)
+            )
+            return verdicts[parts]
+
+        def excluded(path: Path) -> bool:
+            try:
+                rel = path.relative_to(self.repo_root)
+            except ValueError:
+                return True
+            if rel.parts[:-1] and dir_excluded(rel.parts[:-1]):
+                return True
+            return should_ignore(rel.as_posix(), patterns)
+
+        return excluded
+
+    @staticmethod
+    def _allocate_slots(counts: Dict[str, int], budget: int) -> Dict[str, int]:
+        """Divide `budget` index slots across languages by repo composition.
+
+        Proportional, with a floor of one slot per language present. Both
+        halves matter, and each fixes a different way of producing an index
+        that cannot answer a question about the repository:
+
+        - Proportional, because glob order is not a ranking. Concatenating
+          `**/*.py` before `**/*.cs` and slicing gave a .NET backend of 4,272
+          C# files an index of 83 Python files and zero C#.
+        - Floor of one, because proportion alone rounds small languages to
+          nothing. The same repo's 18 Python files deserve a slot; they just
+          do not deserve all 100 of them.
+
+        A language allocated more slots than it has files hands the surplus
+        back, largest language first, so no budget is left on the table.
+        """
+        langs = [lang for lang, n in counts.items() if n > 0]
+        if not langs or budget <= 0:
+            return {}
+
+        # Not enough budget to seat every language: the biggest ones take it.
+        if budget <= len(langs):
+            ordered = sorted(langs, key=lambda lang: (-counts[lang], lang))
+            return {lang: 1 for lang in ordered[:budget]}
+
+        total = sum(counts[lang] for lang in langs)
+        shared = budget - len(langs)  # one slot per language already reserved
+        alloc = {
+            lang: 1 + int(counts[lang] / total * shared) for lang in langs
+        }
+
+        # Nobody gets more slots than they have files; redistribute the rest.
+        # This loop also absorbs the slack left by rounding every share down,
+        # so no separate largest-remainder pass is needed — which language
+        # receives a ±1 rounding slot is not observable against a within-
+        # language ranking that is itself only a path heuristic.
+        alloc = {lang: min(alloc[lang], counts[lang]) for lang in langs}
+        free = budget - sum(alloc.values())
+        while free > 0:
+            hungry = sorted(
+                (lang for lang in langs if alloc[lang] < counts[lang]),
+                key=lambda lang: (-counts[lang], lang),
+            )
+            if not hungry:
+                break
+            for lang in hungry:
+                if free == 0:
+                    break
+                alloc[lang] += 1
+                free -= 1
+
+        return alloc
+
+    @staticmethod
+    def _cap_chunks(chunks: List[CodeChunk], cap: int) -> List[CodeChunk]:
+        """Trim to `cap` by round-robin across files, never by slicing.
+
+        Slicing a language-ordered list is the same defect the file budget
+        was just fixed for, one function later and with the fix's own work
+        as its victim. Chunks arrive grouped by file, and files arrive
+        grouped by language, so `chunks[:1000]` on a 300-file C# repo kept
+        1000 C# chunks and dropped every TypeScript and Python chunk the
+        allocator had just fought to include — 63 of 100 selected files
+        contributed nothing at all.
+
+        Round-robin needs no language awareness: taking every file's first
+        chunk before any file's second means the apportionment already done
+        at file-selection time carries through, and every selected file is
+        represented as long as there are at least as many slots as files
+        (100 files against a 1000-chunk cap by default).
+        """
+        if len(chunks) <= cap:
+            return chunks
+
+        by_file: Dict[str, List[CodeChunk]] = {}
+        for chunk in chunks:
+            by_file.setdefault(chunk.file_path, []).append(chunk)
+
+        kept: List[CodeChunk] = []
+        depth = 0
+        while len(kept) < cap:
+            # `added` rather than a precomputed max depth: the early return
+            # above guarantees more chunks than slots, so the cap is always
+            # what stops this — but a loop whose termination depends on an
+            # invariant established elsewhere should still be able to stop
+            # on its own.
+            added = False
+            for group in by_file.values():
+                if depth < len(group):
+                    kept.append(group[depth])
+                    added = True
+                    if len(kept) >= cap:
+                        break
+            if not added:
+                break
+            depth += 1
+        return kept
+
+    def _select_files(
+        self, file_patterns: List[str], max_files: int
+    ) -> Tuple[List[Tuple[Path, str]], Dict[str, Any]]:
+        """Pick which files to index, and report on what was left out.
+
+        Returns (selected, report) where `selected` is a list of
+        (path, content_hash) pairs — the hash is computed here to reject
+        duplicate content, and returned so the caller need not recompute it.
+
+        The report is what makes truncation visible. `--index` previously
+        printed "Built index" and exited 0 whether it had indexed the
+        repository or 83 files of a stale worktree copy.
+        """
+        from neo.languages import language_for_path
+
+        # Deduplicate at the path level first: overlapping patterns would
+        # otherwise present the same file twice — and would double-count it
+        # in the exclusion tally the operator reads.
+        is_excluded = self._build_exclusion_filter()
+        candidates: Dict[Path, None] = {}
+        excluded_paths: set = set()
+        for pattern in file_patterns:
+            for path in self.repo_root.glob(pattern):
+                if is_excluded(path):
+                    excluded_paths.add(path)
+                    continue
+                candidates.setdefault(path, None)
+        excluded = len(excluded_paths)
+
+        # Security checks live here so a rejected file backfills from the
+        # same language's remaining candidates rather than costing a slot.
+        repo_root_resolved = self.repo_root.resolve()
+        by_language: Dict[str, List[Path]] = {}
+        for path in candidates:
+            # Symlink check comes first and uses lstat: both is_file() and
+            # resolve() follow the link, and the point of rejecting symlinks
+            # is to not touch what they point at.
+            if path.is_symlink():
+                logger.warning(f"Skipping symlink: {path}")
+                continue
+            # Also covers the file-vanished-since-glob race; a missing path is
+            # not a file, and the slot it would have taken backfills below.
+            if not path.is_file():
+                logger.debug(f"Skipping non-file path: {path}")
+                continue
+            try:
+                path.resolve().relative_to(repo_root_resolved)
+            except ValueError:
+                logger.warning(f"Skipping file outside repo: {path}")
+                continue
+            language = language_for_path(path) or path.suffix.lstrip('.')
+            by_language.setdefault(language, []).append(path)
+
+        # Rank within a language: shallower paths first, then alphabetical.
+        # This is a weak heuristic, not centrality — but it is deterministic,
+        # and it beats whatever order the filesystem happened to yield.
+        for paths in by_language.values():
+            paths.sort(key=lambda p: (len(p.relative_to(self.repo_root).parts), str(p)))
+
+        counts = {lang: len(paths) for lang, paths in by_language.items()}
+        eligible = sum(counts.values())
+        allocation = self._allocate_slots(counts, max_files)
+
+        selected: List[Tuple[Path, str]] = []
+        seen_hashes: Dict[str, Path] = {}
+        duplicates = 0
+        examined = 0
+        per_language: Dict[str, Dict[str, int]] = {}
+
+        # One iterator per language, consumed by `take` and then resumed by
+        # the refill pass — so a file examined in the quota pass is never
+        # examined again.
+        pending = {
+            lang: iter(by_language[lang])
+            for lang in sorted(by_language, key=lambda lang: (-counts[lang], lang))
+        }
+
+        def take(language: str, quota: int) -> int:
+            """Consume up to `quota` usable files from `language`."""
+            nonlocal duplicates, examined
+            taken = 0
+            while taken < quota:
+                path = next(pending[language], None)
+                if path is None:
+                    break
+                examined += 1
+                file_hash = self._compute_file_hash(path)
+                if not file_hash:
+                    # Unreadable, or vanished since the glob. Not counted
+                    # against the quota, so the next candidate takes its slot.
+                    continue
+                # Content-identical files must not each consume a slot: they
+                # produce identical chunks and identical embeddings, so the
+                # second copy buys nothing and costs a file the index could
+                # have held instead.
+                #
+                # Two accepted costs. A skipped duplicate never enters
+                # `snapshot.file_hashes`, so `check_staleness` will not
+                # notice if the copies later diverge — it is not indexed, so
+                # there is nothing stale to refresh, and the next full build
+                # re-decides. And genuinely distinct files that happen to be
+                # byte-identical (barrel `index.ts`, empty `__init__.py`,
+                # generated boilerplate) lose their path from the index; the
+                # content is still there under the first path that had it.
+                if file_hash in seen_hashes:
+                    duplicates += 1
+                    logger.debug(f"Skipping duplicate content: {path}")
+                    continue
+                seen_hashes[file_hash] = path
+                selected.append((path, file_hash))
+                taken += 1
+            return taken
+
+        for language in pending:
+            per_language[language] = {
+                'selected': take(language, allocation.get(language, 0)),
+                'eligible': counts[language],
+            }
+
+        # Refill across languages. `take` backfills within a language, but a
+        # language whose remaining candidates are all duplicates (or that ran
+        # out entirely) leaves its quota unspent — and dedup must not quietly
+        # shrink the index below what the operator allowed. Largest language
+        # first, matching how `_allocate_slots` redistributes.
+        for language in pending:
+            if len(selected) >= max_files:
+                break
+            per_language[language]['selected'] += take(
+                language, max_files - len(selected)
+            )
+
+        report = {
+            'eligible': eligible,
+            'selected': len(selected),
+            'excluded': excluded,
+            'duplicates': duplicates,
+            'max_files': max_files,
+            # Truncated means THE CAP BOUND US, and the test that cannot be
+            # fooled is whether any candidate went unexamined: the loops stop
+            # pulling from a language's iterator precisely when the budget is
+            # spent. Counting instead on `selected < eligible` blamed dedup on
+            # the cap — 7 files with 5 duplicates under a cap of 1000 reported
+            # "2 of 7 eligible files (capped at --max-files=1000)", naming a
+            # knob that was never reached and that raising cannot help. So did
+            # `selected >= max_files`, whenever max_files landed exactly on the
+            # unique-file count. Duplicates and exclusions get their own lines.
+            'truncated': examined < eligible,
+            'per_language': per_language,
+        }
+        return selected, report
+
     def build_index(self, file_patterns: List[str] = None, languages: List[str] = None, max_files: int = 100):
         """
         Build initial index for repository.
@@ -334,41 +681,16 @@ class ProjectIndex:
         self.snapshot = IndexSnapshot()
         self.snapshot.commit_hash = self._get_git_commit()
 
-        # Find files to index
-        files_to_index = []
-        for pattern in file_patterns:
-            files_to_index.extend(self.repo_root.glob(pattern))
-
-        # Limit total files
-        files_to_index = files_to_index[:max_files]
+        # Find files to index: excluded paths dropped, ranked across
+        # languages by repo composition, then cut to `max_files`.
+        files_to_index, selection = self._select_files(file_patterns, max_files)
+        self.selection_report = selection
         self.snapshot.total_files = len(files_to_index)
 
         # Extract chunks and edges from each file
         all_chunks = []
         all_edges = []
-        for file_path in files_to_index:
-            # Security: Reject symlinks and paths outside repo
-
-            # Defensive: Check existence first (handles race conditions)
-            if not file_path.exists():
-                logger.warning(f"Skipping non-existent path: {file_path}")
-                continue
-
-            # Check symlinks before resolving (prevents info disclosure)
-            if file_path.is_symlink():
-                logger.warning(f"Skipping symlink: {file_path}")
-                continue
-
-            # Validate path containment using pathlib
-            resolved_path = file_path.resolve()
-            repo_root_resolved = self.repo_root.resolve()
-
-            try:
-                resolved_path.relative_to(repo_root_resolved)
-            except ValueError:
-                logger.warning(f"Skipping file outside repo: {file_path} (resolves to {resolved_path})")
-                continue
-
+        for file_path, file_hash in files_to_index:
             rel_path = file_path.relative_to(self.repo_root)
             chunks = self._extract_chunks_from_file(file_path, str(rel_path))
             all_chunks.extend(chunks)
@@ -377,14 +699,32 @@ class ProjectIndex:
             edges = self._extract_edges_from_file(file_path, str(rel_path))
             all_edges.extend(edges)
 
-            # Track file hash
-            file_hash = self._compute_file_hash(file_path)
+            # Hash was computed during selection (it is what rejects
+            # duplicate content), so reuse it rather than re-reading.
             self.snapshot.file_hashes[str(rel_path)] = file_hash
 
-        # Limit total chunks (take top N by some scoring)
-        if len(all_chunks) > MAX_CHUNKS_PER_REPO:
-            logger.warning(f"Too many chunks ({len(all_chunks)}), limiting to {MAX_CHUNKS_PER_REPO}")
-            all_chunks = all_chunks[:MAX_CHUNKS_PER_REPO]
+        # Limit total chunks. Round-robin across files rather than slicing,
+        # for exactly the reason the file budget is apportioned rather than
+        # sliced — see _cap_chunks.
+        total_chunks = len(all_chunks)
+        all_chunks = self._cap_chunks(all_chunks, MAX_CHUNKS_PER_REPO)
+        selection['chunks_extracted'] = total_chunks
+        selection['chunks_kept'] = len(all_chunks)
+        selection['chunks_capped'] = len(all_chunks) < total_chunks
+        selection['max_chunks'] = MAX_CHUNKS_PER_REPO
+        # Round-robin represents every file only while there are at least as
+        # many chunk slots as files. `MAX_CHUNKS_PER_REPO` is fixed at 1000 and
+        # `--max-files` is operator-settable, so above that the guarantee stops
+        # holding — and `truncated` is False in exactly that case, because the
+        # file cap was never the binding constraint. Report the shortfall
+        # directly: an operator who raises --max-files to 3000 and is told
+        # nothing was truncated should not have to discover that two thirds of
+        # their files carry no chunks at all.
+        selection['files_with_chunks'] = len({c.file_path for c in all_chunks})
+        if selection['chunks_capped']:
+            logger.warning(
+                f"Too many chunks ({total_chunks}), limiting to {MAX_CHUNKS_PER_REPO}"
+            )
 
         self.chunks = all_chunks
         self.edges = all_edges

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -707,11 +707,30 @@ class ProjectIndex:
         # for exactly the reason the file budget is apportioned rather than
         # sliced — see _cap_chunks.
         total_chunks = len(all_chunks)
+        # Measured BEFORE the cap, and that ordering is the whole point. A
+        # selected file can end up absent from the index for two unrelated
+        # reasons, and only one of them is a cap:
+        #
+        #   - it yielded no chunks at all, because it holds no function,
+        #     class, interface or struct for the grammar to match. An empty
+        #     `__init__.py`, an enum-only `.cs`, a type-alias-only `.ts`. No
+        #     cap is involved and no cap setting changes it.
+        #   - it yielded chunks and the cap took every one of them.
+        #
+        # Without this line the two are indistinguishable downstream, and the
+        # report blamed the chunk cap for both. It printed "the 1000-chunk cap
+        # is below the 25 files selected; lower --max-files" for a build that
+        # kept 559 of 559 chunks — naming a cap that had not fired, on
+        # evidence `chunks_capped` contradicted one key over, and prescribing
+        # a remedy that indexes strictly less. Keep the causes separate here
+        # so the console never has to guess between them.
+        files_producing_chunks = len({c.file_path for c in all_chunks})
         all_chunks = self._cap_chunks(all_chunks, MAX_CHUNKS_PER_REPO)
         selection['chunks_extracted'] = total_chunks
         selection['chunks_kept'] = len(all_chunks)
         selection['chunks_capped'] = len(all_chunks) < total_chunks
         selection['max_chunks'] = MAX_CHUNKS_PER_REPO
+        selection['files_producing_chunks'] = files_producing_chunks
         # Round-robin represents every file only while there are at least as
         # many chunk slots as files. `MAX_CHUNKS_PER_REPO` is fixed at 1000 and
         # `--max-files` is operator-settable, so above that the guarantee stops

--- a/tests/test_context_file_truncation.py
+++ b/tests/test_context_file_truncation.py
@@ -1,0 +1,262 @@
+"""Tests for how the reasoning prompt renders REPOSITORY CONTEXT files.
+
+Regression coverage for the failure where every context file was clipped to
+its first 3000 characters with no marker, while the banner reported the
+pre-truncation byte count. The model reasoned about the top of a file
+believing it had the whole thing, and the operator was told it had been sent
+several times more than it had.
+"""
+
+import re
+
+from neo.engine import (
+    _CONTEXT_FILE_CHARS,
+    _IMPORTANT_FILE_CHARS,
+    _MAX_CONTEXT_FILES,
+    NeoEngine,
+)
+from neo.models import ContextFile
+
+
+def _file(path: str, size: int) -> ContextFile:
+    """A context file of exactly `size` characters."""
+    return ContextFile(path=path, content="x" * size)
+
+
+def _render(files):
+    """Returns (sections, banner) — the third element is covered separately."""
+    sections, banner, _visible = NeoEngine._render_context_files(files)
+    return sections, banner
+
+
+class TestTruncationIsMarked:
+    def test_oversized_file_carries_a_marker(self):
+        """The assertion the issue asks for: a clipped file says it was clipped.
+
+        Without this the model cannot tell "the file ends here" from "the
+        file was cut", so it answers questions about absence from a fragment.
+        """
+        sections, _ = _render([_file("src/Service.cs", _CONTEXT_FILE_CHARS + 5000)])
+
+        assert "[truncated:" in sections[0]
+
+    def test_marker_states_how_much_was_dropped(self):
+        sections, _ = _render([_file("src/Service.cs", _CONTEXT_FILE_CHARS + 5000)])
+
+        assert "5000 of 8000 characters not shown" in sections[0]
+
+    def test_file_within_the_cap_is_not_marked(self):
+        """A file that fits must not claim to have been cut."""
+        sections, _ = _render([_file("src/Small.cs", 100)])
+
+        assert "[truncated" not in sections[0]
+
+    def test_content_is_still_capped(self):
+        """The marker is added to the cut, not instead of it."""
+        sections, _ = _render([_file("src/Service.cs", 50_000)])
+
+        body = sections[0].split("---\n", 1)[1]
+        payload = body.split("\n... [truncated:", 1)[0]
+        assert len(payload) == _CONTEXT_FILE_CHARS
+
+    def test_important_files_get_the_larger_cap(self):
+        """README/CLAUDE.md/architecture keep their 8000-char allowance."""
+        sections, _ = _render([_file("docs/README.md", 50_000)])
+
+        payload = sections[0].split("---\n", 1)[1].split("\n... [truncated:", 1)[0]
+        assert len(payload) == _IMPORTANT_FILE_CHARS
+
+    def test_every_oversized_file_is_marked(self):
+        files = [_file(f"src/F{i}.cs", _CONTEXT_FILE_CHARS + 100) for i in range(5)]
+        sections, _ = _render(files)
+
+        assert all("[truncated:" in s for s in sections)
+
+
+class TestBannerReportsWhatWasSent:
+    def test_banner_counts_post_truncation_size(self):
+        """The banner's count must equal what was actually included.
+
+        Previously it summed `len(f.content)` before the cut and labelled the
+        result "bytes", so an operator reading "340000 bytes" concluded the
+        model had seen 340 KB of source when it had seen a fraction of that.
+        The unit is now stated as chars, which is what the caps and the sum
+        actually measure.
+        """
+        files = [_file(f"src/F{i}.cs", 100_000) for i in range(3)]
+        _, banner = _render(files)
+
+        sent = 3 * _CONTEXT_FILE_CHARS
+        assert f"{sent} of {3 * 100_000} chars" in banner
+
+    def test_banner_count_matches_rendered_content(self):
+        """Cross-check the banner against the sections actually produced."""
+        files = [
+            _file("src/Big.cs", 40_000),
+            _file("src/Small.cs", 120),
+            _file("docs/README.md", 30_000),
+        ]
+        sections, banner = _render(files)
+
+        reported = int(re.search(r"\((?:.*?), (\d+) of", banner).group(1))
+        rendered = 0
+        for section in sections:
+            body = section.split("---\n", 1)[1]
+            rendered += len(body.split("\n... [truncated:", 1)[0])
+        assert reported == rendered
+
+    def test_banner_omits_the_of_clause_when_nothing_was_cut(self):
+        _, banner = _render([_file("src/Small.cs", 120)])
+
+        assert "120 chars" in banner
+        assert " of " not in banner
+
+    def test_banner_reports_dropped_files(self):
+        """`files[:20]` silently discarded the rest; now it says so."""
+        files = [_file(f"src/F{i}.cs", 10) for i in range(_MAX_CONTEXT_FILES + 4)]
+        _, banner = _render(files)
+
+        assert f"{_MAX_CONTEXT_FILES} of {_MAX_CONTEXT_FILES + 4} files" in banner
+
+    def test_only_shown_files_are_rendered(self):
+        files = [_file(f"src/F{i}.cs", 10) for i in range(_MAX_CONTEXT_FILES + 4)]
+        sections, _ = _render(files)
+
+        assert len(sections) == _MAX_CONTEXT_FILES
+
+    def test_banner_counts_truncated_files(self):
+        files = [
+            _file("src/Big1.cs", 40_000),
+            _file("src/Big2.cs", 40_000),
+            _file("src/Small.cs", 10),
+        ]
+        _, banner = _render(files)
+
+        assert "2 files truncated" in banner
+
+    def test_single_truncated_file_is_singular(self):
+        _, banner = _render([_file("src/Big.cs", 40_000)])
+
+        assert "1 file truncated" in banner
+
+    def test_dropped_files_still_count_toward_total(self):
+        """The 21st file was never sent, and the total must say so."""
+        files = [_file(f"src/F{i}.cs", 100) for i in range(_MAX_CONTEXT_FILES + 1)]
+        _, banner = _render(files)
+
+        sent = _MAX_CONTEXT_FILES * 100
+        total = (_MAX_CONTEXT_FILES + 1) * 100
+        assert f"{sent} of {total} chars" in banner
+
+
+class TestEdgeCases:
+    def test_empty_content_does_not_crash(self):
+        sections, banner = _render([ContextFile(path="src/Empty.cs", content="")])
+
+        assert "src/Empty.cs" in sections[0]
+        assert "0 chars" in banner
+
+    def test_none_content_is_treated_as_empty(self):
+        sections, banner = _render([ContextFile(path="src/None.cs", content=None)])
+
+        assert "src/None.cs" in sections[0]
+        assert "0 chars" in banner
+
+    def test_content_exactly_at_the_cap_is_not_marked(self):
+        """Boundary: `>` not `>=`, so an exactly-fitting file is untouched."""
+        sections, _ = _render([_file("src/Exact.cs", _CONTEXT_FILE_CHARS)])
+
+        assert "[truncated" not in sections[0]
+
+
+class TestVisibleContent:
+    """The third return value: each file cut down to what the model saw."""
+
+    def test_visible_content_is_truncated(self):
+        _, _, visible = NeoEngine._render_context_files(
+            [_file("src/Service.cs", 40_000)]
+        )
+
+        assert len(visible[0].content) == _CONTEXT_FILE_CHARS
+
+    def test_visible_content_carries_no_marker(self):
+        """The marker is prompt prose; downstream scanners must not see it."""
+        _, _, visible = NeoEngine._render_context_files(
+            [_file("src/Service.cs", 40_000)]
+        )
+
+        assert "[truncated" not in visible[0].content
+
+    def test_untruncated_file_is_passed_through_unchanged(self):
+        original = _file("src/Small.cs", 100)
+        _, _, visible = NeoEngine._render_context_files([original])
+
+        assert visible[0] is original
+
+    def test_visible_excludes_files_past_the_cap(self):
+        files = [_file(f"src/F{i}.cs", 10) for i in range(_MAX_CONTEXT_FILES + 4)]
+        _, _, visible = NeoEngine._render_context_files(files)
+
+        assert len(visible) == _MAX_CONTEXT_FILES
+
+
+class TestPromptIntegration:
+    def _engine(self):
+        engine = NeoEngine.__new__(NeoEngine)
+        engine.exemplar_index = None
+        engine.fact_store = None
+        engine.persistent_memory = None
+        engine.context = None
+        engine.codebase_root = "/nonexistent-for-this-test"
+        return engine
+
+    def test_smells_never_cite_a_line_the_model_cannot_see(self):
+        """A finding about invisible code asserts what a bare cut merely invites.
+
+        `scan_files` reads whatever content it is handed. Handed the
+        originals, it emitted `src/Service.cs:401 [todo/warn] HACK: ...` for
+        a file the model was shown to roughly line 215 — a line-numbered
+        claim about text that was never sent.
+        """
+        head = "// padding line\n" * 400          # ~6400 chars, past the cap
+        content = head + "        // HACK: this is broken\n"
+        marker_file = ContextFile(path="src/Service.cs", content=content)
+
+        prompt, _ = self._engine()._format_combined_prompt({
+            'prompt': 'review this',
+            'task_type': 'bugfix',
+            'files': [marker_file],
+        })
+
+        assert "HACK: this is broken" not in prompt
+
+    def test_smells_within_the_visible_window_are_still_reported(self):
+        """The fix must scope the scan, not disable it."""
+        content = "        // HACK: this is broken\n" + "// padding\n" * 400
+        marker_file = ContextFile(path="src/Service.cs", content=content)
+
+        prompt, _ = self._engine()._format_combined_prompt({
+            'prompt': 'review this',
+            'task_type': 'bugfix',
+            'files': [marker_file],
+        })
+
+        assert "HACK: this is broken" in prompt
+
+    def test_marker_reaches_the_assembled_prompt(self, monkeypatch):
+        """End to end: the marker must survive into the text the model sees."""
+        engine = NeoEngine.__new__(NeoEngine)
+        engine.exemplar_index = None
+        engine.fact_store = None
+        engine.persistent_memory = None
+        engine.context = None
+        engine.codebase_root = "/nonexistent-for-this-test"
+
+        prompt, _ = engine._format_combined_prompt({
+            'prompt': 'why does this fail',
+            'task_type': 'bugfix',
+            'files': [_file("src/Service.cs", 40_000)],
+        })
+
+        assert "[truncated:" in prompt
+        assert "REPOSITORY CONTEXT" in prompt

--- a/tests/test_edge_extraction.py
+++ b/tests/test_edge_extraction.py
@@ -59,6 +59,12 @@ public class Circle : Shape
 {
     public override double Area() { return 3.14; }
 }
+
+public class Square : Shape, IComparable
+{
+    public override double Area() { return 1.0; }
+    public int CompareTo(object o) { return 0; }
+}
 '''
 
 SAMPLE_JAVASCRIPT = '''
@@ -130,6 +136,72 @@ class TestCSharpEdges:
         import_edges = [e for e in edges if e.edge_type == "imports"]
         targets = [e.target_symbol for e in import_edges]
         assert any("System" in t for t in targets)
+
+    def test_inheritance_edges(self, parser):
+        """C# had no inheritance assertion, and its query had been broken.
+
+        The grammar exposes `base_list` as an unnamed child of
+        `class_declaration`, not under a `bases:` field, so the query failed to
+        compile and every C# inheritance edge was dropped. Edge-query compile
+        failures log at DEBUG, so nothing surfaced.
+        """
+        edges = parser.extract_edges(Path("test.cs"), SAMPLE_CSHARP, "c_sharp")
+        pairs = [
+            (e.source_symbol, e.target_symbol)
+            for e in edges
+            if e.edge_type == "inherits"
+        ]
+        assert ("Circle", "Shape") in pairs
+
+    def test_inheritance_edges_include_every_base(self, parser):
+        """Each entry of a plain (non-generic) base list yields its own edge."""
+        edges = parser.extract_edges(Path("test.cs"), SAMPLE_CSHARP, "c_sharp")
+        pairs = [
+            (e.source_symbol, e.target_symbol)
+            for e in edges
+            if e.edge_type == "inherits"
+        ]
+        assert ("Square", "Shape") in pairs
+        assert ("Square", "IComparable") in pairs
+
+    def test_generic_base_is_not_dropped(self, parser):
+        """`: Repository<Order>` parses as `generic_name`, not `identifier`.
+
+        An identifier-only pattern compiles fine and silently omits every
+        generic base — which in .NET is most of them.
+        """
+        edges = parser.extract_edges(
+            Path("g.cs"), "class Repo : Base<Order>, IFoo { }\n", "c_sharp"
+        )
+        pairs = [
+            (e.source_symbol, e.target_symbol)
+            for e in edges
+            if e.edge_type == "inherits"
+        ]
+        assert ("Repo", "Base") in pairs
+        assert ("Repo", "IFoo") in pairs
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            ("interface IX : IY { }\n", ("IX", "IY")),
+            ("record Rec : BaseRec { }\n", ("Rec", "BaseRec")),
+            ("struct St : IEquatable<St> { }\n", ("St", "IEquatable")),
+        ],
+    )
+    def test_non_class_declarations_also_yield_edges(self, parser, source, expected):
+        """Interfaces, records and structs carry their own `base_list`.
+
+        Matching only `class_declaration` meant interface-to-interface
+        inheritance produced nothing at all.
+        """
+        edges = parser.extract_edges(Path("x.cs"), source, "c_sharp")
+        pairs = [
+            (e.source_symbol, e.target_symbol)
+            for e in edges
+            if e.edge_type == "inherits"
+        ]
+        assert expected in pairs
 
 
 class TestJavaScriptEdges:

--- a/tests/test_edge_extraction.py
+++ b/tests/test_edge_extraction.py
@@ -203,6 +203,44 @@ class TestCSharpEdges:
         ]
         assert expected in pairs
 
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            ("class A : System.Exception { }\n", ("A", "Exception")),
+            ("class B : My.Ns.Repo<Order> { }\n", ("B", "Repo")),
+            ("class C : global::Foo.Bar { }\n", ("C", "Bar")),
+        ],
+    )
+    def test_qualified_base_is_not_dropped(self, parser, source, expected):
+        """A fully-qualified base parses as `qualified_name`.
+
+        `: System.Exception` and `: Microsoft.AspNetCore.Mvc.ControllerBase`
+        are everyday .NET, and neither `identifier` nor `generic_name` matches
+        them — so an alternation covering only those two compiles fine and
+        drops the edge, exactly as the identifier-only pattern did for
+        generics.
+
+        The captured name is the rightmost segment (`Exception`, not
+        `System`), via the `name:` field, so qualified and unqualified bases
+        land in the graph under one naming convention rather than two.
+        """
+        edges = parser.extract_edges(Path("q.cs"), source, "c_sharp")
+        pairs = [
+            (e.source_symbol, e.target_symbol)
+            for e in edges
+            if e.edge_type == "inherits"
+        ]
+        assert expected in pairs
+
+    def test_declaration_without_bases_yields_no_edge(self, parser):
+        """The four-way alternation must not match a bare declaration.
+
+        Generated patterns are easy to widen past what was intended; this
+        pins the other side of the contract.
+        """
+        edges = parser.extract_edges(Path("p.cs"), "class Plain { }\n", "c_sharp")
+        assert [e for e in edges if e.edge_type == "inherits"] == []
+
 
 class TestJavaScriptEdges:
     def test_import_edges(self, parser):

--- a/tests/test_index_file_selection.py
+++ b/tests/test_index_file_selection.py
@@ -551,10 +551,11 @@ class TestChunkCap:
         report = index.selection_report
         assert report['truncated'] is False       # the file cap never bound
         assert report['selected'] == 6
-        assert report['files_with_chunks'] == 2
+        assert report['files_producing_chunks'] == 6   # every file had chunks
+        assert report['files_with_chunks'] == 2        # the cap took four
 
         printed = "\n".join(_format_selection_report(report))
-        assert "4 selected files contributed no chunks" in printed
+        assert "4 indexed files lost every chunk to the 2-chunk cap" in printed
 
     def test_no_shortfall_line_when_every_file_is_represented(self, tmp_path):
         for i in range(3):
@@ -564,7 +565,77 @@ class TestChunkCap:
         index.build_index(file_patterns=["**/*.py"], max_files=100)
 
         printed = "\n".join(_format_selection_report(index.selection_report))
-        assert "contributed no chunks" not in printed
+        assert "lost every chunk" not in printed
+        assert "yielded no chunks" not in printed
+
+    def test_constructless_file_is_not_blamed_on_the_chunk_cap(self, tmp_path):
+        """A file with nothing to extract is not a cap event.
+
+        `_extract_chunks_from_file` returns [] for any file holding no
+        function, class, interface or struct — an empty `__init__.py`, an
+        enum-only `.cs`, a type-alias-only `.ts`. That is independent of every
+        cap, and no cap setting changes it.
+
+        The first version of this report subtracted post-cap
+        `files_with_chunks` from `selected` and attributed the whole
+        difference to `MAX_CHUNKS_PER_REPO`. Reproduced against the neo repo
+        itself: 25 files selected, 559 of 559 chunks kept, `chunks_capped`
+        False on the same report, and the console still printed "the
+        1000-chunk cap is below the 25 files selected; lower --max-files".
+        The culprit was an empty `tests/__init__.py`, and lowering
+        --max-files would only have indexed less.
+        """
+        _write(tmp_path, "real.py", "def f(): return 1\n")
+        _write(tmp_path, "__init__.py", "")
+        _write(tmp_path, "constants.py", "TIMEOUT = 30\nRETRIES = 3\n")
+
+        index = ProjectIndex(str(tmp_path))
+        index.build_index(file_patterns=["**/*.py"], max_files=100)
+
+        report = index.selection_report
+        assert report['chunks_capped'] is False
+        assert report['selected'] == 3
+        assert report['files_producing_chunks'] == 1
+        assert report['files_with_chunks'] == 1
+
+        printed = "\n".join(_format_selection_report(report))
+        assert "2 selected files yielded no chunks" in printed
+        # The cap did not fire, so it must not be named and no remedy offered.
+        assert "cap" not in printed
+        assert "--max-files" not in printed
+
+    def test_cap_starvation_and_barren_files_are_reported_separately(self, tmp_path):
+        """Both causes at once must not be conflated into either one."""
+        for i in range(4):
+            _write(tmp_path, f"m{i}.py", f"def f{i}(): return {i}\n")
+        _write(tmp_path, "empty.py", "")
+
+        index = ProjectIndex(str(tmp_path))
+        with patch("neo.index.project_index.MAX_CHUNKS_PER_REPO", 2):
+            index.build_index(file_patterns=["**/*.py"], max_files=100)
+
+        report = index.selection_report
+        assert report['selected'] == 5
+        assert report['files_producing_chunks'] == 4
+        assert report['files_with_chunks'] == 2
+
+        printed = "\n".join(_format_selection_report(report))
+        assert "2 indexed files lost every chunk to the 2-chunk cap" in printed
+        assert "1 selected file yielded no chunks" in printed
+
+    def test_report_without_chunk_phase_makes_no_cap_accusation(self):
+        """A selection-only report predates `files_producing_chunks`.
+
+        Falling back to the post-cap count makes `starved` zero rather than
+        equal to `selected`, so a missing key produces silence instead of a
+        fabricated cap event.
+        """
+        printed = "\n".join(_format_selection_report({
+            'eligible': 5, 'selected': 5, 'excluded': 0, 'duplicates': 0,
+            'max_files': 100, 'truncated': False, 'per_language': {},
+            'files_with_chunks': 5, 'max_chunks': 1000,
+        }))
+        assert printed == ""
 
     def test_no_chunk_cap_flag_when_everything_fits(self, tmp_path):
         _write(tmp_path, "a.py", "def a(): return 1\n")

--- a/tests/test_index_file_selection.py
+++ b/tests/test_index_file_selection.py
@@ -1,0 +1,611 @@
+"""Tests for which files `ProjectIndex.build_index` chooses to index.
+
+Regression coverage for the failure where `neo --index` on a .NET repo
+produced an index containing zero C#: file patterns were globbed in list
+order and concatenated, then sliced to `max_files`, so whichever language
+appeared first in `file_patterns` exhausted the budget. A repo of 4,272 C#
+files indexed 83 Python files — 95 of them from a git worktree checked out
+inside the repo — and exited 0 reporting success.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from neo.cli import _format_selection_report
+from neo.index.project_index import CodeChunk, ProjectIndex
+
+
+DEFAULT_PATTERNS = ["**/*.py", "**/*.cs", "**/*.ts", "**/*.tsx", "**/*.js"]
+
+
+def _write(root: Path, rel: str, content: str = "") -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Default to unique content so files are not treated as duplicates.
+    path.write_text(content or f"// {rel}\n")
+    return path
+
+
+@pytest.fixture
+def dotnet_repo(tmp_path):
+    """A repo shaped like the one in the report: mostly C#, some TS, a
+    little Python, plus a worktree full of Python that used to win.
+    """
+    for i in range(300):
+        _write(tmp_path, f"src/Services/Service{i}.cs", f"public class S{i} {{}}\n")
+    for i in range(20):
+        _write(tmp_path, f"web/comp{i}.ts", f"export class C{i} {{}}\n")
+    for i in range(5):
+        _write(tmp_path, f"adws/tool{i}.py", f"def tool{i}(): return {i}\n")
+    for i in range(200):
+        _write(tmp_path, f".worktrees/PAR-1/adws/poll{i}.py", f"def poll{i}(): pass\n")
+    return tmp_path
+
+
+class TestLanguageAllocation:
+    """`_allocate_slots` divides the budget by composition, with a floor."""
+
+    def test_dominant_language_gets_most_slots(self):
+        alloc = ProjectIndex._allocate_slots(
+            {'c_sharp': 4272, 'typescript': 54, 'python': 18}, 100
+        )
+        assert alloc['c_sharp'] > 90
+        assert sum(alloc.values()) == 100
+
+    def test_no_present_language_is_eliminated(self):
+        """The floor of one is what "cannot eliminate a language" means.
+
+        Pure proportional allocation rounds 18 files out of 4,344 to zero
+        slots. That is a smaller version of the bug being fixed.
+        """
+        alloc = ProjectIndex._allocate_slots(
+            {'c_sharp': 4272, 'typescript': 54, 'python': 18}, 100
+        )
+        assert alloc['python'] >= 1
+        assert alloc['typescript'] >= 1
+
+    def test_allocation_never_exceeds_available_files(self):
+        """A language cannot be given more slots than it has files."""
+        alloc = ProjectIndex._allocate_slots({'python': 1, 'c_sharp': 5}, 100)
+        assert alloc == {'python': 1, 'c_sharp': 5}
+
+    @pytest.mark.parametrize(
+        "counts,budget",
+        [
+            ({'python': 2, 'c_sharp': 500}, 100),
+            ({'c_sharp': 4272, 'typescript': 54, 'python': 18}, 100),
+            ({'a': 1, 'b': 1, 'c': 500}, 100),
+            ({'go': 7, 'rust': 7}, 5),
+            ({'java': 1000}, 1),
+        ],
+    )
+    def test_no_slot_is_left_on_the_table(self, counts, budget):
+        """Whenever enough files exist, the whole budget is allocated.
+
+        Rounding down per language and capping at each language's file count
+        both shed slots; the redistribution pass is what hands them back
+        rather than silently indexing fewer files than the operator allowed.
+        """
+        alloc = ProjectIndex._allocate_slots(counts, budget)
+
+        expected = min(budget, sum(counts.values()))
+        assert sum(alloc.values()) == expected
+        for lang, slots in alloc.items():
+            assert slots <= counts[lang]
+
+    def test_budget_smaller_than_language_count(self):
+        """With fewer slots than languages, the biggest languages take them."""
+        alloc = ProjectIndex._allocate_slots(
+            {'a': 100, 'b': 50, 'c': 10, 'd': 5}, 2
+        )
+        assert alloc == {'a': 1, 'b': 1}
+
+    def test_empty_and_zero_budget(self):
+        assert ProjectIndex._allocate_slots({}, 100) == {}
+        assert ProjectIndex._allocate_slots({'python': 5}, 0) == {}
+
+
+class TestSelectionAcrossLanguages:
+    def test_dominant_language_is_indexed(self, dotnet_repo):
+        """The headline regression: C# must not be absent from a .NET repo.
+
+        Pre-fix this selection was 100% Python because `**/*.py` is first in
+        the pattern list and the worktree supplied enough files to exhaust
+        the cap before `**/*.cs` was ever globbed.
+        """
+        index = ProjectIndex(str(dotnet_repo))
+        selected, report = index._select_files(DEFAULT_PATTERNS, 100)
+
+        suffixes = [p.suffix for p, _ in selected]
+        assert suffixes.count('.cs') > 80, (
+            f"C# is {suffixes.count('.cs')}/100 of the index of a C# repo"
+        )
+        assert report['per_language']['c_sharp']['selected'] > 80
+
+    def test_no_language_present_is_dropped_entirely(self, dotnet_repo):
+        index = ProjectIndex(str(dotnet_repo))
+        selected, _ = index._select_files(DEFAULT_PATTERNS, 100)
+
+        suffixes = {p.suffix for p, _ in selected}
+        assert {'.cs', '.ts', '.py'} <= suffixes
+
+    def test_pattern_order_does_not_change_composition(self, dotnet_repo):
+        """Selection is a ranking, so reordering the patterns is a no-op.
+
+        This is the property the old code lacked: its output was entirely
+        determined by which pattern happened to be listed first.
+        """
+        index = ProjectIndex(str(dotnet_repo))
+        forward, _ = index._select_files(DEFAULT_PATTERNS, 100)
+        reverse, _ = index._select_files(list(reversed(DEFAULT_PATTERNS)), 100)
+
+        assert sorted(str(p) for p, _ in forward) == sorted(
+            str(p) for p, _ in reverse
+        )
+
+
+class TestExclusions:
+    def test_worktree_files_are_excluded(self, dotnet_repo):
+        index = ProjectIndex(str(dotnet_repo))
+        selected, report = index._select_files(DEFAULT_PATTERNS, 100)
+
+        assert not any('.worktrees' in str(p) for p, _ in selected)
+        assert report['excluded'] == 200
+
+    @pytest.mark.parametrize(
+        "excluded_dir",
+        # Named in EXCLUDED_DIR_NAMES: not plausible source directory names,
+        # and routinely untracked-but-not-gitignored.
+        ['node_modules', '.git', 'obj', '__pycache__', '.venv', '.claude',
+         '.next', '.worktrees', 'worktrees', 'Pods',
+         # Excluded via the shared context_gatherer defaults, so the index
+         # and prompt assembly agree on what counts as source.
+         'dist', 'build', 'venv'],
+    )
+    def test_excluded_directories(self, tmp_path, excluded_dir):
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        _write(tmp_path, f"{excluded_dir}/junk.py", "def junk(): pass\n")
+        _write(tmp_path, f"nested/{excluded_dir}/deep.py", "def deep(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        names = {p.name for p, _ in selected}
+        assert names == {'real.py'}
+
+    @pytest.mark.parametrize("ambiguous_dir", ['bin', 'out', 'target', 'vendor'])
+    def test_ambiguous_directory_names_are_indexed_unless_gitignored(
+        self, tmp_path, ambiguous_dir
+    ):
+        """These names are real source somewhere, so they are not blanket-excluded.
+
+        `bin/` holds checked-in helper scripts, `target` and `out` are ordinary
+        package names outside Cargo, `vendor` is source a user may ask about.
+        A repo that generates into them gitignores them, and that is the layer
+        that should decide — excluding a real source directory hides code
+        permanently, while indexing generated code only spends slots.
+        """
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        _write(tmp_path, f"{ambiguous_dir}/script.py", "def script(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py', 'script.py'}
+
+    @pytest.mark.parametrize("ambiguous_dir", ['bin', 'out', 'target', 'vendor'])
+    def test_ambiguous_directory_is_excluded_when_gitignored(
+        self, tmp_path, ambiguous_dir
+    ):
+        """The repo declaring it generated is what excludes it."""
+        (tmp_path / ".gitignore").write_text(f"{ambiguous_dir}/\n")
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        _write(tmp_path, f"{ambiguous_dir}/script.py", "def script(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+    def test_gitignored_file_is_excluded(self, tmp_path):
+        """The repo's own .gitignore is honored, as it is during prompt
+        assembly — the index used to have no exclusions of any kind."""
+        (tmp_path / ".gitignore").write_text("generated_client.py\n")
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        _write(tmp_path, "generated_client.py", "def gen(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+    def test_file_under_a_gitignored_directory_is_excluded(self, tmp_path):
+        """The ancestor case: `should_ignore` alone tests only the path it
+        is given, so a file inside an ignored directory does not match on
+        its own name. The directory chain has to be walked."""
+        (tmp_path / ".gitignore").write_text("codegen/\n")
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        _write(tmp_path, "codegen/deep/nested/api.py", "def api(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+    def test_excluded_count_is_not_inflated_by_overlapping_patterns(self, tmp_path):
+        """A file matched by two patterns is one excluded path, not two."""
+        _write(tmp_path, "node_modules/pkg/index.js", "module.exports = 1;\n")
+
+        index = ProjectIndex(str(tmp_path))
+        _, report = index._select_files(["**/*.js", "**/*.js"], 100)
+
+        assert report['excluded'] == 1
+
+    def test_a_file_named_like_an_excluded_dir_is_kept(self, tmp_path):
+        """Only directory components are matched, never the filename."""
+        _write(tmp_path, "build.py", "def build(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'build.py'}
+
+
+class TestContentDeduplication:
+    def test_duplicate_content_does_not_consume_a_slot(self, tmp_path):
+        """A second copy of a file must not cost a slot the original needs.
+
+        A worktree is a copy of the repository, so without this the same
+        file competes with itself for the budget.
+        """
+        identical = "def shared():\n    return 1\n"
+        _write(tmp_path, "a/dup.py", identical)
+        _write(tmp_path, "b/dup.py", identical)
+        _write(tmp_path, "c/unique.py", "def unique():\n    return 2\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, report = index._select_files(["**/*.py"], 2)
+
+        assert report['duplicates'] == 1
+        assert len(selected) == 2
+        # The slot freed by the duplicate went to the unique file, not to waste.
+        assert 'unique.py' in {p.name for p, _ in selected}
+
+    def test_unused_quota_refills_across_languages(self, tmp_path):
+        """Dedup must not shrink the index below the cap the operator set.
+
+        Backfilling only within a language leaves a hole: if every remaining
+        Python candidate is a duplicate, Python's quota goes unspent even
+        though unique C# files are sitting right there. The refill pass is
+        what spends it.
+        """
+        identical = "def same():\n    return 1\n"
+        for i in range(8):
+            _write(tmp_path, f"py/dup{i}.py", identical)
+        for i in range(8):
+            _write(tmp_path, f"cs/File{i}.cs", f"public class C{i} {{ int a = {i}; }}\n")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, report = index._select_files(["**/*.py", "**/*.cs"], 10)
+
+        # 8 identical Python files contribute 1 unique file, so 9 unique
+        # files exist against a cap of 10 — every one of them must land.
+        # Quotas alone give python 5 and c_sharp 5, which would stop at 6.
+        assert len(selected) == 9, (
+            f"9 unique files exist under a cap of 10, got {len(selected)}"
+        )
+        assert report['duplicates'] == 7
+        suffixes = [p.suffix for p, _ in selected]
+        assert suffixes.count('.py') == 1
+        assert suffixes.count('.cs') == 8
+
+    def test_refill_does_not_re_examine_files(self, tmp_path):
+        """Each candidate is hashed at most once across both passes."""
+        for i in range(6):
+            _write(tmp_path, f"cs/File{i}.cs", f"public class C{i} {{ int a = {i}; }}\n")
+        _write(tmp_path, "py/only.py", "def only(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        hashed = []
+        original = index._compute_file_hash
+        index._compute_file_hash = lambda p: (hashed.append(p), original(p))[1]
+
+        selected, _ = index._select_files(["**/*.py", "**/*.cs"], 100)
+
+        assert len(hashed) == len(set(hashed)) == len(selected) == 7
+
+    def test_selection_hash_is_the_one_staleness_checks_against(self, tmp_path):
+        """The hash computed during selection is reused, not recomputed.
+
+        `build_index` stopped calling `_compute_file_hash` in its own loop, so
+        what matters is that the value carried over from selection is what
+        `check_staleness` later compares against — otherwise an index would
+        report itself stale the moment it was built.
+        """
+        _write(tmp_path, "a.py", "def a(): return 1\n")
+        _write(tmp_path, "b.py", "def b(): return 2\n")
+
+        index = ProjectIndex(str(tmp_path))
+        index.build_index(file_patterns=["**/*.py"], max_files=10)
+
+        assert set(index.snapshot.file_hashes) == {'a.py', 'b.py'}
+        is_stale, ratio, changed = index.check_staleness()
+        assert changed == []
+        assert is_stale is False
+
+
+class TestSecurityChecksStillApply:
+    def test_symlinks_are_rejected(self, tmp_path):
+        real = _write(tmp_path, "real.py", "def real(): pass\n")
+        (tmp_path / "link.py").symlink_to(real)
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+    def test_broken_symlink_does_not_crash(self, tmp_path):
+        _write(tmp_path, "real.py", "def real(): pass\n")
+        (tmp_path / "dangling.py").symlink_to(tmp_path / "nothing_here.py")
+
+        index = ProjectIndex(str(tmp_path))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+    def test_symlink_is_rejected_without_stating_its_target(self, monkeypatch,
+                                                            tmp_path):
+        """The symlink check must run before anything that follows the link.
+
+        `is_file()` and `resolve()` both dereference, so ordering either of
+        them first would stat the target — which is precisely what rejecting
+        symlinks is meant to avoid.
+        """
+        real = _write(tmp_path, "real.py", "def real(): pass\n")
+        (tmp_path / "link.py").symlink_to(real)
+
+        followed = []
+        original_is_file = Path.is_file
+
+        def tracking_is_file(self):
+            if self.name == 'link.py':
+                followed.append(self)
+            return original_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", tracking_is_file)
+
+        index = ProjectIndex(str(tmp_path))
+        index._select_files(["**/*.py"], 100)
+
+        assert followed == [], "symlink was dereferenced before being rejected"
+
+    def test_symlink_out_of_repo_is_rejected(self, tmp_path):
+        outside = tmp_path.parent / "outside_secret.py"
+        outside.write_text("SECRET = 1\n")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _write(repo, "real.py", "def real(): pass\n")
+        (repo / "escape.py").symlink_to(outside)
+
+        index = ProjectIndex(str(repo))
+        selected, _ = index._select_files(["**/*.py"], 100)
+
+        assert {p.name for p, _ in selected} == {'real.py'}
+
+
+class TestSelectionReport:
+    def test_reports_truncation(self, dotnet_repo):
+        index = ProjectIndex(str(dotnet_repo))
+        _, report = index._select_files(DEFAULT_PATTERNS, 100)
+
+        assert report['truncated'] is True
+        assert report['selected'] == 100
+        assert report['eligible'] == 325  # 300 cs + 20 ts + 5 py, worktree excluded
+
+    def test_dedup_alone_is_not_reported_as_a_cap_truncation(self, tmp_path):
+        """Only the cap may set `truncated` — it names `--max-files` in the
+        message, and raising a cap that was never reached does nothing.
+
+        With 7 files, 5 of them identical, and a cap of 1000, the report used
+        to read "Indexed 2 of 7 eligible files (capped at --max-files=1000)".
+        """
+        identical = "def same():\n    return 1\n"
+        for i in range(5):
+            _write(tmp_path, f"dup{i}.py", identical)
+        _write(tmp_path, "a.py", "def a(): return 1\n")
+        _write(tmp_path, "b.py", "def b(): return 2\n")
+
+        index = ProjectIndex(str(tmp_path))
+        _, report = index._select_files(["**/*.py"], 1000)
+
+        assert report['truncated'] is False
+        assert report['duplicates'] == 4
+        assert _format_selection_report(report) != []  # duplicates still reported
+        assert "--max-files" not in "\n".join(_format_selection_report(report))
+
+    def test_cap_landing_exactly_on_the_unique_count_is_not_truncation(
+        self, tmp_path
+    ):
+        """The only unindexed file is a duplicate, so the cap gained nothing.
+
+        `selected >= max_files` called this truncated because the budget did
+        fill — but raising `--max-files` would still index 2 files, which is
+        the same wrong-knob advice the dedup case produced.
+        """
+        identical = "def same():\n    return 1\n"
+        _write(tmp_path, "a.py", identical)
+        _write(tmp_path, "b.py", identical)
+        _write(tmp_path, "c.py", "def c(): return 2\n")
+
+        index = ProjectIndex(str(tmp_path))
+        _, report = index._select_files(["**/*.py"], 2)
+
+        assert report['selected'] == 2
+        assert report['duplicates'] == 1
+        assert report['truncated'] is False
+        assert "--max-files" not in "\n".join(_format_selection_report(report))
+
+    def test_no_truncation_when_everything_fits(self, tmp_path):
+        _write(tmp_path, "a.py", "def a(): pass\n")
+        _write(tmp_path, "b.py", "def b(): pass\n")
+
+        index = ProjectIndex(str(tmp_path))
+        _, report = index._select_files(["**/*.py"], 100)
+
+        assert report['truncated'] is False
+        assert report['selected'] == report['eligible'] == 2
+
+    def test_build_index_exposes_the_report(self, tmp_path):
+        _write(tmp_path, "a.py", "def a(): return 1\n")
+
+        index = ProjectIndex(str(tmp_path))
+        index.build_index(file_patterns=["**/*.py"], max_files=10)
+
+        assert index.selection_report is not None
+        assert index.selection_report['selected'] == 1
+
+
+class TestChunkCap:
+    """`MAX_CHUNKS_PER_REPO` must not undo the file-level apportionment."""
+
+    def _chunks(self, spec):
+        """Build chunks as `[(file_path, count), ...]`, grouped by file."""
+        out = []
+        for file_path, count in spec:
+            for i in range(count):
+                out.append(CodeChunk(
+                    file_path=file_path,
+                    chunk_id=f"function:f{i}",
+                    content="x",
+                    chunk_type="function",
+                    start_line=1,
+                    end_line=1,
+                ))
+        return out
+
+    def test_under_the_cap_is_returned_unchanged(self):
+        chunks = self._chunks([("a.py", 3), ("b.cs", 4)])
+        assert ProjectIndex._cap_chunks(chunks, 100) == chunks
+
+    def test_cap_is_respected(self):
+        chunks = self._chunks([("a.py", 50), ("b.cs", 50)])
+        assert len(ProjectIndex._cap_chunks(chunks, 10)) == 10
+
+    def test_a_chunk_heavy_language_cannot_evict_the_others(self):
+        """The C1 regression: slicing kept 1000 C# chunks and zero of anything
+        else, discarding the very allocation `_allocate_slots` produced.
+
+        Chunks arrive grouped by file and files arrive grouped by language, so
+        a plain `[:cap]` is language-ordered truncation by another name.
+        """
+        spec = [(f"src/S{i}.cs", 15) for i in range(60)]
+        spec += [(f"web/c{i}.ts", 2) for i in range(7)]
+        spec += [(f"adws/t{i}.py", 1) for i in range(2)]
+        kept = ProjectIndex._cap_chunks(self._chunks(spec), 100)
+
+        suffixes = {Path(c.file_path).suffix for c in kept}
+        assert suffixes == {'.cs', '.ts', '.py'}
+
+    def test_every_file_is_represented_when_slots_allow(self):
+        """Round-robin means each file keeps a chunk before any keeps two."""
+        spec = [(f"src/S{i}.cs", 15) for i in range(60)]
+        spec += [(f"web/c{i}.ts", 2) for i in range(7)]
+        chunks = self._chunks(spec)
+        kept = ProjectIndex._cap_chunks(chunks, 100)
+
+        assert len({c.file_path for c in kept}) == 67
+
+    def test_build_index_reports_the_chunk_cap(self, tmp_path):
+        """The cap was previously invisible: `--index` printed success either way."""
+        for i in range(4):
+            body = "\n".join(f"def f{i}_{j}(): return {j}" for j in range(10))
+            _write(tmp_path, f"m{i}.py", body + "\n")
+
+        index = ProjectIndex(str(tmp_path))
+        with patch("neo.index.project_index.MAX_CHUNKS_PER_REPO", 10):
+            index.build_index(file_patterns=["**/*.py"], max_files=10)
+
+        report = index.selection_report
+        assert report['chunks_capped'] is True
+        assert report['chunks_kept'] == 10
+        assert report['chunks_extracted'] == 40
+
+    def test_files_left_without_chunks_are_reported(self, tmp_path):
+        """Round-robin represents every file only while slots >= files.
+
+        `MAX_CHUNKS_PER_REPO` is fixed and `--max-files` is not, so raising
+        the file cap past the chunk cap leaves files with nothing in the
+        index — and `truncated` is False there, because the file cap was not
+        the binding constraint. Without this line the operator is told
+        nothing was truncated while two thirds of their files are absent.
+        """
+        for i in range(6):
+            _write(tmp_path, f"m{i}.py", f"def f{i}(): return {i}\n")
+
+        index = ProjectIndex(str(tmp_path))
+        with patch("neo.index.project_index.MAX_CHUNKS_PER_REPO", 2):
+            index.build_index(file_patterns=["**/*.py"], max_files=100)
+
+        report = index.selection_report
+        assert report['truncated'] is False       # the file cap never bound
+        assert report['selected'] == 6
+        assert report['files_with_chunks'] == 2
+
+        printed = "\n".join(_format_selection_report(report))
+        assert "4 selected files contributed no chunks" in printed
+
+    def test_no_shortfall_line_when_every_file_is_represented(self, tmp_path):
+        for i in range(3):
+            _write(tmp_path, f"m{i}.py", f"def f{i}(): return {i}\n")
+
+        index = ProjectIndex(str(tmp_path))
+        index.build_index(file_patterns=["**/*.py"], max_files=100)
+
+        printed = "\n".join(_format_selection_report(index.selection_report))
+        assert "contributed no chunks" not in printed
+
+    def test_no_chunk_cap_flag_when_everything_fits(self, tmp_path):
+        _write(tmp_path, "a.py", "def a(): return 1\n")
+
+        index = ProjectIndex(str(tmp_path))
+        index.build_index(file_patterns=["**/*.py"], max_files=10)
+
+        assert index.selection_report['chunks_capped'] is False
+
+
+class TestReportFormatting:
+    def test_truncation_is_stated_with_language_breakdown(self):
+        lines = _format_selection_report({
+            'eligible': 4344, 'selected': 100, 'excluded': 0, 'duplicates': 0,
+            'max_files': 100, 'truncated': True,
+            'per_language': {
+                'c_sharp': {'selected': 96, 'eligible': 4272},
+                'typescript': {'selected': 3, 'eligible': 54},
+                'python': {'selected': 1, 'eligible': 18},
+            },
+        })
+        joined = "\n".join(lines)
+        assert "100 of 4344" in joined
+        assert "--max-files=100" in joined
+        # Largest language first — that is what an operator scans for.
+        assert joined.index("c_sharp") < joined.index("typescript")
+        assert "c_sharp 96/4272" in joined
+
+    def test_silent_when_nothing_was_left_out(self):
+        assert _format_selection_report({
+            'eligible': 5, 'selected': 5, 'excluded': 0, 'duplicates': 0,
+            'max_files': 100, 'truncated': False, 'per_language': {},
+        }) == []
+
+    def test_missing_report_is_tolerated(self):
+        assert _format_selection_report(None) == []
+
+    def test_exclusions_and_duplicates_are_reported(self):
+        joined = "\n".join(_format_selection_report({
+            'eligible': 5, 'selected': 5, 'excluded': 200, 'duplicates': 7,
+            'max_files': 100, 'truncated': False, 'per_language': {},
+        }))
+        assert "200" in joined
+        assert "7" in joined

--- a/tests/test_language_parser.py
+++ b/tests/test_language_parser.py
@@ -1,10 +1,11 @@
 """Tests for tree-sitter multi-language parser."""
 
+import logging
 from pathlib import Path
 
 import pytest
 
-from neo.index.language_parser import TreeSitterParser
+from neo.index.language_parser import EDGE_QUERIES, QUERIES, TreeSitterParser
 
 
 # Sample code for each language
@@ -105,10 +106,87 @@ pub struct Calculator {
 '''
 
 
+SAMPLE_TSX = '''
+export interface ButtonProps {
+    label: string;
+}
+
+export class Button {
+    render(): string {
+        return "<button/>";
+    }
+}
+'''
+
+
 @pytest.fixture
 def parser():
     """Create parser instance."""
     return TreeSitterParser()
+
+
+def _query_ids(group):
+    """Flatten a QUERIES-shaped dict into (language, query_name) pairs."""
+    return [(lang, name) for lang, queries in group.items() for name in queries]
+
+
+@pytest.mark.parametrize("language,query_name", _query_ids(QUERIES))
+def test_every_chunk_query_compiles(parser, language, query_name):
+    """Every query in QUERIES must compile against the installed grammar.
+
+    A query that fails to compile is indistinguishable from one that matches
+    nothing: `_get_query` returns None and `parse_file` moves on. That is how
+    `typescript:interfaces` sat broken from the day it shipped, dropping every
+    interface in every TypeScript repo out of the index without an error.
+    Grammars move; this is the assertion that notices when they do.
+    """
+    assert parser._get_query(language, query_name) is not None, (
+        f"QUERIES[{language!r}][{query_name!r}] does not compile against the "
+        f"installed grammar — every construct it matches is silently missing "
+        f"from the index."
+    )
+
+
+@pytest.mark.parametrize("language,query_name", _query_ids(EDGE_QUERIES))
+def test_every_edge_query_compiles(language, query_name):
+    """Same guarantee for the edge queries, which fail even more quietly.
+
+    `_extract_edges` logs compile failures at DEBUG, so a broken edge query
+    produces no console output at all — `c_sharp:inheritance` dropped every
+    inheritance edge in every C# repo with nothing but a debug line to show.
+
+    Compiled against the grammar directly rather than through the parser's
+    private cache key: keying on `f"{language}:edge:{name}"` here would keep
+    passing if `_extract_edges` changed its convention, which is exactly the
+    breakage this test exists to notice.
+    """
+    from tree_sitter import Query
+    from tree_sitter_language_pack import get_language
+    from neo.index.language_parser import _resolve_parser_name
+
+    grammar = get_language(_resolve_parser_name(language))
+    try:
+        Query(grammar, EDGE_QUERIES[language][query_name])
+    except Exception as exc:  # pragma: no cover - the assert carries the message
+        pytest.fail(
+            f"EDGE_QUERIES[{language!r}][{query_name!r}] does not compile "
+            f"against the installed grammar ({exc}) — every edge it matches "
+            f"is silently missing."
+        )
+
+
+def test_edge_queries_are_reached_through_the_parser(parser):
+    """Guards the cache-key convention the compile test deliberately avoids.
+
+    If `_extract_edges` and `_compile_cached` ever disagree on the key, the
+    per-query compile test above still passes; this one does not.
+    """
+    edges = parser.extract_edges(
+        Path("sample.py"), "import os\n\n\nclass A(B):\n    pass\n", "python"
+    )
+
+    kinds = {e.edge_type for e in edges}
+    assert 'imports' in kinds and 'inherits' in kinds
 
 
 def test_parser_initialization(parser):
@@ -192,6 +270,32 @@ def test_parse_typescript(parser):
     # Should find class, interface, and function
     types = {c.chunk_type for c in chunks}
     assert 'class' in types or 'function' in types
+
+
+def test_typescript_interface_is_extracted(parser):
+    """A TypeScript interface must produce an `interface:` chunk.
+
+    The pre-existing TypeScript tests only asserted on classes and functions,
+    so a never-compiling `interfaces` query looked exactly like one that found
+    nothing. This is the assertion that distinguishes them.
+    """
+    chunks = parser.parse_file(Path('test.ts'), SAMPLE_TYPESCRIPT, 'typescript')
+
+    assert 'interface:User' in {c.chunk_id for c in chunks}
+
+
+def test_tsx_interface_is_extracted(parser):
+    """TSX aliases the TypeScript queries, so it needs its own assertion.
+
+    `QUERIES['tsx'] = QUERIES['typescript']` binds the same dict object, which
+    means one broken definition breaks two languages and one fix repairs both
+    — but only a separate test proves the alias is still wired up.
+    """
+    chunks = parser.parse_file(Path('Button.tsx'), SAMPLE_TSX, 'tsx')
+
+    chunk_ids = {c.chunk_id for c in chunks}
+    assert 'interface:ButtonProps' in chunk_ids
+    assert 'class:Button' in chunk_ids
 
 
 def test_parse_javascript(parser):
@@ -295,6 +399,50 @@ def test_lazy_loading(parser):
 
     # Other parsers not loaded yet
     assert 'c_sharp' not in parser.parsers
+
+
+def test_broken_chunk_query_warns_once_not_once_per_file(monkeypatch, caplog):
+    """A query that cannot compile must warn once, not once per parsed file.
+
+    Before failures were cached, `_get_query` recompiled on every call, so a
+    single broken query emitted one warning per file: a run over 175
+    TypeScript files produced 9,699 identical lines and buried the answer.
+    """
+    monkeypatch.setitem(
+        QUERIES['python'], 'functions', '(this_node_type_does_not_exist) @x'
+    )
+    parser = TreeSitterParser()
+
+    with caplog.at_level(logging.WARNING, logger='neo.index.language_parser'):
+        for i in range(5):
+            parser.parse_file(Path(f'f{i}.py'), SAMPLE_PYTHON, 'python')
+
+    failures = [
+        r for r in caplog.records
+        if 'Failed to compile query python:functions' in r.getMessage()
+    ]
+    assert len(failures) == 1, (
+        f"expected exactly 1 compile warning across 5 files, got {len(failures)}"
+    )
+
+
+def test_broken_edge_query_warns_once_not_once_per_file(monkeypatch, caplog):
+    """The edge path recompiled per file with no cache of any kind."""
+    monkeypatch.setitem(
+        EDGE_QUERIES['python'], 'imports', '(this_node_type_does_not_exist) @x'
+    )
+    parser = TreeSitterParser()
+
+    with caplog.at_level(logging.WARNING, logger='neo.index.language_parser'):
+        for i in range(5):
+            parser.extract_edges(Path(f'f{i}.py'), SAMPLE_PYTHON, 'python')
+
+    failures = [
+        r for r in caplog.records
+        if 'Failed to compile query' in r.getMessage()
+        and 'imports' in r.getMessage()
+    ]
+    assert len(failures) == 1
 
 
 def test_syntax_error_handling(parser):

--- a/tests/test_multilang_index.py
+++ b/tests/test_multilang_index.py
@@ -209,7 +209,7 @@ def test_chunk_content_quality(temp_repo):
         assert len(chunk.content) > 0
 
         # Should have proper metadata
-        assert chunk.chunk_type in ['function', 'class', 'module_doc']
+        assert chunk.chunk_type in ['function', 'class']
         assert chunk.start_line > 0
         assert chunk.end_line >= chunk.start_line
 


### PR DESCRIPTION
## Description

Fixes three independent defects that share one shape: **the index and the prompt both silently discarded most of what they were asked to represent, and reported success.**

- **#158** — four tree-sitter queries did not compile against the installed grammars. A query that fails to compile is indistinguishable from one that matches nothing, so TypeScript/TSX interfaces and *every* C# inheritance edge had been missing from every index since the queries shipped. The only signal was a warning emitted once per query **per parsed file** — 9,699 lines in one reported run.
- **#159** — `build_index` globbed file patterns in list order, concatenated, and sliced to `--max-files`. Whichever language globbed first ate the budget: a .NET repo of 4,272 C# files produced an index of 83 Python files (95 of them from a git worktree checked out inside the repo) and zero C#, exit 0.
- **#176** — every context file was clipped to 3000 characters with no marker, while the banner reported the **pre-truncation** byte count. The model reasoned about the top of a file believing it had the whole thing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issue

Fixes #158
Fixes #159
Fixes #176

## Motivation and Context

### #158 — queries that never compiled

`typescript`/`tsx` `interfaces` matched the interface body as `object_type`; the grammar calls it `interface_body`. Probing every entry in `QUERIES` and `EDGE_QUERIES` found three more broken the same way:

| query | fault | consequence |
|---|---|---|
| `typescript`/`tsx` `interfaces` | `object_type` → `interface_body` | every TS interface missing from the index |
| `c_sharp` `inheritance` | `bases:` is not a field in the grammar | every C# inheritance edge missing |
| `python` `module_doc` | matched an `expression_statement` wrapper the grammar does not produce | none — see below |

`module_doc` was **deleted rather than fixed**: correcting it only revealed that nothing consumes a lone `@doc` capture (`_process_captures` builds chunks from construct captures), so it has never produced a chunk in any released version.

Compile results are now cached **including failures**, which is what turns 9,699 warnings into one per query per process.

C# bases additionally needed widening beyond the reported fault — an identifier-only, class-only pattern compiles fine and silently drops `: Repository<Order>` (parses as `generic_name`) and `interface IX : IY` entirely. Now matches `class`/`interface`/`record`/`struct` with generic bases.

### #159 — a slice is not a ranking

`_select_files` now groups eligible files by language and gives each a share of `--max-files` proportional to repo composition, with a floor of one slot per language (`_allocate_slots`). Non-source paths are excluded on two layers: `EXCLUDED_DIR_NAMES` for what repos forget to ignore (`.worktrees`, `.claude`, `node_modules`, `obj`, virtualenvs), plus the repo's own `.gitignore` via the helper `context_gatherer` already uses. Byte-identical files are indexed once, and the freed slot refills — across languages if the original has nothing unique left.

Ambiguous directory names — `bin`, `build`, `out`, `target`, `dist`, `vendor` — are deliberately **not** hardcoded. Each is real source somewhere (`src/bin/main.rs`, vendored trees); a sweep of three local repos found 254 git-tracked source files under `bin/` or `vendor/` alone. Repos that generate into them gitignore them, and the asymmetry is one-sided: over-excluding hides code permanently and invisibly, over-including only spends slots.

**Fixing the file cut alone was not enough.** `MAX_CHUNKS_PER_REPO` re-created the identical bug one function later: chunks arrive grouped by file and files grouped by language, so `chunks[:1000]` kept 1000 C# chunks and discarded every TypeScript and Python chunk the allocator had just fought to include. `_cap_chunks` round-robins across files instead.

Measured on a synthetic repo shaped like the reported one — 300 C#, 20 TS, 5 Python, plus a 200-file Python worktree under `.worktrees/`, `--max-files=100`:

| | before | after |
|---|---|---|
| files selected | 100, all `.py`, 95 of them from the worktree | `.cs` 91 / `.ts` 7 / `.py` 2, worktree excluded |
| chunks kept after the 1000 cap | `.cs` 1000, `.ts` 0, `.py` 0 | `.cs` 984 / `.ts` 14 / `.py` 2 |
| selected files represented in the index | 63 of 100 | 100 of 100 |

The per-repo figures in the issue reports (4,272 `.cs`; 83 indexed; 175 `.ts`) are the reporter's, not re-measured here.

### #176 — an unmarked cut invites a wrong inference

Every truncation now carries `... [truncated: N of M characters not shown]`, matching what `agent_context._read_doc` has always done. The banner reports post-truncation size, and says **chars** rather than bytes — `len()` on a `str` counts code points, so the old label was wrong twice over.

`_render_context_files` returns a third value, `visible`: each shown file cut to what the model actually received. `code_smells.scan_files` is fed that instead of the originals, because scanning full content emitted findings like `src/Service.cs:401 [todo/warn] HACK: ...` for a file the model was shown to line ~215. An unmarked cut *invites* a wrong inference about unseen code; a line-numbered finding about unseen code *asserts* one.

## How Has This Been Tested?

- [x] `1905 passed, 8 skipped` — full suite, against a measured `1750 passed, 8 skipped` baseline on `main` (+155 tests)
- [x] `ruff check src/ tests/ tools/` clean
- [x] Every new regression test verified to **fail** against the pre-fix source, so none is vacuous — including reverting each fix in turn to confirm the guarding test goes red
- [x] Both original reporter scenarios reproduced end to end and confirmed fixed (tables above)
- [x] Reviewed by the `neo` CLI itself and by an adversarial reviewer; both re-verified after fixes

New test files: `tests/test_index_file_selection.py` (64 tests), `tests/test_context_file_truncation.py` (24 tests).

`test_every_chunk_query_compiles` / `test_every_edge_query_compiles` are parametrized over **every** entry in `QUERIES` and `EDGE_QUERIES`, so the next grammar rename fails a test instead of quietly shrinking the index. They prove compilation only, so behavioural assertions were added alongside for the constructs that actually broke.

**Test Configuration**:
- Python version: 3.13.9
- OS: macOS 26.5.2 (darwin)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Behaviour changes an operator will notice:**

1. `neo --index` now prints what the caps left out — eligible vs indexed with a per-language breakdown, excluded paths, skipped duplicates, a capped chunk total, and files that contributed no chunks. Every line is conditional, so a build that indexed everything prints none of them and their presence is the signal. "Built index" on its own no longer means the index represents the repository.
2. Indexes built before this change should be rebuilt (`neo --index`); an existing `.neo/index.json` still carries the old composition.
3. `docs/tree-sitter-setup.md` claimed "Neo honors `.gitignore` by default" for the index. That was false — the handling existed only in `context_gatherer`. It is now true, via the same helper.
