### PR TITLE
fix(tests): detach the suite from an ambient git environment (#179)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,66 @@ def isolate_neo_home(tmp_path, monkeypatch):
     return fake_home
 
 
+# Variables through which an ambient git process redirects every `git`
+# invocation a child makes. `GIT_DIR` and `GIT_WORK_TREE` are the dangerous
+# pair: they override the repository discovery that `cwd=` is supposed to
+# drive, so `subprocess.run(["git", "init"], cwd=tmp_path)` silently operates
+# on the INHERITED repository instead of the temporary one.
+#
+# Sourced from `git(1)`'s environment section; the object/alternate ones are
+# included because they redirect writes even when GIT_DIR is correct.
+_GIT_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_INTERNAL_SUPER_PREFIX",
+)
+
+
+@pytest.fixture(autouse=True)
+def scrub_ambient_git_env(monkeypatch):
+    """Detach the suite from any git process that spawned it.
+
+    Tests and production code both shell out to `git` with `cwd=` pointing at a
+    temporary repository. `cwd` does NOT override `GIT_DIR`: when it is set,
+    git ignores repository discovery entirely and operates on the directory it
+    names. So an inherited `GIT_DIR` silently redirects every one of those
+    calls at the real repository.
+
+    Which is not hypothetical, and the damage is not subtle. Committing from a
+    LINKED WORKTREE exports `GIT_DIR=<repo>/.git/worktrees/<name>` and an
+    absolute `GIT_INDEX_FILE` to hooks — a commit from the main worktree
+    exports neither, which is why this hid for so long. `.githooks/pre-commit`
+    runs the full suite, so a single `git commit` inside a worktree ran
+    `tests/test_pending_session_retention.py`'s `git init -q .` against the
+    real gitdir. That set `core.bare = true` in `.git/config`, which worktrees
+    SHARE with the main repository, and the fixture's subsequent
+    `git add -A` / `git commit` wrote its two-file temp tree onto the
+    worktree's checked-out branch as a new commit. Reproduced from first
+    principles, then again end to end: the main checkout stopped being a work
+    tree and the worktree's history was replaced.
+
+    Scrubbed for the whole suite rather than fixed in the one fixture that
+    tripped it, because the exposure is every `subprocess` git call in `src/`
+    as much as in `tests/` — `_get_changed_files_since`,
+    `_get_working_tree_changes`, `_get_git_remote_url` and the acceptance
+    detector all shell out, and under an inherited `GIT_DIR` they would answer
+    about the wrong repository while looking perfectly healthy.
+
+    `GIT_AUTHOR_*` / `GIT_COMMITTER_*` are deliberately left alone: they only
+    supply identity, which a temp repo needs anyway, and removing them would
+    break commits on machines with no `user.email` configured.
+    """
+    for name in _GIT_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture(autouse=True)
 def clear_remote_url_cache():
     """Reset the memoized git-remote lookups between tests.

--- a/tests/test_git_env_isolation.py
+++ b/tests/test_git_env_isolation.py
@@ -1,0 +1,92 @@
+"""The suite must not inherit git's environment from a process that spawned it.
+
+`cwd=` does not override `GIT_DIR`. When `GIT_DIR` is set, git skips repository
+discovery entirely and operates on the directory it names, so every
+`subprocess.run(["git", ...], cwd=some_tmp_repo)` in the suite — and every one
+in `src/` — is silently redirected at whatever repository the parent was using.
+
+This is not a theoretical exposure. `git commit` from a LINKED WORKTREE exports
+`GIT_DIR=<repo>/.git/worktrees/<name>` plus an absolute `GIT_INDEX_FILE` to
+hooks; a commit from the main worktree exports neither. `.githooks/pre-commit`
+runs this suite, so one commit inside a worktree ran a fixture's `git init -q .`
+against the real gitdir, set `core.bare = true` in the `.git/config` that
+worktrees SHARE with the main repository, and committed a temp fixture's tree
+onto the worktree's branch. The main checkout stopped being a work tree.
+
+`conftest.scrub_ambient_git_env` removes those variables. These tests pin both
+that it happens and that it is sufficient, because a scrub that silently stops
+working leaves no trace until something is already destroyed.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from tests.conftest import _GIT_ENV_VARS
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+@pytest.mark.parametrize("name", _GIT_ENV_VARS)
+def test_redirecting_git_variables_are_absent(name):
+    """The scrub covers every variable that can redirect a git invocation."""
+    assert name not in os.environ
+
+
+def test_git_dir_is_scrubbed_even_when_the_parent_exported_it(monkeypatch):
+    """The fixture must win against a value present before the test starts.
+
+    `monkeypatch.delenv` in an autouse fixture runs before the test body, so
+    setting it here proves ordering, not the scrub. Instead assert the scrub's
+    own contract directly: after the autouse fixture, nothing is set.
+    """
+    assert os.environ.get("GIT_DIR") is None
+    assert os.environ.get("GIT_INDEX_FILE") is None
+
+
+def test_git_init_targets_cwd_not_an_inherited_gitdir(tmp_path):
+    """The exact operation that caused the damage, in miniature.
+
+    A fixture calling `git init` with `cwd=` a temp path must create a
+    repository THERE. Under an inherited `GIT_DIR` it instead reinitializes the
+    inherited one and flips it bare, which is what happened to the real
+    repository.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    _git(victim, "init", "-q", ".")
+    _git(victim, "config", "user.email", "t@t.t")
+    _git(victim, "config", "user.name", "T")
+    (victim / "kept.txt").write_text("original\n")
+    _git(victim, "add", "-A")
+    _git(victim, "commit", "-qm", "victim-base")
+
+    sandbox = tmp_path / "sandbox"
+    (sandbox / "src").mkdir(parents=True)
+    (sandbox / "src" / "foo.py").write_text("def f():\n    return 1\n")
+    _git(sandbox, "init", "-q", ".")
+    _git(sandbox, "config", "user.email", "t@t.t")
+    _git(sandbox, "config", "user.name", "T")
+    _git(sandbox, "add", "-A")
+    _git(sandbox, "commit", "-qm", "sandbox-init")
+
+    # The victim is untouched: still a work tree, still one commit, still its
+    # own file. Each assertion is one of the three observed symptoms.
+    bare = _git(victim, "config", "--get", "core.bare").stdout.strip()
+    assert bare == "false"
+
+    log = _git(victim, "log", "--oneline").stdout.strip().splitlines()
+    assert len(log) == 1 and log[0].endswith("victim-base")
+
+    assert (victim / "kept.txt").read_text() == "original\n"
+    assert not (victim / "src" / "foo.py").exists()
+
+    # And the sandbox really did get its own repository, so the test above is
+    # not passing because nothing happened at all.
+    sandbox_log = _git(sandbox, "log", "--oneline").stdout.strip()
+    assert sandbox_log.endswith("sandbox-init")


### PR DESCRIPTION
## Description

`git commit` inside a **linked git worktree** of this repo set `core.bare = true` on the main repository and wrote a test fixture's tree onto the worktree's branch as a real commit. The main checkout then failed every git command with `fatal: this operation must be run in a work tree`.

Hit while committing on a PR branch in a worktree; reproduced from first principles, then verified end to end with a control.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #179

## Motivation and Context

Three individually reasonable things, jointly destructive.

**1. A commit from a linked worktree exports `GIT_DIR` to hooks. A commit from the main worktree does not.** That asymmetry is why this hid — the hook has run from the main checkout many times without incident.

```
# hook env, committing from the MAIN worktree
GIT_INDEX_FILE=.git/index          <- relative, resolves correctly under any cwd
GIT_PREFIX=

# hook env, committing from a LINKED worktree
GIT_DIR=/path/to/repo/.git/worktrees/<name>              <- absolute
GIT_INDEX_FILE=/path/to/repo/.git/worktrees/<name>/index <- absolute
```

**2. `.githooks/pre-commit` runs the full test suite**, which inherits that environment.

**3. `cwd=` does not override `GIT_DIR`.** With it set, git skips repository discovery entirely and operates on the directory it names. So `tests/test_pending_session_retention.py`'s fixture —

```python
subprocess.run(["git", "init", "-q", "."], cwd=tmp_path / "repo")
```

— which looks perfectly isolated, did not touch `tmp_path` at all. `git init` reinitialized the inherited gitdir and, the cwd being unrelated to it, set `core.bare = true`. Worktrees **share** `.git/config` with the main repository, so that one setting took the main checkout offline; the following `add`/`commit` then wrote the fixture's two-file tree onto the worktree's branch.

Observed:

```
$ git status
fatal: this operation must be run in a work tree

$ git worktree list
/Users/…/neo          (bare)
/…/wt177              5e1ff13 [pr177]

$ git -C wt177 log --oneline -3
5e1ff13 init          <- the fixture's commits, on the PR branch
83d1779 applied
6b20a38 init
```

33 tests failed and 13 errored in the same run, all git-dependent — which is what made the corruption visible at all. Recoverable (`git config --local core.bare false` plus resetting the branch, no committed work lost), but nothing warns you and the failing suite reads as an unrelated test problem.

### Why the fix is suite-wide rather than in the one fixture

The exposure is every `subprocess` git call in `src/` as much as in `tests/`. `_get_changed_files_since`, `_get_working_tree_changes`, `_get_git_remote_url` and the acceptance detector all shell out — and under an inherited `GIT_DIR` they answer about the wrong repository while looking perfectly healthy. Repairing only the fixture that happened to call `git init` would leave every read path silently misdirected.

`GIT_AUTHOR_*` / `GIT_COMMITTER_*` are deliberately left alone: they only supply identity, which a temp repo needs anyway, and removing them breaks commits on machines with no `user.email` configured.

This matters beyond one fixture — the project's own tooling uses worktrees (Claude Code agent worktrees are common enough that `.worktrees` is being added to the index exclusion list in #177), so the affected path is one people are actively encouraged onto.

## How Has This Been Tested?

- [x] Ran `tests/test_pending_session_retention.py` from a real linked worktree under the exact hook environment, with and without the fixture:

  | | `core.bare` after | worktree history | result |
  |---|---|---|---|
  | fix disabled (control) | `true` | 4 fixture commits appended | 4 passed, **13 errors** |
  | fix enabled | `false` | unchanged | **29 passed** |

- [x] `1762 passed, 8 skipped` — full suite via the pre-commit hook
- [x] `ruff check src/ tests/ tools/` clean (pinned 0.16.1)
- [x] Reproducer confirmed independently with raw git commands, no pytest involved

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS 26.5.2 (darwin)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`tests/test_git_env_isolation.py` pins both halves: that each redirecting variable is absent, and that a `git init` with `cwd=` a temp path leaves a neighbouring repository bare-free, single-commit and with its own file intact — the three symptoms actually observed. It also asserts the sandbox really got its own repository, so the test cannot pass by nothing happening at all.

Note this fix is on `main` only. The `#177` branch does not carry it, so committing from a worktree on that branch is still unsafe until this merges — commit from the main checkout instead.
