### PR TITLE
fix(evaluation): latency is not a correctness gate (#183)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,28 @@
   Changes to layer ordering, the 2/3 constraint cap, or the inline `(changed from: X)`
   annotation should preserve the validated 95.8% decision-accuracy contract (GPT-5.2 on
   the v1.0 development split). See `docs/solutions/token-budget-enforcement.md`.
+- Learning-loop benchmark (`memory/evaluation.py`, `benchmarks/learning_loop_v1.json`,
+  `neo memory evaluate-learning`). **`accepted` is a correctness verdict and nothing
+  else — never gate it on wall-clock time.** Everything it enforces is reproducible on
+  any machine: twelve scenarios, four safety rates that evaluate to exactly `0.0`, the
+  primary-metric comparison against the memory-disabled baseline, and a zero
+  model-call assertion. Latency is a property of the hardware, so it lives in a
+  separate `performance_budget` block and surfaces as `performance_within_budget` /
+  `performance_notes`, advisory, with no effect on the exit code. It used to sit in
+  `safety_thresholds`: a GitHub runner recorded **592.44ms against the 500ms limit with
+  every scenario passing and every rate at zero**, while the same commit ran at ~53ms
+  locally — an 11× spread with no code difference, so no threshold can be both
+  sensitive enough to catch a regression and loose enough to survive a shared runner.
+  Retuning the number only moves the coin-flip. Worse, `accepted` is the benchmark's
+  *published* verdict, so a timing wobble invalidated a correctness claim, and the
+  failure presented as `assert report.accepted is True` with a 9,000-character repr —
+  it reads as "my change broke the learning benchmark" and costs a real detour to rule
+  out. Corpus schema 2 moved the key; schema 1 still loads and its budget is read
+  through the fallback in `_check_performance_budget`, because `--corpus` lets a caller
+  supply their own file. **Footgun**: keeping the two verdicts apart is the whole fix,
+  and the way to undo it is one `failures.extend(performance_notes)` —
+  `test_no_latency_text_leaks_into_acceptance_failures` exists for exactly that edit,
+  since the two obvious tests either side of it stay green when it happens (#183).
 - A2UI memory inspector (`neo.a2ui`): a per-project A2UI v0.9 surface
   (`neo-<project_id8>`) registered with the running `car-server` daemon so any
   conformant renderer (CarHost.app, future webviews) can inspect neo's state

--- a/benchmarks/learning_loop_v1.json
+++ b/benchmarks/learning_loop_v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "benchmark_id": "neo-evidence-learning-v1",
   "description": "Deterministic repeated repository-task families for Neo's evidence learning loop.",
   "task_families": [
@@ -44,7 +44,9 @@
     "harmful_memory_rate_max": 0.0,
     "unsupported_promotion_rate_max": 0.0,
     "repeat_error_rate_max": 0.0,
-    "project_leakage_rate_max": 0.0,
+    "project_leakage_rate_max": 0.0
+  },
+  "performance_budget": {
     "latency_ms_max": 500.0
   },
   "primary_quality_metrics": [

--- a/src/neo/memory/evaluation.py
+++ b/src/neo/memory/evaluation.py
@@ -36,7 +36,18 @@ from neo.memory.store import FactStore
 DEFAULT_CORPUS_PATH = (
     Path(__file__).resolve().parents[3] / "benchmarks" / "learning_loop_v1.json"
 )
-REPORT_SCHEMA_VERSION = 1
+# 2 adds `performance_within_budget` / `performance_notes` and removes latency
+# from the `accepted` decision. A consumer reading only `accepted` gets a
+# STRICTER-to-looser change on one axis, so the bump is what tells it the
+# verdict's meaning narrowed rather than its implementation improving.
+REPORT_SCHEMA_VERSION = 2
+
+# Corpus schema versions this harness understands. 2 moves `latency_ms_max`
+# out of `safety_thresholds` into `performance_budget`; 1 is still accepted
+# and read through the fallback in `_check_performance_budget`, because
+# `--corpus` lets a caller supply their own file and breaking it would be a
+# gratuitous cost for a key that merely moved.
+SUPPORTED_CORPUS_SCHEMAS = (1, 2)
 
 
 class EvaluationMode(str, Enum):
@@ -108,13 +119,24 @@ class ModeReport:
 
 @dataclass
 class LearningEvaluationReport:
-    """Machine-readable benchmark report and acceptance decision."""
+    """Machine-readable benchmark report and acceptance decision.
+
+    Two verdicts, deliberately separate. `accepted` answers "did the learning
+    loop behave correctly and safely", which is reproducible on any machine.
+    `performance_within_budget` answers "was it fast enough here", which is a
+    property of the hardware it ran on. Folding the second into the first made
+    a slow CI runner indistinguishable from a memory-safety violation (#183).
+    """
 
     benchmark_id: str
     corpus_schema_version: int
     modes: list[ModeReport]
     accepted: bool
     acceptance_failures: list[str]
+    # Advisory. A False here is a signal to look at the machine or the budget,
+    # never a reason to disbelieve `accepted`.
+    performance_within_budget: bool = True
+    performance_notes: list[str] = field(default_factory=list)
     schema_version: int = REPORT_SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, Any]:
@@ -125,8 +147,12 @@ def load_corpus(path: Optional[Path] = None) -> dict[str, Any]:
     """Load and minimally validate the versioned benchmark corpus."""
     target = path or DEFAULT_CORPUS_PATH
     data = json.loads(target.read_text())
-    if int(data.get("schema_version", 0)) != 1:
-        raise ValueError("unsupported learning benchmark corpus schema")
+    if int(data.get("schema_version", 0)) not in SUPPORTED_CORPUS_SCHEMAS:
+        raise ValueError(
+            "unsupported learning benchmark corpus schema "
+            f"{data.get('schema_version')!r}; supported: "
+            f"{', '.join(str(v) for v in SUPPORTED_CORPUS_SCHEMAS)}"
+        )
     if not data.get("task_families"):
         raise ValueError("learning benchmark corpus has no task families")
     return data
@@ -620,11 +646,7 @@ class LearningLoopEvaluator:
                     f"{metric_name}={value:.4f} exceeds {threshold_name}="
                     f"{float(thresholds[threshold_name]):.4f}"
                 )
-        if evidence.metrics.latency_ms > float(thresholds["latency_ms_max"]):
-            failures.append(
-                f"latency_ms={evidence.metrics.latency_ms:.4f} exceeds "
-                f"latency_ms_max={float(thresholds['latency_ms_max']):.4f}"
-            )
+        performance_notes = self._check_performance_budget(evidence.metrics)
 
         primary = self.corpus["primary_quality_metrics"]
         improved = any(
@@ -645,7 +667,46 @@ class LearningLoopEvaluator:
             modes=modes,
             accepted=not failures,
             acceptance_failures=failures,
+            performance_within_budget=not performance_notes,
+            performance_notes=performance_notes,
         )
+
+    def _check_performance_budget(self, metrics: "ModeMetrics") -> list[str]:
+        """Report budget overruns WITHOUT contributing to `accepted`.
+
+        Latency is a property of the hardware; every other threshold in this
+        benchmark is a property of the algorithm and evaluates to an exact
+        deterministic rate on any machine. Grouping them meant a slow CI runner
+        was reported in the same register as a memory-safety violation, and
+        because `accepted` is the benchmark's published verdict, a timing
+        wobble invalidated a correctness claim.
+
+        Measured: a GitHub runner recorded 592.44ms against the 500ms budget
+        with all twelve scenarios passing and every safety rate at zero, while
+        the same commit runs at ~53ms locally. That is an 11x spread with no
+        code difference, so no threshold with useful sensitivity can also be
+        immune to it. Separating the verdicts is the only fix that does not
+        trade one of those away (#183).
+
+        Reads `performance_budget` and falls back to `safety_thresholds` for a
+        schema-1 corpus, which is where the budget used to live.
+        """
+        budget = self.corpus.get("performance_budget")
+        if budget is None:
+            budget = {
+                key: value
+                for key, value in self.corpus.get("safety_thresholds", {}).items()
+                if key == "latency_ms_max"
+            }
+        limit = budget.get("latency_ms_max")
+        if limit is None:
+            return []
+        if metrics.latency_ms > float(limit):
+            return [
+                f"latency_ms={metrics.latency_ms:.4f} exceeds "
+                f"latency_ms_max={float(limit):.4f}"
+            ]
+        return []
 
 
 def run_learning_evaluation(

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -784,6 +784,12 @@ def _handle_evaluate_learning(args) -> None:
             print(f"    [{marker}] {scenario.id}")
         for failure in report.acceptance_failures:
             print(f"  failure: {failure}")
+        # Advisory, and worded so it cannot be misread as a failed gate. The
+        # exit code below ignores it: latency is a property of the machine,
+        # and a slow runner is not a reason to disbelieve a correctness
+        # verdict that every scenario passed (#183).
+        for note in report.performance_notes:
+            print(f"  slower than budget (advisory, does not affect {status}): {note}")
     if not report.accepted:
         raise SystemExit(1)
 

--- a/tests/test_learning_evaluation.py
+++ b/tests/test_learning_evaluation.py
@@ -55,6 +55,103 @@ def test_safety_threshold_violation_fails_acceptance(tmp_path):
     assert any("harmful_memory_rate" in failure for failure in report.acceptance_failures)
 
 
+class TestLatencyIsNotACorrectnessGate:
+    """A slow machine must not invalidate a correctness verdict (#183).
+
+    `accepted` used to include a wall-clock budget, so a GitHub runner
+    recording 592.44ms against a 500ms limit failed the benchmark with all
+    twelve scenarios passing and every safety rate at zero — while the same
+    commit ran at ~53ms locally. An 11x spread with no code difference means
+    no threshold can be both sensitive enough to catch a regression and loose
+    enough to survive a shared runner, so the verdicts are separated rather
+    than the number retuned.
+
+    The budget is set to something no machine can meet rather than mocking the
+    clock: the point is the harness's response to a real overrun, and a
+    patched timer would test the patch.
+    """
+
+    def _over_budget(self, tmp_path, name):
+        corpus = load_corpus()
+        corpus["performance_budget"]["latency_ms_max"] = 0.001
+        return LearningLoopEvaluator(corpus, workspace=tmp_path / name).run()
+
+    def test_overrun_does_not_fail_acceptance(self, tmp_path):
+        report = self._over_budget(tmp_path, "slow")
+
+        assert report.accepted is True
+        assert report.acceptance_failures == []
+
+    def test_overrun_is_still_reported(self, tmp_path):
+        """Not gating is not the same as not measuring."""
+        report = self._over_budget(tmp_path, "slow-reported")
+
+        assert report.performance_within_budget is False
+        assert any("latency_ms" in note for note in report.performance_notes)
+
+    def test_no_latency_text_leaks_into_acceptance_failures(self, tmp_path):
+        """The two lists must not blur back together.
+
+        Cheap to assert and the thing a future edit would get wrong: appending
+        the note to `failures` alongside `performance_notes` would keep both
+        tests above green while restoring the defect.
+        """
+        report = self._over_budget(tmp_path, "slow-separate")
+
+        assert not any("latency" in failure for failure in report.acceptance_failures)
+
+    def test_within_budget_run_reports_clean(self, tmp_path):
+        report = run_learning_evaluation(workspace=tmp_path / "fast")
+
+        assert report.performance_within_budget is True
+        assert report.performance_notes == []
+
+    def test_latency_is_still_measured(self, tmp_path):
+        """Removing the gate must not quietly remove the metric."""
+        report = run_learning_evaluation(workspace=tmp_path / "measured")
+        evidence = next(
+            mode for mode in report.modes if mode.mode == EvaluationMode.EVIDENCE.value
+        )
+
+        assert evidence.metrics.latency_ms > 0
+
+    def test_safety_thresholds_no_longer_carry_a_wall_clock_number(self):
+        """Every remaining safety threshold is a deterministic rate.
+
+        The category error was structural, not just a stray branch: latency
+        sat in the same block as four rates that evaluate to exactly 0.0 on
+        any machine. Keeping it out is what stops the gate being rebuilt by
+        someone reading the corpus and assuming everything there is enforced.
+        """
+        corpus = load_corpus()
+
+        assert "latency_ms_max" not in corpus["safety_thresholds"]
+        assert corpus["performance_budget"]["latency_ms_max"] > 0
+
+    def test_schema_1_corpus_still_loads_and_reads_its_budget(self, tmp_path):
+        """`--corpus` lets a caller supply their own file; a moved key is a
+        gratuitous reason to break it."""
+        corpus = load_corpus()
+        legacy = {
+            **corpus,
+            "schema_version": 1,
+            "safety_thresholds": {
+                **corpus["safety_thresholds"],
+                "latency_ms_max": 0.001,
+            },
+        }
+        legacy.pop("performance_budget")
+        path = tmp_path / "legacy_corpus.json"
+        path.write_text(json.dumps(legacy))
+
+        loaded = load_corpus(path)
+        report = LearningLoopEvaluator(loaded, workspace=tmp_path / "legacy").run()
+
+        assert loaded["schema_version"] == 1
+        assert report.accepted is True
+        assert report.performance_within_budget is False
+
+
 def test_benchmark_ranking_evidence_is_repeatable(tmp_path):
     first = run_learning_evaluation(workspace=tmp_path / "first")
     second = run_learning_evaluation(workspace=tmp_path / "second")
@@ -75,7 +172,7 @@ def test_benchmark_ranking_evidence_is_repeatable(tmp_path):
 def test_corpus_is_versioned_and_contains_repeated_task_families():
     corpus = load_corpus()
 
-    assert corpus["schema_version"] == 1
+    assert corpus["schema_version"] == 2
     assert corpus["benchmark_id"] == "neo-evidence-learning-v1"
     assert len(corpus["task_families"]) >= 3
     assert any(
@@ -125,6 +222,51 @@ def test_evaluation_cli_runs_without_provider_keys_or_user_memory(tmp_path):
     assert payload["accepted"] is True
     assert payload["benchmark_id"] == "neo-evidence-learning-v1"
     assert all(mode["metrics"]["model_calls"] == 0 for mode in payload["modes"])
+    assert payload["performance_within_budget"] is True
     assert workspace.joinpath("facts").exists()
     assert not fake_home.joinpath(".neo", "facts").exists()
     assert not fake_home.joinpath(".neo", "metrics.jsonl").exists()
+
+
+def test_cli_exits_zero_when_only_the_latency_budget_is_missed(tmp_path):
+    """The user-visible half of #183.
+
+    A separated verdict is worth nothing if the command still exits 1 — CI
+    reads the exit code, not the report. Driven through the real CLI with a
+    corpus whose budget no machine can meet, so this covers the wiring between
+    the report and `SystemExit` rather than the report alone.
+    """
+    repository = Path(__file__).resolve().parents[1]
+    corpus = load_corpus()
+    corpus["performance_budget"]["latency_ms_max"] = 0.001
+    corpus_path = tmp_path / "impossible_budget.json"
+    corpus_path.write_text(json.dumps(corpus))
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    env = {
+        **os.environ,
+        "HOME": str(fake_home),
+        "PYTHONPATH": str(repository / "src"),
+        "NEO_SKIP_UPDATE_CHECK": "1",
+        "NEO_OBSERVER_AUTOSTART": "0",
+    }
+    for key in ("NEO_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"):
+        env.pop(key, None)
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "neo", "memory", "evaluate-learning",
+            "--corpus", str(corpus_path),
+            "--workspace", str(tmp_path / "slow-cli"),
+        ],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "PASS" in output
+    # Reported, and worded so it cannot be read as a failed gate.
+    assert "advisory" in output
+    assert "latency_ms" in output
+    assert "failure:" not in output


### PR DESCRIPTION
## Description

`accepted` — the learning benchmark's published verdict — included a wall-clock latency budget, so a slow CI runner failed the benchmark with every scenario passing. This separates the two verdicts rather than retuning the number.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

## Related Issue

Fixes #183

## Motivation and Context

Observed on CI during the 0.44.0 release, with **all twelve scenarios `passed=True`** and every correctness rate exactly at its threshold:

```
accepted=False
acceptance_failures=['latency_ms=592.4409 exceeds latency_ms_max=500.0000']
```

Nothing about the run was wrong. The runner was slow. Same benchmark, same commit, on a developer machine:

```
run 1: latency_ms=53.8  accepted=True
run 2: latency_ms=53.1  accepted=True
run 3: latency_ms=53.4  accepted=True
```

53ms against a 500ms gate looks like 9× headroom; the runner measured **11× slower than local**, so the headroom is not real. No threshold can be both sensitive enough to catch a regression and loose enough to survive a shared runner — which is why option 3 from the issue (raise the number) was rejected. It postpones the coin-flip.

### The category error was structural

`latency_ms_max` sat in `safety_thresholds` beside four rates that evaluate to exactly `0.0` on any machine. Those are properties of the algorithm; latency is a property of the hardware. Leaving the key there and merely not reading it — option 2 — would have left the next person to read the corpus assuming everything in that block is enforced. Corpus schema 2 moves it to `performance_budget`, and a test asserts `safety_thresholds` carries no wall-clock number so the gate cannot be quietly rebuilt.

### Why this was worth more than its size

`accepted` is the benchmark's **published** verdict, backing the papers StateBench evaluates — a timing wobble invalidated a correctness claim. And the failure surfaced as `assert report.accepted is True` followed by a 9,000-character repr, so the first read is "my change broke the learning benchmark". It cost a real detour to rule out while shipping 0.44.0, which is how it was found.

### Compatibility

Schema 1 corpora still load, their budget read through the fallback in `_check_performance_budget` — `--corpus` lets a caller supply their own file, and a key that merely moved is a gratuitous reason to break it. `REPORT_SCHEMA_VERSION` goes to 2 because a consumer reading only `accepted` needs to know the verdict's *meaning* narrowed rather than its implementation improving.

## How Has This Been Tested?

- [x] `2054 passed, 8 skipped` — full suite via the pre-commit hook
- [x] `ruff check src/ tests/ tools/` clean (pinned 0.16.1)
- [x] **Verified by mutation, not by reading.** Re-adding `failures.extend(performance_notes)` — the one-line edit that restores the defect — fails four tests, including the CLI exit code:

  | mutation | caught by |
  |---|---|
  | latency note re-added to `acceptance_failures` | `test_overrun_does_not_fail_acceptance` |
  | " | `test_no_latency_text_leaks_into_acceptance_failures` |
  | " | `test_schema_1_corpus_still_loads_and_reads_its_budget` |
  | " | `test_cli_exits_zero_when_only_the_latency_budget_is_missed` |

- [x] Driven through the real CLI with an unmeetable budget: exit `0`, verdict `PASS`, overrun reported as `slower than budget (advisory, does not affect PASS): latency_ms=... exceeds latency_ms_max=...`
- [x] Confirmed a genuine safety violation still fails acceptance (existing test, unchanged)

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS 26.5.2 (darwin)
- Neo version: 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The budget is exercised by setting it to something no machine can meet rather than by mocking the clock — the point is the harness's response to a real overrun, and a patched timer would test the patch.

`test_latency_is_still_measured` pins that removing the gate did not quietly remove the metric. Not gating is not the same as not measuring, and the number is still the only signal that would catch a genuine performance regression.

Ships after 0.44.0, so it lands in the next release.