### PR TITLE
fix(construct): confine pattern ids, bound --top-k, make the ordering test test ordering (#25, #27, #28)

### DIFF
--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -62,6 +62,33 @@ from neo.subcommands import (  # noqa: E402, F401
 # Re-export constants that were at module level
 from neo.subcommands import MIN_EMBEDDING_SUCCESS_RATE, VALID_EMBEDDING_DIMENSIONS  # noqa: E402, F401
 
+# Upper bound on `construct search --top-k`. The pattern library is curated and
+# small — a request for more than this is a typo or a misunderstanding of what
+# the command returns, not a real query.
+MAX_TOP_K = 100
+
+
+def _top_k(value: str) -> int:
+    """argparse type for `--top-k`: an integer in [1, MAX_TOP_K].
+
+    Rejecting at parse time rather than clamping downstream, because the two
+    failures it prevents are silent in opposite directions. A negative value
+    reaches a list slice as `results[:-3]`, which drops the LAST three results
+    and returns the rest — plausible output for a nonsense request. A value of
+    zero returns nothing, which reads as "no patterns match".
+    """
+    import argparse
+
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"--top-k must be an integer, got {value!r}")
+    if not 1 <= parsed <= MAX_TOP_K:
+        raise argparse.ArgumentTypeError(
+            f"--top-k must be between 1 and {MAX_TOP_K}, got {parsed}"
+        )
+    return parsed
+
 
 def parse_args():
     """Parse command-line arguments."""
@@ -191,7 +218,8 @@ def parse_args():
         # construct search
         search_p = subparsers.add_parser('search', help='Search patterns')
         search_p.add_argument('query', help='Search query')
-        search_p.add_argument('--top-k', type=int, default=5, help='Number of results')
+        search_p.add_argument('--top-k', type=_top_k, default=5,
+                              help=f'Number of results (1-{MAX_TOP_K}, default 5)')
 
         # construct index
         index_p = subparsers.add_parser('index', help='Build search index')

--- a/src/neo/construct.py
+++ b/src/neo/construct.py
@@ -583,10 +583,38 @@ class ConstructIndex:
 
         Returns:
             PatternSchema or None if not found
+
+        `pattern_id` is interpolated into a filesystem path, so it is confined
+        to `construct_root` before anything is read. The check that holds is
+        resolved-path containment, not a scan for `..`: a symlink planted
+        inside the library escapes without the string ever containing `..`,
+        and a substring test would reject a legitimate id like `retry..backoff`
+        while missing that case entirely. `resolve()` collapses both traversal
+        segments and symlinks, so one comparison covers both.
+
+        Read-only, and the caller already has filesystem access — so this is
+        hygiene rather than a privilege boundary. It matters because
+        `pattern_id` reaches here straight from argv and from MCP callers,
+        where "already has filesystem access" stops being obviously true.
         """
-        # Construct file path from pattern_id
-        # pattern_id format: "domain/filename"
-        pattern_path = self.construct_root / f"{pattern_id}.md"
+        # `Path` treats an absolute right-hand operand as a replacement rather
+        # than a suffix, so `construct_root / "/etc/passwd"` IS "/etc/passwd" —
+        # containment below catches it, but reject it here where the intent is
+        # legible. An empty id would address `construct_root/.md`.
+        if not pattern_id or Path(pattern_id).is_absolute():
+            logger.warning(f"Invalid pattern_id: {pattern_id!r}")
+            return None
+
+        root = self.construct_root.resolve()
+        pattern_path = (self.construct_root / f"{pattern_id}.md").resolve()
+
+        try:
+            pattern_path.relative_to(root)
+        except ValueError:
+            logger.warning(
+                f"Rejected pattern_id escaping the pattern library: {pattern_id!r}"
+            )
+            return None
 
         if not pattern_path.exists():
             logger.warning(f"Pattern not found: {pattern_id}")

--- a/tests/test_cli_global_flags.py
+++ b/tests/test_cli_global_flags.py
@@ -218,6 +218,51 @@ class TestCLIGlobalFlags:
         assert "traceback" not in output.lower()
 
 
+class TestConstructTopKBounds:
+    """`construct search --top-k` must reject values it cannot honour.
+
+    Rejected at parse time rather than clamped downstream, because both
+    out-of-range directions fail silently and plausibly (issue #28). A
+    negative value reaches a list slice as `results[:-3]`, which drops the
+    LAST three results and returns the rest; zero returns nothing, which
+    reads as "no patterns match".
+    """
+
+    @pytest.mark.parametrize("value", ["-1", "0", "101", "abc", "3.5"])
+    def test_out_of_range_values_are_rejected(self, value):
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            cli._top_k(value)
+        assert "--top-k" in str(excinfo.value)
+
+    @pytest.mark.parametrize("value", ["-1", "0", "101", "abc"])
+    def test_rejection_exits_rather_than_running_the_search(
+        self, value, monkeypatch
+    ):
+        """argparse must turn the rejection into exit 2, not a traceback."""
+        monkeypatch.setattr(
+            sys, "argv",
+            ["neo", "construct", "search", "q", "--top-k", value],
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            cli.parse_args()
+        assert excinfo.value.code == 2
+
+    @pytest.mark.parametrize("value", ["1", "5", "100"])
+    def test_in_range_values_are_accepted(self, value, monkeypatch):
+        """Parsing must succeed; the search itself may still find nothing."""
+        monkeypatch.setattr(
+            sys, "argv",
+            ["neo", "construct", "search", "q", "--top-k", value],
+        )
+        assert cli.parse_args().top_k == int(value)
+
+    def test_default_is_unchanged(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["neo", "construct", "search", "q"])
+        assert cli.parse_args().top_k == 5
+
+
 def test_adapter_kwargs_passes_base_url_to_ollama():
     class Config:
         provider = "ollama"

--- a/tests/test_construct.py
+++ b/tests/test_construct.py
@@ -4,6 +4,7 @@ Tests for The Construct pattern library.
 Tests cover pattern parsing, validation, indexing, and CLI integration.
 """
 
+import os
 import pytest
 import tempfile
 import time
@@ -71,6 +72,31 @@ This pattern is missing required sections.
 ## Forces
 Some forces
 """
+
+
+def _axis_embedder():
+    """A stub embedder putting each fixture pattern on its own unit axis.
+
+    Two properties are load-bearing, and each corresponds to a way the earlier
+    version of the ordering test could not have worked:
+
+    - The vectors must be near-ORTHOGONAL, not just unequal. FAISS normalizes
+      to unit length for cosine similarity, so `[0.9]*768` and `[0.1]*768`
+      normalize to the same vector and rank identically.
+    - The discriminating token must be unique to one fixture. `"cache"` is
+      not: the rate-limiting pattern inherits the caching pattern's tradeoff
+      list, "Cache invalidation complexity" included, so keying on it puts
+      both patterns on the same axis. `"token bucket"` appears only in the
+      rate-limiting fixture.
+    """
+    def embed(texts):
+        vector = [0.0] * 768
+        vector[1 if "token bucket" in texts[0].lower() else 0] = 1.0
+        return [vector]
+
+    embedder = MagicMock()
+    embedder.embed = MagicMock(side_effect=embed)
+    return embedder
 
 
 @pytest.fixture
@@ -287,6 +313,74 @@ class TestConstructIndex:
         pattern = index.show_pattern('nonexistent/pattern')
         assert pattern is None
 
+    @pytest.mark.parametrize("template", [
+        "../{stem}",
+        "caching/../../{stem}",
+        "{absolute}",
+    ])
+    def test_show_pattern_rejects_paths_outside_the_library(
+        self, temp_construct_dir, template
+    ):
+        """`pattern_id` is interpolated into a path, so it must be confined.
+
+        The escape target is a real, loadable pattern file placed outside the
+        library — otherwise the test proves nothing. A traversal to a path
+        that does not exist is rejected by the pre-existing `exists()` check
+        for the wrong reason, so every such case passes with or without
+        containment. Confirmed by running these against the unfixed source.
+
+        The absolute case is included because `Path.__truediv__` treats an
+        absolute right-hand operand as a REPLACEMENT, not a suffix:
+        `construct_root / "/tmp/x"` is `/tmp/x`, library root discarded
+        entirely (issue #25).
+        """
+        outside = temp_construct_dir.parent / "outside.md"
+        outside.write_text(VALID_PATTERN_CONTENT)
+        # Sanity: the escape target really is loadable, so a None result below
+        # is containment refusing it rather than the file being unreadable.
+        assert PatternReader.load(outside) is not None
+
+        pattern_id = template.format(
+            stem="outside", absolute=str(outside.with_suffix("")),
+        )
+        index = ConstructIndex(construct_root=temp_construct_dir)
+        assert index.show_pattern(pattern_id) is None
+
+    @pytest.mark.parametrize("pattern_id", ["", ".."])
+    def test_show_pattern_rejects_degenerate_ids(
+        self, temp_construct_dir, pattern_id
+    ):
+        """An empty id addresses `construct_root/.md`; `..` the parent dir."""
+        index = ConstructIndex(construct_root=temp_construct_dir)
+        assert index.show_pattern(pattern_id) is None
+
+    def test_show_pattern_rejects_symlink_escape(self, temp_construct_dir):
+        """A symlink escapes without the id ever containing `..`.
+
+        This is why the check is resolved-path containment rather than a scan
+        for traversal sequences: the string test passes this case cleanly.
+        """
+        outside = temp_construct_dir.parent / "outside.md"
+        outside.write_text(VALID_PATTERN_CONTENT)
+        os.symlink(outside, temp_construct_dir / "caching" / "escape.md")
+
+        index = ConstructIndex(construct_root=temp_construct_dir)
+        assert index.show_pattern("caching/escape") is None
+
+    def test_show_pattern_still_loads_legitimate_ids(self, temp_construct_dir):
+        """The other side of the contract: containment must not over-reject.
+
+        A dotted id is legal — `..` as a substring is not traversal — and the
+        ordinary nested id must keep working.
+        """
+        index = ConstructIndex(construct_root=temp_construct_dir)
+        assert index.show_pattern("caching/cache-aside") is not None
+
+        (temp_construct_dir / "caching" / "retry..backoff.md").write_text(
+            VALID_PATTERN_CONTENT
+        )
+        assert index.show_pattern("caching/retry..backoff") is not None
+
     def test_construct_show_malformed_yaml(self):
         """Test handling of malformed pattern files."""
         tmpdir = tempfile.mkdtemp()
@@ -319,29 +413,54 @@ class TestConstructIndex:
     @patch('neo.construct.FASTEMBED_AVAILABLE', True)
     @patch('neo.construct.FAISS_AVAILABLE', True)
     def test_construct_search_relevance_ordering(self, temp_construct_dir):
-        """Test that search results are ordered by relevance."""
-        # Mock the embedder
+        """Search results come back ordered by similarity to the query.
+
+        This test previously built the differentiated embeddings below and
+        then asserted only `index.embedder is not None`, never calling
+        `search()` — scaffolding for an assertion it did not make, which reads
+        to a skimmer as though ordering were covered (issue #27).
+
+        The embeddings must be near-ORTHOGONAL, not merely different in
+        magnitude. FAISS normalizes to unit length for cosine similarity, so
+        the old `[0.9]*768` and `[0.1]*768` both normalize to the identical
+        vector and rank equally — the ordering would have been arbitrary even
+        if the assertion had existed.
+        """
         with patch('neo.memory.store.build_resilient_embedder') as mock_embedder_class:
-            mock_embedder = MagicMock()
-            # Return different embeddings for different queries
-            def embed_side_effect(texts):
-                # Simulate embeddings: first pattern matches "cache", second matches "rate"
-                if "cache" in texts[0].lower():
-                    return [[0.9] * 768]  # High similarity to caching pattern
-                elif "rate" in texts[0].lower():
-                    return [[0.1] * 768]  # Low similarity to caching pattern
-                else:
-                    return [[0.5] * 768]
-            mock_embedder.embed = MagicMock(side_effect=embed_side_effect)
-            mock_embedder_class.return_value = mock_embedder
+            mock_embedder_class.return_value = _axis_embedder()
 
             index = ConstructIndex(construct_root=temp_construct_dir)
-            # Force index build
             index.build_index(force_rebuild=True)
 
-            # Search should work with mocked embedder
-            # This is a basic test - in reality, semantic search ordering depends on embeddings
-            assert index.embedder is not None
+            results = index.search("cache-aside read-through", top_k=2)
+
+            assert len(results) == 2
+            ordered = [pattern.pattern_id for pattern, _ in results]
+            assert ordered[0] == "caching/cache-aside"
+            assert ordered[1] == "rate-limiting/token-bucket"
+
+            scores = [score for _, score in results]
+            assert scores[0] > scores[1]
+            assert scores == sorted(scores, reverse=True)
+
+    @patch('neo.construct.FASTEMBED_AVAILABLE', True)
+    @patch('neo.construct.FAISS_AVAILABLE', True)
+    def test_construct_search_ordering_follows_the_query(self, temp_construct_dir):
+        """The ranking must track the query, not a fixed pattern order.
+
+        Without this, a `search()` that ignored its argument and returned
+        patterns in directory order would satisfy the test above.
+        """
+        with patch('neo.memory.store.build_resilient_embedder') as mock_embedder_class:
+            mock_embedder_class.return_value = _axis_embedder()
+
+            index = ConstructIndex(construct_root=temp_construct_dir)
+            index.build_index(force_rebuild=True)
+
+            results = index.search("token bucket limiter", top_k=2)
+
+            ordered = [pattern.pattern_id for pattern, _ in results]
+            assert ordered[0] == "rate-limiting/token-bucket"
 
     @patch('neo.construct.FASTEMBED_AVAILABLE', True)
     @patch('neo.construct.FAISS_AVAILABLE', True)


### PR DESCRIPTION
## Description

Three long-open `construct` issues. Each was verified to still reproduce on `main` before being touched, and each fix departs from the proposal in the issue where the proposal would not have held.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

## Related Issue

Fixes #25
Fixes #27
Fixes #28

## Motivation and Context

### #25 — containment, not a `..` scan

`show_pattern` interpolated `pattern_id` straight into a filesystem path. The issue proposed rejecting ids containing `..`; that is the weaker half and should not be the whole fix:

- a symlink planted inside the library escapes **without the string ever containing `..`**
- the substring test rejects a legitimate id like `retry..backoff`

`resolve()` collapses both traversal segments and symlinks, so one containment comparison covers both cases. The substring test is not kept — it adds a false rejection and catches nothing the containment check misses.

An absolute id is rejected explicitly because `Path.__truediv__` treats an absolute right-hand operand as a **replacement**, not a suffix: `construct_root / "/etc/passwd"` *is* `/etc/passwd`, library root discarded. Containment catches it anyway; rejecting it up front keeps the intent legible.

Read-only, and the caller usually has filesystem access already — so this is hygiene, not a privilege boundary. It matters because `pattern_id` arrives straight from argv and from MCP callers, where "already has filesystem access" stops being obviously true.

**Worth recording how the tests for this were nearly vacuous.** A traversal to a path that does not exist is rejected by the pre-existing `exists()` check for the wrong reason, so every such case passes with or without containment — confirmed by running them against the unfixed source, where they passed. The escape target is now a real, loadable pattern file placed outside the library, with a sanity assertion that it loads, so a `None` result is containment refusing it rather than the file being unreadable. All four escape tests now fail pre-fix.

### #28 — reject at parse time

`--top-k` accepted any integer. Rejected at parse time rather than clamped downstream, because both out-of-range directions fail *silently and plausibly*:

- a negative value reaches a list slice as `results[:-3]`, which drops the **last** three results and returns the rest — plausible output for a nonsense request
- zero returns nothing, which reads as "no patterns match"

Bounds are the proposed 1–100.

### #27 — the test now tests what it is named for

`test_construct_search_relevance_ordering` built differentiated embeddings and then asserted only `index.embedder is not None`, never calling `search()`. Slightly worse than "only checks initialization": it carries the scaffolding for the assertion it does not make, which reads to a skimmer as though ordering were covered.

That settled the option choice — Option 2 was nearly free, since the differentiated embeddings already existed.

Two properties of the stub embedder are load-bearing, and **each is a way the original could not have worked even if the assertion had been present**:

- The vectors must be near-**orthogonal**, not merely unequal. FAISS normalizes to unit length for cosine similarity, so `[0.9]*768` and `[0.1]*768` normalize to the identical vector and rank equally.
- The discriminating token must be unique to one fixture. `"cache"` is not — the rate-limiting pattern inherits the caching pattern's tradeoff list, `"Cache invalidation complexity"` included, so keying on it puts both patterns on the same axis. (Found by writing the test and watching it fail.) `"token bucket"` appears only in the rate-limiting fixture.

A second case with a different query is included, so a `search()` that ignored its argument and returned directory order would still fail.

## How Has This Been Tested?

- [x] `1771 passed, 8 skipped` — full suite via the pre-commit hook
- [x] `ruff check src/ tests/ tools/` clean (pinned 0.16.1)
- [x] Every new test verified against the pre-fix source: the four #25 escape tests and the eight #28 rejection tests fail; the degenerate-id and in-range tests pass either way and are non-regression pins, not proofs
- [x] All three issues confirmed to still reproduce on `main` before any change

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS 26.5.2 (darwin)
- Neo version: 0.43.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`#26` from the same batch is already fixed on `main` (`parse_args(sys.argv[2:])`, no `sys.argv.pop`) and has been closed separately rather than included here.

**Behaviour an operator will notice:** `neo construct search --top-k 0` (or a negative, or >100) now exits 2 with a message naming the bounds, where it previously ran and returned a confusing result set.
