### PR TITLE
fix(memory): ingest one rule file once, not once per spelling (#138)

### DIFF
--- a/src/neo/memory/constraints.py
+++ b/src/neo/memory/constraints.py
@@ -18,7 +18,15 @@ from neo.memory.models import Fact, FactKind, FactMetadata, FactScope
 
 logger = logging.getLogger(__name__)
 
-# Files to scan for constraints, in priority order
+# Files to scan for constraints, in priority order.
+#
+# Several entries deliberately name the same document under different
+# spellings, because different tools write different ones. On a
+# case-insensitive filesystem — macOS by default — `AGENTS.md` and `agents.md`
+# are then not two candidates but ONE FILE listed twice, and a symlinked
+# `CLAUDE.md -> AGENTS.md` is a third spelling of it. `_group_by_file_identity`
+# collapses those before ingestion; the order here decides which spelling wins
+# and becomes the `source_file` recorded on the facts.
 CONSTRAINT_FILES = [
     ("~/.claude/CLAUDE.md", FactScope.GLOBAL),
     ("{project}/CLAUDE.md", FactScope.PROJECT),
@@ -63,10 +71,21 @@ class ConstraintIngester:
         new_facts: list[Fact] = []
         superseded_facts: list[Fact] = []
 
-        for file_template, scope in CONSTRAINT_FILES:
-            file_path = self._resolve_path(file_template)
-            if not file_path or not file_path.exists():
-                continue
+        for file_path, aliases, scope in self._group_by_file_identity():
+            # Retire facts recorded under a non-canonical spelling of this same
+            # file, and do it BEFORE the unchanged-checksum short-circuit.
+            #
+            # This is the migration path, and the ordering is the whole of it.
+            # Stores written before aliases were collapsed hold a full second
+            # (and third) copy of every section under the other spellings —
+            # valid, confidence 1.0, CONSTRAINT and therefore exempt from
+            # recall decay, so nothing ages them out. Their file has not
+            # changed, so the checksum matches, so a cleanup placed below the
+            # short-circuit would never run and the duplicates would outlive
+            # the fix indefinitely.
+            self._retire_alias_facts(
+                file_path, aliases, existing_facts, superseded_facts
+            )
 
             current_checksum = self._file_checksum(file_path)
             stored_checksum = self._checksums.get(str(file_path), "")
@@ -111,6 +130,97 @@ class ConstraintIngester:
 
         self._save_checksums()
         return new_facts, superseded_facts
+
+    def _group_by_file_identity(
+        self,
+    ) -> list[tuple[Path, list[Path], FactScope]]:
+        """Collapse `CONSTRAINT_FILES` entries that name the same file.
+
+        Returns one `(canonical_path, alias_paths, scope)` per distinct file,
+        in `CONSTRAINT_FILES` order. `alias_paths` are the other spellings that
+        reached it, and is empty for the ordinary case.
+
+        The table lists `AGENTS.md` and `agents.md` separately because
+        different tools write different ones. On a case-insensitive filesystem
+        — macOS by default, which is where this was found — those are the same
+        file, so the ingest loop visited it twice. Both the checksum cache and
+        the supersession pass key on the literal path string, and
+        `"…/AGENTS.md" != "…/agents.md"`, so neither pass saw the other's work:
+        the second visit found no stored checksum, superseded nothing, and
+        minted a complete second copy of every section. Measured on one machine
+        before this fix: 51 duplicated subjects in a single project, and the
+        same pattern in every project that had an `AGENTS.md` — with the
+        control holding, since projects without one showed zero.
+
+        Identity is `(st_dev, st_ino)`, not a normalized string. `realpath`
+        resolves symlinks but preserves the case it was given, so on macOS it
+        does not equate the two spellings at all, and `os.path.normcase` is a
+        no-op outside Windows. Only the filesystem knows, so ask it — which
+        catches the symlinked `CLAUDE.md -> AGENTS.md` layout for free.
+
+        Falls back to the resolved path string when `stat` fails, which keeps a
+        race between `exists()` and `stat()` from dropping a file entirely: the
+        cost is a missed alias collapse, not a missed rule file.
+        """
+        groups: list[tuple[Path, list[Path], FactScope]] = []
+        by_identity: dict[object, int] = {}
+
+        for file_template, scope in CONSTRAINT_FILES:
+            file_path = self._resolve_path(file_template)
+            if not file_path or not file_path.exists():
+                continue
+
+            try:
+                stat = file_path.stat()
+                identity: object = (stat.st_dev, stat.st_ino)
+            except OSError:
+                identity = str(file_path.resolve())
+
+            if identity in by_identity:
+                # A later spelling of a file already claimed. The first entry
+                # wins, so CONSTRAINT_FILES order is what decides the canonical
+                # path — deliberately, since it is the documented priority
+                # order and is stable across runs.
+                canonical, aliases, _ = groups[by_identity[identity]]
+                if file_path != canonical:
+                    aliases.append(file_path)
+                continue
+
+            by_identity[identity] = len(groups)
+            groups.append((file_path, [], scope))
+
+        return groups
+
+    def _retire_alias_facts(
+        self,
+        canonical: Path,
+        aliases: list[Path],
+        existing_facts: list[Fact],
+        superseded_facts: list[Fact],
+    ) -> None:
+        """Invalidate constraints recorded under a non-canonical spelling.
+
+        Also drops the aliases' checksum entries, so a stale cache row cannot
+        keep a retired spelling alive in `checksums.json` forever.
+        """
+        alias_keys = {str(path) for path in aliases} - {str(canonical)}
+        if not alias_keys:
+            return
+
+        for fact in existing_facts:
+            if (fact.kind == FactKind.CONSTRAINT
+                    and fact.is_valid
+                    and fact.metadata.source_file in alias_keys):
+                fact.is_valid = False
+                superseded_facts.append(fact)
+
+        for key in alias_keys:
+            self._checksums.pop(key, None)
+
+        logger.info(
+            f"Collapsed {len(alias_keys)} alias spelling(s) of {canonical} "
+            f"({', '.join(sorted(alias_keys))})"
+        )
 
     def _resolve_path(self, template: str) -> Optional[Path]:
         """Resolve a file path template."""

--- a/tests/test_constraint_ingestion.py
+++ b/tests/test_constraint_ingestion.py
@@ -1,0 +1,217 @@
+"""Constraint ingestion: one rule file must produce one set of facts.
+
+`CONSTRAINT_FILES` names several spellings of the same document on purpose,
+because different tools write different ones. On a case-insensitive filesystem
+those spellings are not alternatives, they are the same file listed twice — and
+the ingester used to walk it once per spelling, keying both the checksum cache
+and the supersession pass on the literal path string, so each visit was blind to
+the last. Every extra spelling minted a complete duplicate set of CONSTRAINT
+facts at confidence 1.0, which are exempt from recall decay and so never aged
+out. See issue #138.
+"""
+
+import os
+
+import pytest
+
+from neo.memory.constraints import ConstraintIngester
+from neo.memory.models import Fact, FactKind, FactMetadata, FactScope
+
+RULES = """# Project
+
+## Build
+
+Run `make build`.
+
+## Test
+
+Run `make test`.
+"""
+
+
+def _ingester(root):
+    return ConstraintIngester(
+        codebase_root=str(root), org_id="org", project_id="proj"
+    )
+
+
+def _valid(facts):
+    return [f for f in facts if f.is_valid]
+
+
+def _case_insensitive(root) -> bool:
+    """Does this filesystem treat AGENTS.md and agents.md as one file?
+
+    Asked rather than assumed: the bug is native to macOS and Windows, and the
+    fix must be exercised where it applies without failing the suite on the
+    ext4 CI runners where it cannot reproduce.
+    """
+    probe = root / "CaseProbe.tmp"
+    probe.write_text("x")
+    try:
+        return (root / "caseprobe.tmp").exists()
+    finally:
+        probe.unlink()
+
+
+class TestAliasCollapsing:
+    def test_one_file_two_spellings_ingests_once(self, tmp_path):
+        """The reported defect, at its root.
+
+        With `AGENTS.md` present and the filesystem case-insensitive, the
+        `agents.md` entry resolves to the same file. Before the fix this
+        produced two facts per section; every project on the reporting machine
+        that had an `AGENTS.md` showed exactly this, and projects without one
+        showed none.
+        """
+        if not _case_insensitive(tmp_path):
+            pytest.skip("filesystem is case-sensitive; aliasing cannot occur")
+
+        (tmp_path / "AGENTS.md").write_text(RULES)
+
+        new_facts, _ = _ingester(tmp_path).ingest([])
+
+        subjects = sorted(f.subject for f in new_facts)
+        assert subjects == ["Build", "Test"]
+
+    def test_symlinked_spelling_is_collapsed_on_any_filesystem(self, tmp_path):
+        """Identity is `(st_dev, st_ino)`, so symlinks collapse too.
+
+        This is the case-sensitive filesystem's version of the same fault, and
+        it is why the fix asks the filesystem instead of normalizing strings:
+        `realpath` would resolve this one but not the case-only alias, and
+        `normcase` is a no-op outside Windows.
+        """
+        (tmp_path / "AGENTS.md").write_text(RULES)
+        os.symlink(tmp_path / "AGENTS.md", tmp_path / "CLAUDE.md")
+
+        new_facts, _ = _ingester(tmp_path).ingest([])
+
+        assert sorted(f.subject for f in new_facts) == ["Build", "Test"]
+
+    def test_genuinely_distinct_files_are_both_ingested(self, tmp_path):
+        """The other side of the contract.
+
+        A repo carrying a real `CLAUDE.md` AND a real `AGENTS.md` has two rule
+        files, not one written twice. Collapsing those would lose rules, which
+        is a worse failure than the duplication being fixed.
+        """
+        (tmp_path / "CLAUDE.md").write_text("## Build\n\nUse cmake.\n")
+        (tmp_path / "AGENTS.md").write_text("## Deploy\n\nUse helm.\n")
+
+        new_facts, _ = _ingester(tmp_path).ingest([])
+
+        assert sorted(f.subject for f in new_facts) == ["Build", "Deploy"]
+
+    def test_canonical_path_follows_constraint_files_order(self, tmp_path):
+        """Which spelling wins must be stable, not filesystem-dependent."""
+        (tmp_path / "AGENTS.md").write_text(RULES)
+        os.symlink(tmp_path / "AGENTS.md", tmp_path / "CLAUDE.md")
+
+        new_facts, _ = _ingester(tmp_path).ingest([])
+
+        # CLAUDE.md precedes AGENTS.md in CONSTRAINT_FILES.
+        assert {f.metadata.source_file for f in new_facts} == {
+            str(tmp_path / "CLAUDE.md")
+        }
+
+
+class TestMigrationOfExistingDuplicates:
+    """Duplicates already in a store must be retired, not merely stopped.
+
+    CONSTRAINT facts bypass recall decay and are protected from eviction, so
+    nothing else in the system will ever remove them. And the file they came
+    from has not changed, so its checksum still matches — meaning the cleanup
+    has to run ABOVE the unchanged-file short-circuit or it never runs at all.
+    """
+
+    def _stale(self, path, subject):
+        return Fact(
+            subject=subject,
+            body="Old copy.",
+            kind=FactKind.CONSTRAINT,
+            scope=FactScope.PROJECT,
+            project_id="proj",
+            metadata=FactMetadata(source_file=str(path), confidence=1.0),
+            tags=["constraint", "auto-ingested"],
+        )
+
+    def test_alias_duplicates_are_retired_when_file_is_unchanged(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text(RULES)
+        os.symlink(tmp_path / "AGENTS.md", tmp_path / "CLAUDE.md")
+
+        ingester = _ingester(tmp_path)
+        # First pass populates the checksum cache, so the second pass takes the
+        # unchanged-file path — which is exactly where the old code stopped.
+        first_facts, _ = ingester.ingest([])
+
+        store = list(first_facts) + [
+            self._stale(tmp_path / "AGENTS.md", "Build"),
+            self._stale(tmp_path / "AGENTS.md", "Test"),
+        ]
+
+        new_facts, superseded = ingester.ingest(store)
+
+        assert new_facts == []                    # nothing re-minted
+        assert len(superseded) == 2               # both alias copies retired
+        assert all(not f.is_valid for f in superseded)
+        assert {f.metadata.source_file for f in _valid(store)} == {
+            str(tmp_path / "CLAUDE.md")
+        }
+
+    def test_canonical_facts_survive_the_migration(self, tmp_path):
+        """Retiring aliases must not take the good copies with them."""
+        (tmp_path / "AGENTS.md").write_text(RULES)
+        os.symlink(tmp_path / "AGENTS.md", tmp_path / "CLAUDE.md")
+
+        ingester = _ingester(tmp_path)
+        canonical, _ = ingester.ingest([])
+        store = list(canonical) + [self._stale(tmp_path / "AGENTS.md", "Build")]
+
+        ingester.ingest(store)
+
+        assert len(_valid(store)) == len(canonical)
+        assert sorted(f.subject for f in _valid(store)) == ["Build", "Test"]
+
+    def test_alias_checksum_rows_are_dropped(self, tmp_path):
+        """A stale cache row must not outlive the spelling it belonged to."""
+        (tmp_path / "AGENTS.md").write_text(RULES)
+        os.symlink(tmp_path / "AGENTS.md", tmp_path / "CLAUDE.md")
+
+        ingester = _ingester(tmp_path)
+        ingester._checksums[str(tmp_path / "AGENTS.md")] = "stale"
+        ingester.ingest([])
+
+        assert str(tmp_path / "AGENTS.md") not in ingester._checksums
+        assert str(tmp_path / "CLAUDE.md") in ingester._checksums
+
+
+class TestUnchangedBehaviour:
+    def test_unchanged_file_is_not_re_ingested(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text(RULES)
+        ingester = _ingester(tmp_path)
+
+        first, _ = ingester.ingest([])
+        second, superseded = ingester.ingest(list(first))
+
+        assert first != []
+        assert second == []
+        assert superseded == []
+
+    def test_changed_file_supersedes_and_re_mints(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text(RULES)
+        ingester = _ingester(tmp_path)
+        first, _ = ingester.ingest([])
+
+        (tmp_path / "CLAUDE.md").write_text("## Build\n\nUse bazel now.\n")
+        store = list(first)
+        second, superseded = ingester.ingest(store)
+
+        assert len(superseded) == len(first)
+        assert [f.subject for f in second] == ["Build"]
+        assert "bazel" in second[0].body
+
+    def test_missing_files_are_skipped(self, tmp_path):
+        new_facts, superseded = _ingester(tmp_path).ingest([])
+        assert new_facts == []
+        assert superseded == []


### PR DESCRIPTION
## Description

neo ingested one rule file once **per spelling** of its name, minting a complete duplicate set of `CONSTRAINT` facts each time. Those facts are exempt from recall decay and protected from eviction, so nothing aged them out and stale copies outranked corrected ones.

The cause turns out to be narrower and more mundane than #138 supposes: no cosine threshold is involved, and the supersession logic works exactly as designed. `CONSTRAINT_FILES` simply asks for the same file more than once.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #138

## Motivation and Context

`src/neo/memory/constraints.py` lists `{project}/AGENTS.md` and `{project}/agents.md` as separate entries, because different tools write different ones. On a case-insensitive filesystem — macOS by default, which is where every affected store was written — **those are the same file**, and a symlinked `CLAUDE.md -> AGENTS.md` is a third spelling of it.

Both the checksum cache and the supersession pass key on the literal path string:

```python
stored_checksum = self._checksums.get(str(file_path), "")
...
if fact.metadata.source_file == str(file_path) and fact.is_valid:
```

`"…/AGENTS.md" != "…/agents.md"`, so neither pass saw the other's work. The second visit found no stored checksum, superseded nothing, and minted a full second copy of every section at `confidence=1.0`.

So the accumulation is not drift over time and not a dedup threshold set too loose. It is one ingest producing N copies, every time, on any project with an `AGENTS.md`.

### Measured

Counting subjects appearing under more than one `source_file`, across the fact stores on one machine:

| fact file | valid constraints | subjects duplicated across paths |
|---|---|---|
| `facts_project_b0d41729f03bbc6b` | 155 | 51 |
| `facts_project_9e7cb4428fbcc303` | 73 | 35 |
| `facts_project_e1f64ee2d1d5f392` | 73 | 35 |
| `facts_project_fad18e61d5775275` | 87 | 33 |
| `facts_project_ec3850afaf8dca1a` | 81 | 27 |
| `facts_project_5bbd6578e0b4efb7` | 26 | 12 |

Projects with no `AGENTS.md` show zero, which is the control. One project held three valid copies of every section — identical 290-char bodies — under `agents.md` / `AGENTS.md` / `CLAUDE.md`, two of which `ls` shows as a single file.

A separate census found only **one** case of the same `(subject, source_file)` pair appearing twice across 86 fact files, and that one is a markdown file with two identically-named headings. Supersession-by-`source_file` is working; path aliasing accounts for essentially all of it.

### Why identity, not string normalization

`_group_by_file_identity` keys on `(st_dev, st_ino)`. `realpath` resolves symlinks but **preserves the case it was given**, so on macOS it does not equate the two spellings at all, and `os.path.normcase` is a no-op outside Windows. Only the filesystem knows — and asking it catches the symlink layout for free. `CONSTRAINT_FILES` order decides which spelling becomes canonical, so the choice is the documented priority order and is stable across runs. A `stat` failure falls back to the resolved path string, so a race between `exists()` and `stat()` costs a missed alias collapse, never a dropped rule file.

### Why the cleanup runs above the short-circuit

`_retire_alias_facts` runs **before** the unchanged-checksum `continue`, and that ordering is the whole of the migration. Existing stores hold the duplicates already; their file has not changed, so the checksum matches, so a cleanup placed below the short-circuit would never run and the duplicates would outlive the fix indefinitely. Placed where it is, every store self-heals on its next ingest.

### Incidental finding

The ingesters bypass `add_fact` entirely — `store.py` does `self._facts.extend(new_facts)` — so pre-write canonical-signature dedup never had a chance to catch these. That is why byte-identical twins could coexist at all. Not changed here; noting it because it explains why the existing dedup layer was not a backstop.

## How Has This Been Tested?

- [x] `1760 passed, 8 skipped` — full suite via the pre-commit hook
- [x] `ruff check src/ tests/ tools/` clean (pinned 0.16.1)
- [x] 10 new tests in `tests/test_constraint_ingestion.py`; **7 of them verified to fail against the pre-fix source**, so none is vacuous. The 3 that pass pre-fix are the deliberate non-regression pins (unchanged file not re-ingested, changed file supersedes and re-mints, missing files skipped).
- [x] Root cause confirmed directly against live fact stores, with the no-`AGENTS.md` control

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS 26.5.2 (darwin)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

There were no tests for `ConstraintIngester` at all before this.

**The other side of the contract is tested too**, since it is the failure this fix could plausibly introduce: a repo carrying a real `CLAUDE.md` *and* a real `AGENTS.md` has two rule files, not one written twice, and both must still be ingested. Collapsing those would lose rules — a worse outcome than the duplication being fixed.

**Behaviour an operator will notice:** the first ingest after this lands invalidates the alias duplicates and logs `Collapsed N alias spelling(s) of <path>`. No new facts are minted for an unchanged file. Fact counts in affected projects will drop — that is the fix working, and the tombstones age off under the existing 30-day policy.
