### PR TITLE
fix(dry-run): show what would actually be sent, and stop the panel billing you

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,12 +551,33 @@
   `pi_boost + hist_boost + _symbol_score` and applies an adaptive limit and a byte
   budget. A first-pass harness overstated R@10 by 0.14 against the real CLI. Validate
   any in-process replica against `--dry-run` output before trusting a sweep.
-- Debugging: `neo --dry-run "your query"` assembles the full context (file selection,
-  fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
-  the LM, then exits without making the LLM call. Faster iteration on context-gatherer
-  and retrieval changes than waiting for an inference round trip. **Use it before
-  believing any claim about what Neo "saw"** — the two defects below were both
-  invisible from the outside and presented as the model being unhelpful.
+- Debugging: `neo --dry-run "your query"` runs the real engine — file selection, fact
+  retrieval, constraints, four-layer assembly — and prints the **exact messages** that
+  would go to the provider, then exits without making the LLM call. Faster iteration on
+  context-gatherer and retrieval changes than waiting for an inference round trip.
+  **Use it before believing any claim about what Neo "saw"** — the two defects below
+  were both invisible from the outside and presented as the model being unhelpful.
+  This bullet described the tool's *intent* for a long time and not its behaviour: the
+  flag used to exit in `cli.main` **before the engine was constructed**, so three of
+  the four things listed above never ran and the output was the file list alone. The
+  Execution Envelope, retrieved facts, and the REPOSITORY CONTEXT block with its
+  truncation markers — the #178 work, whose entire point is that a cut be visible —
+  were all uninspectable through the tool built for inspecting them. An instrument
+  that under-reports sends the operator to the wrong knob, which is the same failure
+  as a cap that blames itself for an absence it did not cause.
+  **The prompt is recorded, never rebuilt** (`neo.dry_run.RecordingLM` is a real
+  `LMAdapter` installed in the engine's own `self.lm` slot), because a renderer that
+  walked the context dict would be a second implementation of the seven prompt
+  builders, free to drift the moment one changed — the duplicated-rule shape that put
+  `EXCLUDED_DIR_NAMES` in two places. `DryRunComplete` derives from `BaseException`,
+  not `Exception`: `_process_guarded` converts anything its `except Exception` catches
+  into a `FAILED` lifecycle event, and reporting a dry run as a crash would be one
+  more way of misdescribing the run. **A dry run mutates nothing** — the old
+  implementation had that for free by never reaching the engine, so `dry_run=True`
+  now skips `detect_implicit_feedback`, the one pre-inference call that both changes
+  confidence and saves. Pinned by `test_dry_run_skips_the_one_call_that_saves`; the
+  file-diffing test beside it is a backstop only and stays green either way, because
+  that call is a no-op without a prior session.
 - Project index (`index/project_index.py`, `index/language_parser.py`; full
   notes in `docs/tree-sitter-setup.md`). Three invariants, each of which was
   violated and each of which produced an index that could not answer a question

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,15 +597,26 @@
   reaching the engine at all meant a "read-only" inspection was aging the store it
   inspected. `FactStore(read_only=True)` makes `save()` a no-op at the single write
   choke point, which a new caller cannot forget; `dry_run` also skips
-  `detect_implicit_feedback`. Retrieval still marks facts accessed in memory, and
-  `metrics.jsonl` still records the run — deliberately: the two events it writes
-  (`execution_context_resolved`, `retrieve`) are read by neither `citation-stats`
-  (which filters `citation_survival`) nor `learning-stats` (which reads the episode
-  ledger), so observability costs nothing here.
-  Under `--json` the report is the single stdout document and a terminal `completed`
-  event is emitted, because writing prose to stderr broke both `--json` invariants at
-  once: zero documents on stdout, and every source line beginning with `{` became a
-  counterfeit event.
+  `detect_implicit_feedback` and `_complete_learning_episode`. Retrieval still marks
+  facts accessed in memory, and `metrics.jsonl` still records the run —
+  deliberately: the two events it writes (`execution_context_resolved`, `retrieve`)
+  are read by neither `citation-stats` (which filters `citation_survival`) nor
+  `learning-stats` (which reads the episode ledger), so observability costs nothing.
+  **That argument was measured on the fast path and briefly untrue on another.**
+  VERIFY mode reasons without an LM call, so `process()` returns NORMALLY and never
+  raises `DryRunComplete`; `_complete_learning_episode` then wrote an episode file
+  AND a `citation_survival` metric — the exact two surfaces the sentence above
+  claims are untouched. Measured on a clean HOME: 1 episode, 1 `citation_survival`.
+  Gating that call is what makes the claim true; do not narrow the gate to the
+  recorded-call path.
+  Under `--json` the report is the single stdout document (`{dry_run, calls, note}`
+  — a second schema, discriminated by `dry_run: true`, with no `orchestrator` key;
+  `test_host_adapter_parity.py` does not know about it) and a terminal
+  `phase_completed(reasoning)` + `completed` pair is emitted. Writing prose to
+  stderr broke both `--json` invariants at once: zero documents on stdout, and every
+  source line beginning with `{` became a counterfeit event. **Both dry-run exits
+  route through `cli._report_dry_run`** — there are two, the recorded call and the
+  normal return, and the second shipped without the `--json` handling the first had.
 - Project index (`index/project_index.py`, `index/language_parser.py`; full
   notes in `docs/tree-sitter-setup.md`). Three invariants, each of which was
   violated and each of which produced an index that could not answer a question

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,15 +569,43 @@
   `LMAdapter` installed in the engine's own `self.lm` slot), because a renderer that
   walked the context dict would be a second implementation of the seven prompt
   builders, free to drift the moment one changed — the duplicated-rule shape that put
-  `EXCLUDED_DIR_NAMES` in two places. `DryRunComplete` derives from `BaseException`,
+  `EXCLUDED_DIR_NAMES` in two places. What it shows is the adapter's INPUT, not the
+  wire payload: Anthropic hoists `system` into a separate kwarg, Google remaps roles,
+  Ollama flattens, CAR adds `intent_json`, and no provider is resolved at all because
+  the flag deliberately requires no credentials. The output says so rather than
+  claiming exactness it cannot have.
+  `DryRunComplete` derives from `BaseException`,
   not `Exception`: `_process_guarded` converts anything its `except Exception` catches
   into a `FAILED` lifecycle event, and reporting a dry run as a crash would be one
-  more way of misdescribing the run. **A dry run mutates nothing** — the old
-  implementation had that for free by never reaching the engine, so `dry_run=True`
-  now skips `detect_implicit_feedback`, the one pre-inference call that both changes
-  confidence and saves. Pinned by `test_dry_run_skips_the_one_call_that_saves`; the
-  file-diffing test beside it is a backstop only and stays green either way, because
-  that call is a no-op without a prior session.
+  more way of misdescribing the run. An ordinary exception is NOT a safe substitute —
+  `_deliberate` has its own `except Exception` that would swallow it and silently
+  fall back to the fast path.
+  **The panel is forced OFF** under `dry_run`. This is correctness, not tidiness:
+  `_build_car_role_factory` calls `create_adapter("car", model=m)` per role and uses
+  `self.lm` only as the fallback, so `RecordingLM` never intercepts it. With
+  `car-server` reachable — the normal setup here, since the observer autostarts off
+  it — a novel prompt under `--dry-run` ran the full panel against real models, spent
+  real money, never raised `DryRunComplete`, and printed ordinary output. Measured: 4
+  real adapters built. It is also the honest scope, since the panel's later prompts
+  are built from earlier model responses and cannot be shown without making the calls
+  the flag exists to avoid.
+  **A dry run does not modify the fact store**, which is narrower than "mutates
+  nothing" and is the claim that survives measurement. The old implementation got it
+  for free by never constructing a `FactStore`; `FactStore.initialize` runs
+  `prune_stale_facts` → `demote_unhelpful_facts` → `purge_dead_facts` and then
+  **saves**, and `demote_unhelpful_facts` lowers confidence and invalidates facts — so
+  reaching the engine at all meant a "read-only" inspection was aging the store it
+  inspected. `FactStore(read_only=True)` makes `save()` a no-op at the single write
+  choke point, which a new caller cannot forget; `dry_run` also skips
+  `detect_implicit_feedback`. Retrieval still marks facts accessed in memory, and
+  `metrics.jsonl` still records the run — deliberately: the two events it writes
+  (`execution_context_resolved`, `retrieve`) are read by neither `citation-stats`
+  (which filters `citation_survival`) nor `learning-stats` (which reads the episode
+  ledger), so observability costs nothing here.
+  Under `--json` the report is the single stdout document and a terminal `completed`
+  event is emitted, because writing prose to stderr broke both `--json` invariants at
+  once: zero documents on stdout, and every source line beginning with `{` became a
+  counterfeit event.
 - Project index (`index/project_index.py`, `index/language_parser.py`; full
   notes in `docs/tree-sitter-setup.md`). Three invariants, each of which was
   violated and each of which produced an index that could not answer a question

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -709,6 +709,22 @@ def _configure_logging(args) -> None:
         logging.getLogger(name).setLevel(max(level, logging.WARNING))
 
 
+def _emit_dry_run_terminal_event() -> None:
+    """Close the JSONL stream a dry run opened.
+
+    `--json` promises every run ends with `completed` or `FAILED`, because a
+    host cannot tell STARTED-then-silence from a crash or a hang. A dry run
+    raises past the engine's own COMPLETED emit, so the CLI closes the stream
+    itself rather than leaving `reasoning` running forever.
+    """
+    from neo.events import JsonlSink, NeoEvent, NeoEventType
+
+    JsonlSink(sys.stderr).emit(NeoEvent(
+        type=NeoEventType.COMPLETED,
+        message="dry run: context assembled, no inference performed",
+    ))
+
+
 def _print_selected_files(gathered) -> None:
     """Report the gatherer's choice: which files, which lines, what score.
 
@@ -1138,9 +1154,9 @@ def main():
             if args.dry_run:
                 _print_selected_files(gathered)
 
-        if args.dry_run and not gathered:
-            # No gatherer ran (explicit --file / stdin), so report what the
-            # caller supplied instead of printing nothing above the prompt.
+        if args.dry_run and args.no_scan:
+            # Keyed on --no-scan, not on `not gathered`: a scan that legitimately
+            # finds zero files would otherwise print BOTH reports, each empty.
             _print_supplied_files(neo_input.context_files)
 
     if neo_input.operating_mode is OperatingMode.AGENT:
@@ -1213,11 +1229,42 @@ def main():
         )
         try:
             output = engine.process(neo_input)
+            if args.dry_run:
+                # `process()` returning normally under --dry-run means no LM
+                # call was ever assembled: VERIFY mode reasons without one,
+                # and the budget-skip branch closes reasoning as `skipped`.
+                # Without this the command exits 0 having printed ordinary
+                # output, and the operator reads it as the dry-run report.
+                print(render([]), file=sys.stderr)
+                sys.exit(0)
         except DryRunComplete as complete:
             # Not an error path. `DryRunComplete` is a BaseException so the
             # engine's own `except Exception` cannot mistake assembly-finished
             # for a crash; see `neo.dry_run`.
-            print(render(complete.calls), file=sys.stderr)
+            #
+            # Under --json the report goes to STDOUT as the single JSON
+            # document that contract promises, not to stderr. Writing prose
+            # to stderr there broke two documented invariants at once: stdout
+            # carried zero documents, and every source line beginning with
+            # `{` became a counterfeit event for a host parsing the JSONL
+            # stream by that prefix. The synthetic terminal event exists
+            # because the engine raised past its own COMPLETED emit, and
+            # STARTED-then-silence is precisely what a host cannot
+            # distinguish from a crash or a hang.
+            if args.json:
+                print(json.dumps({
+                    "dry_run": True,
+                    "calls": complete.calls,
+                    "note": (
+                        "messages as Neo hands them to the adapter; the "
+                        "provider adapter restructures them (Anthropic "
+                        "hoists system, Google remaps roles, Ollama "
+                        "flattens, CAR adds intent_json)"
+                    ),
+                }, indent=2))
+                _emit_dry_run_terminal_event()
+            else:
+                print(render(complete.calls), file=sys.stderr)
             sys.exit(0)
     except TimeoutError as e:
         error_output = {

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -38,6 +38,7 @@ from neo.models import (  # noqa: E402, F401
     CodeSuggestion, StaticCheckResult, NeoOutput, RegenerateStats, LMAdapter,
     ProposedChange, classify_task_type,
 )
+from neo.dry_run import DryRunComplete, RecordingLM, render  # noqa: E402
 from neo import progress  # noqa: E402
 from neo.operating_mode import AuthorityPolicy, OperatingMode  # noqa: E402
 from neo.execution_context import execution_fields_from_dict  # noqa: E402
@@ -708,6 +709,36 @@ def _configure_logging(args) -> None:
         logging.getLogger(name).setLevel(max(level, logging.WARNING))
 
 
+def _print_selected_files(gathered) -> None:
+    """Report the gatherer's choice: which files, which lines, what score.
+
+    Kept even though the assembled prompt is printed in full below it. The
+    prompt shows the file CONTENT that survived; this shows the ranking that
+    produced it, including the score — the number an operator needs when the
+    right file is missing and they want to know whether it lost or was never
+    eligible.
+    """
+    print("\n=== DRY RUN: files selected, in rank order ===\n", file=sys.stderr)
+    for gf in gathered:
+        lines_info = f" (lines {gf.start}-{gf.end})" if gf.start else ""
+        print(
+            f"  {gf.rel_path}{lines_info} - {gf.bytes} bytes "
+            f"(score: {gf.score:.2f})",
+            file=sys.stderr,
+        )
+
+
+def _print_supplied_files(context_files) -> None:
+    """The same report for callers that supplied files instead of gathering."""
+    print("\n=== DRY RUN: files supplied by the caller ===\n", file=sys.stderr)
+    for cf in context_files:
+        content = cf.content or ""
+        print(
+            f"  {cf.path} - {len(content.encode('utf-8'))} bytes",
+            file=sys.stderr,
+        )
+
+
 def main():
     """Main entry point for stdin/stdout interface."""
     # Parse arguments
@@ -1061,6 +1092,10 @@ def main():
         if not args.dry_run:
             _print_neo_greeting(prompt, working_dir)
 
+        # Bound before the branch: `--no-scan` skips the gatherer entirely and
+        # the dry-run report below still has to say something truthful.
+        gathered = []
+
         # Gather context from working directory unless --no-scan
         if not args.no_scan:
             from neo.context_gatherer import gather_context, gather_context_semantic, GatherConfig
@@ -1101,20 +1136,12 @@ def main():
             progress.note("Invoking LLM inference...")
 
             if args.dry_run:
-                print("\n=== DRY RUN: Context that would be sent ===\n", file=sys.stderr)
-                for gf in gathered:
-                    lines_info = f" (lines {gf.start}-{gf.end})" if gf.start else ""
-                    print(f"  {gf.rel_path}{lines_info} - {gf.bytes} bytes (score: {gf.score:.2f})", file=sys.stderr)
-                print(f"\nPrompt: {prompt[:200]}...\n", file=sys.stderr)
-                sys.exit(0)
+                _print_selected_files(gathered)
 
-        if args.dry_run:
-            print("\n=== DRY RUN: Context that would be sent ===\n", file=sys.stderr)
-            for cf in neo_input.context_files:
-                content = cf.content or ""
-                print(f"  {cf.path} - {len(content.encode('utf-8'))} bytes", file=sys.stderr)
-            print(f"\nPrompt: {prompt[:200]}...\n", file=sys.stderr)
-            sys.exit(0)
+        if args.dry_run and not gathered:
+            # No gatherer ran (explicit --file / stdin), so report what the
+            # caller supplied instead of printing nothing above the prompt.
+            _print_supplied_files(neo_input.context_files)
 
     if neo_input.operating_mode is OperatingMode.AGENT:
         print(json.dumps({
@@ -1148,8 +1175,17 @@ def main():
                 if cfg_level is not None:
                     logging.getLogger().setLevel(cfg_level)
 
+        # `--dry-run` resolves no provider and needs no credentials: it makes
+        # no call, so requiring an API key to find out what Neo would have
+        # sent is a barrier with nothing behind it. The old implementation got
+        # this by exiting before this line; now it is explicit, because moving
+        # the stop into the engine moved it PAST adapter construction and
+        # briefly reintroduced the requirement (caught by
+        # `test_no_scan_dry_run_does_not_require_api_key`).
         adapter = (
-            _VerificationOnlyAdapter()
+            RecordingLM()
+            if args.dry_run
+            else _VerificationOnlyAdapter()
             if neo_input.operating_mode is OperatingMode.VERIFY
             else resolve_adapter(config)
         )
@@ -1173,8 +1209,16 @@ def main():
             codebase_root=neo_input.working_directory,
             config=config,
             event_sink=JsonlSink(sys.stderr) if args.json else None,
+            dry_run=args.dry_run,
         )
-        output = engine.process(neo_input)
+        try:
+            output = engine.process(neo_input)
+        except DryRunComplete as complete:
+            # Not an error path. `DryRunComplete` is a BaseException so the
+            # engine's own `except Exception` cannot mistake assembly-finished
+            # for a crash; see `neo.dry_run`.
+            print(render(complete.calls), file=sys.stderr)
+            sys.exit(0)
     except TimeoutError as e:
         error_output = {
             "error": "RequestTimeout",

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -709,6 +709,29 @@ def _configure_logging(args) -> None:
         logging.getLogger(name).setLevel(max(level, logging.WARNING))
 
 
+def _report_dry_run(args, calls) -> None:
+    """Single exit for every dry-run report, in both output modes.
+
+    One function because there are TWO ways a dry run ends -- a recorded
+    call, and `process()` returning without ever making one (VERIFY, or the
+    budget-skip branch) -- and the second was missing the `--json` handling
+    the first had.
+    """
+    if args.json:
+        print(json.dumps({
+            "dry_run": True,
+            "calls": calls,
+            "note": (
+                "messages as Neo hands them to the adapter; the provider "
+                "adapter restructures them (Anthropic hoists system, Google "
+                "remaps roles, Ollama flattens, CAR adds intent_json)"
+            ),
+        }, indent=2))
+        _emit_dry_run_terminal_event()
+    else:
+        print(render(calls), file=sys.stderr)
+
+
 def _emit_dry_run_terminal_event() -> None:
     """Close the JSONL stream a dry run opened.
 
@@ -719,7 +742,18 @@ def _emit_dry_run_terminal_event() -> None:
     """
     from neo.events import JsonlSink, NeoEvent, NeoEventType
 
-    JsonlSink(sys.stderr).emit(NeoEvent(
+    sink = JsonlSink(sys.stderr)
+    # Close `reasoning` first. Invariant 3 ("every phase_completed has a
+    # phase_started") survives without this, but the converse does not: the
+    # dry run raises out of an OPEN reasoning phase, so a host tracking open
+    # phases is left with one that never closes.
+    sink.emit(NeoEvent(
+        type=NeoEventType.PHASE_COMPLETED,
+        phase="reasoning",
+        message="dry run: stopped before inference",
+        data={"status": "dry_run"},
+    ))
+    sink.emit(NeoEvent(
         type=NeoEventType.COMPLETED,
         message="dry run: context assembled, no inference performed",
     ))
@@ -1235,7 +1269,14 @@ def main():
                 # and the budget-skip branch closes reasoning as `skipped`.
                 # Without this the command exits 0 having printed ordinary
                 # output, and the operator reads it as the dry-run report.
-                print(render([]), file=sys.stderr)
+                #
+                # Routed through the same helper as the recorded-call branch.
+                # It previously inlined `render([])` to stderr with no --json
+                # handling, so `--stdin-json --json --dry-run` in VERIFY mode
+                # emitted zero stdout documents -- the identical invariant
+                # break, on the same command, fixed on one path and not its
+                # twin five lines away.
+                _report_dry_run(args, [])
                 sys.exit(0)
         except DryRunComplete as complete:
             # Not an error path. `DryRunComplete` is a BaseException so the
@@ -1251,20 +1292,7 @@ def main():
             # because the engine raised past its own COMPLETED emit, and
             # STARTED-then-silence is precisely what a host cannot
             # distinguish from a crash or a hang.
-            if args.json:
-                print(json.dumps({
-                    "dry_run": True,
-                    "calls": complete.calls,
-                    "note": (
-                        "messages as Neo hands them to the adapter; the "
-                        "provider adapter restructures them (Anthropic "
-                        "hoists system, Google remaps roles, Ollama "
-                        "flattens, CAR adds intent_json)"
-                    ),
-                }, indent=2))
-                _emit_dry_run_terminal_event()
-            else:
-                print(render(complete.calls), file=sys.stderr)
+            _report_dry_run(args, complete.calls)
             sys.exit(0)
     except TimeoutError as e:
         error_output = {

--- a/src/neo/dry_run.py
+++ b/src/neo/dry_run.py
@@ -1,0 +1,131 @@
+"""`--dry-run`: show what would actually be sent to the model.
+
+The old implementation exited in `cli.main` **before the engine was
+constructed**, so it could only ever print the file-gathering result. That is
+not what it claimed. `CLAUDE.md` told operators the flag "assembles the full
+context (file selection, fact retrieval, constraints, four-layer assembly) and
+prints what *would* be sent to the LM"; three of those four never ran. The
+Execution Envelope reaches the model through seven prompt builders, retrieved
+facts drive the whole memory system, and the REPOSITORY CONTEXT block carries
+the truncation markers that exist specifically so a cut is visible -- and none
+of it was inspectable through the tool built for inspecting it.
+
+That mattered more than an ordinary documentation slip, because `--dry-run` is
+the instrument the project tells people to use *before believing any claim
+about what Neo saw*. An instrument that under-reports sends the operator
+looking in the wrong place, which is the same failure as a cap that blames the
+wrong knob.
+
+**The prompt is recorded, never reconstructed.** `RecordingLM` is a real
+`LMAdapter` installed in the engine's own `self.lm` slot, so what gets printed
+is the exact `messages` list the provider adapter would have received. A
+renderer that walked the context dict and re-assembled the prompt would be a
+second implementation of the prompt builders, free to drift from the seven
+real ones the moment any of them changed -- the same duplicated-rule shape
+that put `EXCLUDED_DIR_NAMES` in two places and cost a release.
+
+`DryRunComplete` derives from `BaseException`, not `Exception`, and that is
+load-bearing: `NeoEngine._process_guarded` wraps the run in `except Exception`
+and converts anything it catches into a `FAILED` lifecycle event. A dry run is
+not a failure, and reporting one as a crash would be a third way of lying
+about what happened. `finally` blocks still run, so the overseer stops and the
+engine lock releases exactly as on any other path.
+"""
+
+from typing import Any, Optional
+
+from neo.models import LMAdapter
+
+
+class DryRunComplete(BaseException):
+    """Control-flow signal: assembly finished, stop before inference.
+
+    `BaseException` on purpose -- see the module docstring. It carries the
+    recorded calls so the caller does not have to reach back into the engine.
+    """
+
+    def __init__(self, calls: list[dict[str, Any]]):
+        super().__init__("dry run complete")
+        self.calls = calls
+
+
+class RecordingLM(LMAdapter):
+    """An `LMAdapter` that captures one call's messages and stops the run.
+
+    Raising on the FIRST call is deliberate. Letting the run continue would
+    mean either returning a stub -- which the parser downstream would reject,
+    producing a repair loop and a second call -- or making real requests,
+    which is the one thing `--dry-run` promises not to do. One call is also
+    all that is needed: every builder assembles from the same enriched
+    context, so the first prompt is the one that answers "what did Neo see".
+    """
+
+    #: Advertised so `_decide_reasoning_mode` and any capability probe see a
+    #: plausible model rather than an empty string.
+    model = "dry-run"
+    provider = "dry-run"
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def name(self) -> str:
+        return "dry-run"
+
+    def generate(
+        self,
+        messages: list[dict[str, str]],
+        stop: Optional[list[str]] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: Optional[str] = None,
+    ) -> str:
+        self.calls.append({
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "reasoning_effort": reasoning_effort,
+            "stop": stop,
+        })
+        raise DryRunComplete(self.calls)
+
+
+def render(calls: list[dict[str, Any]], gathered: Any = None) -> str:
+    """Format recorded calls for the console.
+
+    Prints every message role in full. There is no truncation here on purpose:
+    this output exists so an operator can see what the model got, and a viewer
+    that silently cut its own output would reproduce, one level up, the exact
+    defect the `text_budget` markers were introduced to fix.
+    """
+    out: list[str] = []
+    if not calls:
+        out.append(
+            "No LM call was assembled. The run ended before reaching the "
+            "model -- usually a budget skip or an early return, not an empty "
+            "prompt."
+        )
+        return "\n".join(out)
+
+    call = calls[0]
+    total = sum(len(m.get("content") or "") for m in call["messages"])
+    out.append("=== DRY RUN: the exact prompt that would be sent ===")
+    out.append("")
+    out.append(
+        f"model params: max_tokens={call['max_tokens']} "
+        f"temperature={call['temperature']} "
+        f"reasoning_effort={call['reasoning_effort']}"
+    )
+    out.append(f"{len(call['messages'])} message(s), {total:,} chars total")
+    out.append("")
+
+    for i, message in enumerate(call["messages"], 1):
+        content = message.get("content") or ""
+        role = message.get("role", "?")
+        out.append(f"--- message {i}/{len(call['messages'])}: {role} "
+                   f"({len(content):,} chars) ---")
+        out.append(content)
+        out.append("")
+
+    if len(calls) > 1:  # pragma: no cover - RecordingLM stops at the first
+        out.append(f"({len(calls) - 1} further call(s) recorded)")
+    return "\n".join(out)

--- a/src/neo/dry_run.py
+++ b/src/neo/dry_run.py
@@ -16,13 +16,30 @@ about what Neo saw*. An instrument that under-reports sends the operator
 looking in the wrong place, which is the same failure as a cap that blames the
 wrong knob.
 
+**One call, and only the first.** `RecordingLM` stops at the first
+`generate()`. The multi-agent panel is separately suppressed under `dry_run`
+(see `NeoEngine._decide_reasoning_mode`) for two reasons: it routes around
+`self.lm` to real CAR adapters and would bill you under a flag that promises
+no calls, and its later prompts are built from earlier model responses, so
+they cannot be shown without making the calls this flag exists to avoid.
+
 **The prompt is recorded, never reconstructed.** `RecordingLM` is a real
 `LMAdapter` installed in the engine's own `self.lm` slot, so what gets printed
-is the exact `messages` list the provider adapter would have received. A
-renderer that walked the context dict and re-assembled the prompt would be a
-second implementation of the prompt builders, free to drift from the seven
-real ones the moment any of them changed -- the same duplicated-rule shape
-that put `EXCLUDED_DIR_NAMES` in two places and cost a release.
+is the exact `messages` list Neo hands the adapter. A renderer that walked the
+context dict and re-assembled the prompt would be a second implementation of
+the prompt builders, free to drift from the seven real ones the moment any of
+them changed -- the same duplicated-rule shape that put `EXCLUDED_DIR_NAMES`
+in two places and cost a release.
+
+That is the adapter's INPUT, not the wire payload, and the distinction is
+worth keeping straight because half the adapters restructure it: Anthropic
+hoists the system message into a separate `system=` kwarg, Google remaps
+`system`->`user` and `content`->`parts`, Ollama flattens everything into one
+delimited string, and CAR sends a flattened `prompt` and an `intent_json`
+alongside. Rendering the true wire payload would mean resolving a provider,
+which needs credentials -- and requiring an API key to find out what Neo would
+have sent is a barrier with nothing behind it. So the scope is named in the
+output rather than quietly overclaimed.
 
 `DryRunComplete` derives from `BaseException`, not `Exception`, and that is
 load-bearing: `NeoEngine._process_guarded` wraps the run in `except Exception`
@@ -60,8 +77,12 @@ class RecordingLM(LMAdapter):
     context, so the first prompt is the one that answers "what did Neo see".
     """
 
-    #: Advertised so `_decide_reasoning_mode` and any capability probe see a
-    #: plausible model rather than an empty string.
+    #: Set because `NeoOutput` and the metrics layer read `.model`/`.provider`
+    #: off the adapter and would otherwise report an empty string. NOT read by
+    #: `_decide_reasoning_mode`, which never consults `self.lm` -- the panel is
+    #: suppressed under `dry_run` in the engine instead, because
+    #: `_build_car_role_factory` builds real CAR adapters and would route
+    #: around this class entirely.
     model = "dry-run"
     provider = "dry-run"
 
@@ -108,12 +129,27 @@ def render(calls: list[dict[str, Any]], gathered: Any = None) -> str:
 
     call = calls[0]
     total = sum(len(m.get("content") or "") for m in call["messages"])
-    out.append("=== DRY RUN: the exact prompt that would be sent ===")
+    out.append("=== DRY RUN: the messages Neo hands the adapter ===")
     out.append("")
     out.append(
-        f"model params: max_tokens={call['max_tokens']} "
+        "This is Neo's request, not the wire payload. The provider adapter "
+        "restructures it: Anthropic hoists the system message into a separate "
+        "`system=` argument, Google remaps roles and content keys, Ollama "
+        "flattens everything into one string, and CAR adds an intent hint. "
+        "Which adapter would run is not resolved here, because --dry-run "
+        "deliberately requires no credentials."
+    )
+    out.append("")
+    out.append(
+        f"engine requested: max_tokens={call['max_tokens']} "
         f"temperature={call['temperature']} "
-        f"reasoning_effort={call['reasoning_effort']}"
+        f"reasoning_effort={call['reasoning_effort']} "
+        f"stop={call['stop']!r}"
+    )
+    out.append(
+        "  (providers drop what they do not accept -- Anthropic ignores "
+        "temperature on Opus 4.7+/Sonnet 5, CAR lets backend defaults win, "
+        "and reasoning_effort reaches only the OpenAI-family adapters.)"
     )
     out.append(f"{len(call['messages'])} message(s), {total:,} chars total")
     out.append("")

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -245,6 +245,10 @@ class NeoEngine:
                         codebase_root=codebase_root,
                         config=config,
                         lm_adapter=lm_adapter,
+                        # `initialize()` prunes, demotes and purges, then
+                        # saves -- all before inference. A dry run must not
+                        # age the store it is inspecting.
+                        read_only=dry_run,
                     )
                     # Set persistent_memory for backward compat in methods that check it
                     self.persistent_memory = self.fact_store
@@ -2174,8 +2178,32 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
             return False, 0, None
 
     def _decide_reasoning_mode(self, context: dict[str, Any], difficulty: str, neo_input):
-        """Gate: fast vs multi-agent. Returns (ModeDecision, route_fn|None)."""
+        """Gate: fast vs multi-agent. Returns (ModeDecision, route_fn|None).
+
+        `dry_run` forces FAST, and that is a correctness requirement rather
+        than a shortcut. The panel does NOT reason through `self.lm`:
+        `_build_car_role_factory` calls `create_adapter("car", model=m)` per
+        role and uses `self.lm` only as the fallback for unassigned roles. So
+        a `RecordingLM` does not intercept the panel — on a machine with
+        `car-server` reachable, which is this project's documented normal
+        setup because the observer autostarts off it, `--dry-run` on a novel
+        prompt would run the full multi-agent panel against real models,
+        spend real money, never raise `DryRunComplete`, and print ordinary
+        output. The flag would become a no-op that bills you.
+
+        Forcing FAST is also the honest choice for what the flag reports: the
+        panel's later prompts are built from earlier model responses, so they
+        cannot be shown without making the calls that `--dry-run` exists to
+        avoid.
+        """
         from neo.reasoning_mode import decide_mode
+
+        if self.dry_run:
+            from neo.reasoning_mode import ModeDecision, ReasoningMode
+            return ModeDecision(
+                mode=ReasoningMode.FAST,
+                reason="dry-run: the panel routes around self.lm to real CAR adapters",
+            ), None
         signal = self._compute_memory_signal(context)
         explicit = (getattr(self.config, "reasoning_mode", "auto") if self.config else "auto") or "auto"
         explicit = None if explicit.lower() == "auto" else explicit.lower()

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -1611,9 +1611,19 @@ class NeoEngine:
         self, *, code_suggestions, static_checks, reasoning_fact,
         simulation_facts, metadata,
     ) -> None:
-        """Finalize and persist the task evidence without promoting knowledge."""
+        """Finalize and persist the task evidence without promoting knowledge.
+
+        Skipped entirely under `dry_run`, and that path is reachable: VERIFY
+        mode reasons without an LM call, so `process()` returns NORMALLY and
+        never raises `DryRunComplete` -- and this method then writes an
+        episode file AND a `citation_survival` metric. Those are exactly the
+        two surfaces `learning-stats` and `citation-stats` read, so a dry run
+        was polluting both "is it learning?" dashboards. Measured on a clean
+        HOME: `--stdin-json --json --dry-run` in VERIFY mode produced 1
+        episode and 1 `citation_survival` line.
+        """
         episode = self.current_learning_episode
-        if episode is None:
+        if episode is None or self.dry_run:
             return
         from neo.memory.episodes import (
             aggregate_verification_status,
@@ -2200,6 +2210,29 @@ CRITICAL: Start with <<<. NO text before, between, or after blocks. id format: "
 
         if self.dry_run:
             from neo.reasoning_mode import ModeDecision, ReasoningMode
+
+            # Say so, unconditionally and without asking anything. Silence
+            # would reproduce one level up the defect this flag exists to
+            # expose -- fast-path output on a machine that would have
+            # deliberated is a report about a run Neo would not have made.
+            #
+            # But the note must not overclaim either, and the obvious version
+            # did: gating on `car_available` announces a suppressed panel on
+            # any car-server machine, including for the familiar, low-effort
+            # prompts that would have taken the fast path anyway. That is the
+            # failure `shown_of` already forbids -- a marker that fires when
+            # nothing was dropped trains the reader to ignore it.
+            # Reconstructing the real answer needs `capable_model_count` and
+            # the effort tier, i.e. a CAR daemon round-trip taken purely to
+            # decide whether to print a string, under a flag that promises no
+            # calls. So the note states what is unconditionally true instead.
+            from neo import progress
+
+            progress.note(
+                "dry-run: always takes the fast path; the multi-agent panel "
+                "is never previewed (it builds real CAR adapters and would "
+                "bill you)"
+            )
             return ModeDecision(
                 mode=ReasoningMode.FAST,
                 reason="dry-run: the panel routes around self.lm to real CAR adapters",

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -186,8 +186,12 @@ class NeoEngine:
         config: Optional[Any] = None,  # NeoConfig instance
         execution_adapter: Optional[ExecutionAdapter] = None,
         event_sink: Optional[NeoEventSink] = None,
+        dry_run: bool = False,
     ):
         self.lm = lm_adapter
+        # Assemble for real, stop before inference, mutate nothing. See
+        # `neo.dry_run` for why the prompt is recorded rather than rebuilt.
+        self.dry_run = dry_run
         self.exemplar_index = exemplar_index
         self.context: Optional[NeoInput] = None
         self.enable_persistent_memory = enable_persistent_memory
@@ -1027,8 +1031,21 @@ class NeoEngine:
         # Store for outcome recording
         self.last_difficulty = difficulty
 
-        # Phase 0: Detect implicit feedback from request history
-        if self.persistent_memory and neo_input.operating_mode.allows_learning:
+        # Phase 0: Detect implicit feedback from request history.
+        #
+        # Skipped under `dry_run`. This is the one call before inference that
+        # both mutates fact confidence and SAVES, and `--dry-run` used to exit
+        # in the CLI before the engine existed, so it had no side effects at
+        # all. Gaining them while fixing what the flag reports would be a poor
+        # trade: an operator runs a dry run precisely when they do not want to
+        # perturb the thing they are inspecting. Retrieval still marks facts
+        # accessed in memory, which is why nothing on this path may save --
+        # pinned by `test_dry_run_does_not_mutate_the_fact_store`.
+        if (
+            self.persistent_memory
+            and neo_input.operating_mode.allows_learning
+            and not self.dry_run
+        ):
             current_request = {
                 "prompt": neo_input.prompt,
                 "timestamp": time.time(),

--- a/src/neo/execution_context.py
+++ b/src/neo/execution_context.py
@@ -390,7 +390,7 @@ class ResolvedExecutionContext:
             # all the reader needs to know something is missing.
             lines.append(
                 f"Recent attempts"
-                f"{shown_of(self.trajectory.attempts, _MAX_RECENT_ATTEMPTS)}: "
+                f"{shown_of(self.trajectory.attempts, _MAX_RECENT_ATTEMPTS, tail=True)}: "
                 + _bounded_json(
                     self.trajectory.attempts[-_MAX_RECENT_ATTEMPTS:], 1500
                 )

--- a/src/neo/execution_context.py
+++ b/src/neo/execution_context.py
@@ -12,6 +12,8 @@ from dataclasses import asdict, dataclass, field, replace
 from enum import Enum
 from typing import Any, Optional
 
+from neo.text_budget import shown_of
+
 
 class CallerRole(str, Enum):
     PLANNER = "planner"
@@ -35,6 +37,26 @@ class GoalStatus(str, Enum):
     SATISFIED = "satisfied"
     BLOCKED = "blocked"
     UNVERIFIABLE = "unverifiable"
+
+
+# Caps on what `prompt_section` shows. Every one is paired with a `shown_of`
+# annotation at its use site -- an unmarked cut in prompt-bound text is the
+# defect #178 existed to remove, and this module was missed by that sweep.
+#
+# The numbers are unchanged from the bare slices they replaced: this change is
+# about making the loss VISIBLE, not about tuning how much survives. Retuning
+# them is a separate decision that wants evidence about real list lengths.
+_MAX_CONSTRAINTS = 12
+_MAX_SUCCESS_CRITERIA = 8
+_MAX_RECENT_ATTEMPTS = 3
+# The proof-aware execution sections (#200) landed while this branch was open
+# and arrived as bare `[:12]`/`[:12]`/`[:5]` slices — the same defect, three
+# more times, in the one function whose docstring promises every cut is
+# marked. Named and marked here rather than left for a later sweep, because
+# an unmarked cut beneath that docstring makes the docstring the lie.
+_MAX_VALIDATION_GATES = 12
+_MAX_VALIDATION_OBSERVATIONS = 12
+_MAX_HYPOTHESES = 5
 
 
 @dataclass
@@ -216,7 +238,16 @@ class ResolvedExecutionContext:
         return asdict(self)
 
     def retrieval_query(self) -> str:
-        """Stable goal-conditioned semantic query without raw trajectory dumps."""
+        """Stable goal-conditioned semantic query without raw trajectory dumps.
+
+        The slices below are deliberately NOT marked, unlike the visually
+        identical ones in `prompt_section`. This string is embedded and
+        compared by cosine similarity; it is never read as instructions. A
+        `[showing 8 of 13]` annotation here would be tokens in the query
+        vector, moving every retrieval slightly toward facts about
+        truncation. Marking is for text a reader could be misled by, and
+        nothing reads this.
+        """
         parts = [
             f"task: {self.task}",
             f"goal: {self.goal.value}",
@@ -268,7 +299,24 @@ class ResolvedExecutionContext:
         return "\n".join(parts)
 
     def prompt_section(self) -> str:
-        """Bounded role contract and execution frame for provider prompts."""
+        """Bounded role contract and execution frame for provider prompts.
+
+        Every cut here is MARKED. This text reaches the model through seven
+        prompt builders in `engine.py`, and the list cuts below used to be
+        bare slices: `constraints[:12]` and `success_criteria[:8]` dropped
+        their tail silently. Under a prompt that says "satisfy these
+        constraints", twelve of thirteen constraints read as thirteen — the
+        model cannot ask what it was not told exists, and neither can the
+        operator reading `--dry-run`.
+
+        This module was missed by the sweep that introduced `text_budget`
+        (#178), which found nineteen such cuts across nine prompt builders in
+        six modules. It was missed for the reason that sweep itself wrote
+        down: it looked for slices in the known prompt builders, and this one
+        is a `prompt_section()` on a dataclass, reached only indirectly
+        through `_retrieve_context`. A sweep that looks where the last bug was
+        finds the last bug.
+        """
         lines = [
             "## Execution Envelope",
             f"Goal ({self.goal.origin}, confidence={self.goal.confidence:.2f}): "
@@ -279,33 +327,45 @@ class ResolvedExecutionContext:
             f"Requested output: {self.requested_output}",
         ]
         if self.constraints:
-            lines.append("Constraints: " + "; ".join(self.constraints[:12]))
+            lines.append(
+                f"Constraints{shown_of(self.constraints, _MAX_CONSTRAINTS)}: "
+                + "; ".join(self.constraints[:_MAX_CONSTRAINTS])
+            )
         if self.success_criteria:
             criteria = [
                 item.description or item.command or item.type
-                for item in self.success_criteria[:8]
+                for item in self.success_criteria[:_MAX_SUCCESS_CRITERIA]
             ]
-            lines.append("Success criteria: " + "; ".join(criteria))
+            lines.append(
+                f"Success criteria"
+                f"{shown_of(self.success_criteria, _MAX_SUCCESS_CRITERIA)}: "
+                + "; ".join(criteria)
+            )
         if self.validation_gates:
             lines.append(
-                "Validation gates: " + "; ".join(
+                f"Validation gates"
+                f"{shown_of(self.validation_gates, _MAX_VALIDATION_GATES)}: "
+                + "; ".join(
                     f"{item.gate_id} ({'required' if item.required else 'optional'}): "
                     f"{item.description}"
-                    for item in self.validation_gates[:12]
+                    for item in self.validation_gates[:_MAX_VALIDATION_GATES]
                 )
             )
         if self.validation_observations:
             lines.append(
-                "Validation evidence: " + "; ".join(
+                f"Validation evidence"
+                f"{shown_of(self.validation_observations, _MAX_VALIDATION_OBSERVATIONS)}: "
+                + "; ".join(
                     f"{item.gate_id}={item.status}"
-                    for item in self.validation_observations[:12]
+                    for item in self.validation_observations[:_MAX_VALIDATION_OBSERVATIONS]
                 )
             )
         if self.hypotheses:
             lines.append(
-                "Hypotheses: " + "; ".join(
+                f"Hypotheses{shown_of(self.hypotheses, _MAX_HYPOTHESES)}: "
+                + "; ".join(
                     f"{item.hypothesis_id}={item.status}: {item.statement}"
-                    for item in self.hypotheses[:5]
+                    for item in self.hypotheses[:_MAX_HYPOTHESES]
                 )
             )
         if self.attempt:
@@ -323,9 +383,17 @@ class ResolvedExecutionContext:
                 f"{self.trajectory.max_iterations if self.trajectory.max_iterations is not None else 'unbounded'}"
             )
         if self.trajectory.attempts:
+            # A TAIL slice, deliberately, and marked for the same reason the
+            # head cuts are: "Recent attempts" names the intent but not the
+            # loss, so four attempts shown as three read as a complete history
+            # of a loop that has run four times. `shown_of` counts, which is
+            # all the reader needs to know something is missing.
             lines.append(
-                "Recent attempts: "
-                + _bounded_json(self.trajectory.attempts[-3:], 1500)
+                f"Recent attempts"
+                f"{shown_of(self.trajectory.attempts, _MAX_RECENT_ATTEMPTS)}: "
+                + _bounded_json(
+                    self.trajectory.attempts[-_MAX_RECENT_ATTEMPTS:], 1500
+                )
             )
         if self.current_state:
             lines.append(

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -305,7 +305,19 @@ class FactStore:
         facts_dir: Optional[Path] = None,
         episodes_dir: Optional[Path] = None,
         emit_metrics: bool = True,
+        read_only: bool = False,
     ):
+        # `read_only` makes `save()` a no-op. It exists for `--dry-run`, which
+        # promises to report what Neo would do without perturbing what Neo
+        # knows. Asserting that in a docstring was not enough: `initialize()`
+        # runs `prune_stale_facts` -> `demote_unhelpful_facts` ->
+        # `purge_dead_facts` and then SAVES, and `demote_unhelpful_facts`
+        # lowers confidence and invalidates facts. That fires before any
+        # inference, so a "read-only" inspection was aging the very store it
+        # was inspecting. Enforcing it at the single write choke point is
+        # ~3 lines and cannot be forgotten by a new caller, which threading a
+        # flag through every retrieval path could.
+        self.read_only = read_only
         self.codebase_root = codebase_root
         self._config = config
         self._lm_adapter = lm_adapter
@@ -2541,6 +2553,8 @@ class FactStore:
     def save(self) -> None:
         """Save facts to scoped JSON files.
 
+        A no-op when ``read_only`` is set; see ``__init__``.
+
         EVERY scope file is written with a best-effort merge (not just global):
         re-read the file and preserve any fact present on disk but absent from
         memory, so a concurrent writer's *additions* survive. This matters most
@@ -2579,6 +2593,8 @@ class FactStore:
         (favor recorded reinforcement), not a lossless merge; lossless would
         need a per-fact operation log, which is a deliberate non-goal.
         """
+        if self.read_only:
+            return
         for path, scope in (
             (self._global_path, FactScope.GLOBAL),
             (self._org_path, FactScope.ORG),

--- a/src/neo/text_budget.py
+++ b/src/neo/text_budget.py
@@ -140,14 +140,24 @@ def elide_middle(text: str, budget: int) -> str:
     )
 
 
-def shown_of(items: List, shown: int) -> str:
+def shown_of(items: List, shown: int, tail: bool = False) -> str:
     """Annotate an elided list with how much of it is being shown.
 
     Empty string when nothing was elided, so the annotation always means an
     omission — the same contract `truncate_marked` holds for text. Returned
     with a leading space so it can sit on a header line.
+
+    `tail=True` for a `[-n:]` slice. Which END survived is part of the
+    meaning, not decoration: "Recent attempts [showing 3 of 20]" reads as a
+    sample of twenty, where "[showing last 3 of 20]" says the loop has run
+    twenty times and you are seeing where it is now. Only one of the seven
+    call sites is a tail cut, which is exactly why the default has to be the
+    head form.
     """
-    return f" [showing {shown} of {len(items)}]" if len(items) > shown else ""
+    if len(items) <= shown:
+        return ""
+    where = "last " if tail else ""
+    return f" [showing {where}{shown} of {len(items)}]"
 
 
 def apportion(sizes: dict, budget: int) -> dict:

--- a/tests/test_cli_global_flags.py
+++ b/tests/test_cli_global_flags.py
@@ -167,8 +167,21 @@ class TestCLIGlobalFlags:
         assert "traceback" not in output_lower, f"Unexpected traceback in output: {output}"
 
     def test_no_scan_dry_run_does_not_require_api_key(self):
-        """
-        `--dry-run --no-scan` should exit before adapter initialization.
+        """`--dry-run --no-scan` must not require credentials.
+
+        The 30s budget this used to carry was calibrated to a flag that
+        exited in `cli.main` before the engine existed. `--dry-run` now runs
+        the real engine so it can report retrieved facts, which means loading
+        the embedding model -- ~0.5s against a warm cache, but a ~400MB
+        download on a cold one. This is alphabetically the first test to pay
+        that, and it timed out on all four CI runners while passing locally.
+        The budget is the fixture's, not the feature's: raised to match the
+        300s the other dry-run tests already use.
+
+        What this test asserts is unchanged, and is NOT about speed -- it is
+        that no API key is needed. The old docstring's "should exit before
+        adapter initialization" is no longer how that is achieved; the CLI
+        now installs `RecordingLM` instead of resolving a provider.
         """
         env = {
             **os.environ,
@@ -183,7 +196,7 @@ class TestCLIGlobalFlags:
             capture_output=True,
             text=True,
             env=env,
-            timeout=30,
+            timeout=300,
         )
 
         assert result.returncode == 0, f"Expected exit code 0, got {result.returncode}. stderr: {result.stderr}"

--- a/tests/test_context_assembly.py
+++ b/tests/test_context_assembly.py
@@ -261,3 +261,86 @@ class TestTokenBudgetEnforcement:
         assert len(result.valid_facts) == 1  # at_least_one kicks in
         assert len(result.working_set) == 0  # no budget cascade
         assert len(result.known_unknowns) == 0  # no budget cascade
+
+
+class TestRankingPolicyStaysSingleSourced:
+    """`models.py` says the ranking formula "MUST stay in one place -- if the
+    two paths diverge, outcome learning ranks inconsistently."
+
+    That invariant was held by a comment and nothing else. A comment is what
+    held `EXCLUDED_DIR_NAMES` in two places while the gatherer's copy was
+    corrected and the index's copy kept hiding the same files. Checked at the
+    time of writing: both paths do call `rank_score` and nothing recomputes
+    the formula inline. These tests are here so that stays true.
+    """
+
+    def _facts(self, n=60):
+        import random
+
+        import numpy as np
+
+        from neo.memory.models import Fact, FactKind
+
+        random.seed(0)
+        np.random.seed(0)
+        out = []
+        for i in range(n):
+            fact = Fact(subject=f"s{i}", body="b",
+                        kind=random.choice(list(FactKind)))
+            fact.metadata.confidence = random.random()
+            fact.metadata.success_count = random.randint(0, 9)
+            fact.metadata.access_count = random.randint(0, 9)
+            fact.embedding = list(np.random.rand(16))
+            out.append(fact)
+        return out
+
+    def test_both_retrieval_paths_produce_the_same_ordering(self):
+        import time
+
+        import numpy as np
+
+        from neo.math_utils import batched_cosine
+        from neo.memory.context import ContextAssembler
+        from neo.memory.models import rank_score
+
+        np.random.seed(1)
+        facts = self._facts()
+        query = np.random.rand(16)
+        now = time.time()
+
+        assembled = ContextAssembler()._score_facts(facts, query)
+        sims = batched_cosine([f.embedding for f in facts], query)
+        direct = sorted(
+            [(f, rank_score(f, s, now)) for f, s in zip(facts, sims)],
+            key=lambda pair: pair[1], reverse=True,
+        )
+
+        assert [f.id for f, _ in assembled] == [f.id for f, _ in direct]
+        # Scores agree to floating-point noise; they differ only by the
+        # microseconds between the two `now` captures feeding recall decay.
+        assert max(abs(a - b) for (_, a), (_, b) in zip(assembled, direct)) < 1e-6
+
+    def test_no_module_recomputes_the_formula_inline(self):
+        """The structural half. The differential above only compares the two
+        paths that exist today; this catches a THIRD path being written with
+        the formula pasted in, which is exactly how the duplication starts.
+        """
+        import pathlib
+
+        src = pathlib.Path(__file__).resolve().parents[1] / "src" / "neo"
+        offenders = []
+        for path in src.rglob("*.py"):
+            if path.name == "models.py":
+                continue  # the one legitimate definition site
+            text = path.read_text()
+            for lineno, line in enumerate(text.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#") or stripped.startswith(('"', "'")):
+                    continue
+                if "success_bonus(" in line or "provenance_bonus(" in line:
+                    offenders.append(f"{path.relative_to(src)}:{lineno}")
+
+        assert not offenders, (
+            "the ranking formula is being recomputed outside models.py: "
+            f"{offenders} -- call rank_score() instead"
+        )

--- a/tests/test_context_assembly.py
+++ b/tests/test_context_assembly.py
@@ -296,6 +296,7 @@ class TestRankingPolicyStaysSingleSourced:
 
     def test_both_retrieval_paths_produce_the_same_ordering(self):
         import time
+        from unittest.mock import patch
 
         import numpy as np
 
@@ -308,7 +309,14 @@ class TestRankingPolicyStaysSingleSourced:
         query = np.random.rand(16)
         now = time.time()
 
-        assembled = ContextAssembler()._score_facts(facts, query)
+        # `now` is pinned rather than captured twice. Recall decay is a
+        # function of elapsed time, so two `time.time()` calls make the
+        # comparison depend on wall-clock drift between them -- green on a
+        # quiet laptop, a coin-flip on a loaded CI runner, and the failure
+        # would read as "my change broke ranking". That is the #183 shape,
+        # and #183 is why latency is no longer a correctness gate here.
+        with patch("neo.memory.context.time.time", return_value=now):
+            assembled = ContextAssembler()._score_facts(facts, query)
         sims = batched_cosine([f.embedding for f in facts], query)
         direct = sorted(
             [(f, rank_score(f, s, now)) for f, s in zip(facts, sims)],
@@ -316,9 +324,8 @@ class TestRankingPolicyStaysSingleSourced:
         )
 
         assert [f.id for f, _ in assembled] == [f.id for f, _ in direct]
-        # Scores agree to floating-point noise; they differ only by the
-        # microseconds between the two `now` captures feeding recall decay.
-        assert max(abs(a - b) for (_, a), (_, b) in zip(assembled, direct)) < 1e-6
+        # Identical inputs and one clock: exact equality, no tolerance.
+        assert [s for _, s in assembled] == [s for _, s in direct]
 
     def test_no_module_recomputes_the_formula_inline(self):
         """The structural half. The differential above only compares the two
@@ -327,18 +334,34 @@ class TestRankingPolicyStaysSingleSourced:
         """
         import pathlib
 
+        import ast
+
         src = pathlib.Path(__file__).resolve().parents[1] / "src" / "neo"
+        # By PATH, not by name: `src/neo/models.py` and
+        # `src/neo/memory/models.py` both exist, so a name check exempted the
+        # wrong file too and a formula pasted into the former was invisible.
+        definition_site = src / "memory" / "models.py"
+
         offenders = []
         for path in src.rglob("*.py"):
-            if path.name == "models.py":
-                continue  # the one legitimate definition site
-            text = path.read_text()
-            for lineno, line in enumerate(text.splitlines(), 1):
-                stripped = line.strip()
-                if stripped.startswith("#") or stripped.startswith(('"', "'")):
+            if path == definition_site:
+                continue
+            # Parsed, not grepped. A line filter cannot tell a call from
+            # prose: `success_bonus(...)` inside a multi-line docstring, or a
+            # trailing `# not success_bonus(x)`, both read as offenders, and
+            # the `startswith` guard only ever skipped a docstring's FIRST
+            # line. The AST sees calls and nothing else.
+            try:
+                tree = ast.parse(path.read_text())
+            except SyntaxError:  # pragma: no cover - not our file to fix
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
                     continue
-                if "success_bonus(" in line or "provenance_bonus(" in line:
-                    offenders.append(f"{path.relative_to(src)}:{lineno}")
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name in ("success_bonus", "provenance_bonus"):
+                    offenders.append(f"{path.relative_to(src)}:{node.lineno}")
 
         assert not offenders, (
             "the ranking formula is being recomputed outside models.py: "

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,265 @@
+"""`--dry-run` must show what would actually be sent, and change nothing.
+
+The flag used to exit in `cli.main` before the engine was constructed, so it
+could only print the file-gathering result while `CLAUDE.md` told operators it
+printed "file selection, fact retrieval, constraints, four-layer assembly".
+Three of those four never ran. Since `--dry-run` is the instrument the project
+tells people to use before believing any claim about what Neo saw, an
+instrument that under-reports sends the operator to the wrong knob.
+
+Two properties are load-bearing and pinned here:
+
+1. What is printed is what would be SENT -- recorded off the adapter, never
+   rebuilt. A renderer that walked the context dict would be a second
+   implementation of the prompt builders, free to drift the moment one
+   changed.
+2. A dry run mutates nothing. The old implementation had that property for
+   free by never reaching the engine; the new one has to earn it, because
+   retrieval marks facts accessed and `detect_implicit_feedback` both mutates
+   confidence and saves.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from neo.dry_run import DryRunComplete, RecordingLM, render
+
+
+class TestRecordingAdapter:
+    def test_generate_records_the_messages_and_stops(self):
+        lm = RecordingLM()
+        messages = [{"role": "system", "content": "sys"},
+                    {"role": "user", "content": "usr"}]
+
+        with pytest.raises(DryRunComplete) as excinfo:
+            lm.generate(messages, max_tokens=99, temperature=0.3)
+
+        recorded = excinfo.value.calls[0]
+        assert recorded["messages"] == messages
+        assert recorded["max_tokens"] == 99
+        assert recorded["temperature"] == 0.3
+
+    def test_dry_run_complete_is_not_an_exception(self):
+        """`_process_guarded` wraps the run in `except Exception` and turns
+        anything it catches into a FAILED lifecycle event. A dry run is not a
+        crash, and reporting it as one would be a third way of lying about
+        what happened.
+        """
+        assert issubclass(DryRunComplete, BaseException)
+        assert not issubclass(DryRunComplete, Exception)
+
+    def test_a_broad_handler_does_not_swallow_it(self):
+        """The property above, exercised rather than asserted about."""
+        caught = None
+        try:
+            try:
+                RecordingLM().generate([{"role": "user", "content": "x"}])
+            except Exception as exc:  # noqa: BLE001 - the point of the test
+                caught = f"swallowed by except Exception: {exc}"
+        except DryRunComplete:
+            caught = "propagated"
+        assert caught == "propagated"
+
+
+class TestRender:
+    def test_renders_every_message_in_full(self):
+        """No truncation in the viewer.
+
+        This output exists so an operator can see what the model got. A viewer
+        that silently cut its own output would reproduce, one level up, the
+        exact defect the `text_budget` markers were introduced to fix.
+        """
+        body = "x" * 50_000
+        out = render([{"messages": [{"role": "user", "content": body}],
+                       "max_tokens": 1, "temperature": 0.0,
+                       "reasoning_effort": None, "stop": None}])
+        assert body in out
+        assert "50,000 chars" in out
+
+    def test_no_calls_says_so_rather_than_printing_nothing(self):
+        out = render([])
+        assert "No LM call was assembled" in out
+
+
+def _run(args, timeout=300):
+    return subprocess.run(
+        [sys.executable, "-m", "neo", *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+class TestEndToEnd:
+    """Exercised through the real CLI: these are integration properties."""
+
+    def test_dry_run_prints_the_assembled_prompt_not_just_files(self, tmp_path):
+        (tmp_path / "app.py").write_text("def handler():\n    return 1\n")
+        result = _run(["--dry-run", "fix the handler", "--cwd", str(tmp_path)])
+
+        assert result.returncode == 0
+        # The file list survives -- it carries the SCORE, which is what an
+        # operator needs when the right file is missing.
+        assert "files selected, in rank order" in result.stderr
+        # ...and the four things the docs promised and did not deliver.
+        assert "exact prompt that would be sent" in result.stderr
+        assert "Execution Envelope" in result.stderr
+        assert "message 1/" in result.stderr
+
+    def test_dry_run_makes_no_real_lm_call(self, tmp_path):
+        """A bogus key would fail loudly against a real provider."""
+        (tmp_path / "app.py").write_text("def handler():\n    return 1\n")
+        result = _run(["--dry-run", "fix the handler", "--cwd", str(tmp_path)])
+        assert result.returncode == 0
+        assert "AuthenticationError" not in result.stderr
+
+    def test_no_scan_does_not_crash(self, tmp_path):
+        """`gathered` is only bound inside the gather branch; `--no-scan`
+        skips it, and the dry-run report below still has to say something."""
+        result = _run(["--dry-run", "--no-scan", "hello", "--cwd", str(tmp_path)])
+        assert result.returncode == 0
+        assert "NameError" not in result.stderr
+
+    def test_json_input_dry_run_also_stops_before_inference(self, tmp_path):
+        """The old early-exit lived inside the plain-text branch only, so
+        `--stdin-json --dry-run` fell through and made a REAL call. The stop
+        now lives at engine construction, which both modes share.
+        """
+        payload = json.dumps({
+            "prompt": "fix the handler",
+            "task_type": "bugfix",
+            "context_files": [{"path": "app.py", "content": "def handler(): return 1"}],
+            "working_directory": str(tmp_path),
+        })
+        result = subprocess.run(
+            [sys.executable, "-m", "neo", "--stdin-json", "--dry-run"],
+            input=payload, capture_output=True, text=True, timeout=300,
+        )
+        assert result.returncode == 0
+        assert "exact prompt that would be sent" in result.stderr
+
+    def test_dry_run_leaves_the_fact_files_byte_identical(self, tmp_path):
+        """A coarse backstop, and labelled as one.
+
+        This compares the fact files across two dry runs, so it catches any
+        NEW writer that appears on the path. It does NOT prove the
+        `detect_implicit_feedback` skip works -- that call is a no-op without
+        a prior session, so on a fresh HOME it writes nothing either way.
+        Measured: deleting the `not self.dry_run` guard leaves this test
+        GREEN. `test_dry_run_skips_the_one_call_that_saves` is the real guard;
+        this one is a net, not a hook.
+        """
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+        (tmp_path / "app.py").write_text("def handler():\n    return 1\n")
+
+        env = {**dict(__import__("os").environ), "HOME": str(home)}
+        args = [sys.executable, "-m", "neo", "--dry-run", "fix the handler",
+                "--cwd", str(tmp_path)]
+
+        subprocess.run(args, capture_output=True, text=True, timeout=300, env=env)
+        facts_dir = home / ".neo" / "facts"
+        before = {
+            p.name: p.read_bytes()
+            for p in (facts_dir.glob("*.json") if facts_dir.exists() else [])
+        }
+
+        subprocess.run(args, capture_output=True, text=True, timeout=300, env=env)
+        after = {
+            p.name: p.read_bytes()
+            for p in (facts_dir.glob("*.json") if facts_dir.exists() else [])
+        }
+
+        assert after == before, (
+            "a dry run rewrote the fact store; it must assemble and report, "
+            "never persist"
+        )
+
+
+class TestSideEffectsAreSkipped:
+    """The one call before inference that mutates confidence AND saves.
+
+    `--dry-run` used to exit in the CLI before the engine existed, so it had
+    no side effects at all. Gaining them while fixing what the flag reports
+    would be a poor trade: an operator runs a dry run precisely when they do
+    not want to perturb the thing they are inspecting.
+
+    Asserted with a spy rather than by diffing files, because
+    `detect_implicit_feedback` is a no-op without a prior session -- the
+    file-level check stays green whether the skip works or not, which makes
+    it a backstop and not a guard.
+    """
+
+    def _engine(self, tmp_path, *, dry_run):
+        from unittest.mock import MagicMock
+
+        from neo.engine import NeoEngine
+
+        engine = NeoEngine(
+            lm_adapter=RecordingLM(),
+            enable_persistent_memory=False,
+            codebase_root=str(tmp_path),
+            dry_run=dry_run,
+        )
+        engine.persistent_memory = MagicMock()
+        engine.persistent_memory.retrieve_relevant.return_value = []
+        engine.persistent_memory.build_context.return_value = None
+        return engine
+
+    def _run(self, engine, tmp_path):
+        from neo.models import NeoInput
+
+        try:
+            engine.process(NeoInput(
+                prompt="fix the handler",
+                context_files=[],
+                working_directory=str(tmp_path),
+            ))
+        except (DryRunComplete, Exception):  # noqa: BLE001
+            # Either the dry-run stop or a downstream parse failure on the
+            # RecordingLM path -- neither is what this test measures.
+            pass
+
+    def test_dry_run_skips_the_one_call_that_saves(self, tmp_path):
+        engine = self._engine(tmp_path, dry_run=True)
+        self._run(engine, tmp_path)
+        engine.persistent_memory.detect_implicit_feedback.assert_not_called()
+
+    def test_a_normal_run_still_makes_it(self, tmp_path):
+        """The other half. Without this, deleting the whole `if` block --
+        not just the `and not self.dry_run` clause -- would pass the test
+        above while silently disabling implicit feedback for every run.
+        """
+        engine = self._engine(tmp_path, dry_run=False)
+        self._run(engine, tmp_path)
+        engine.persistent_memory.detect_implicit_feedback.assert_called_once()
+
+
+class TestNoCredentialsRequired:
+    def test_dry_run_needs_no_api_key_even_with_scanning(self, tmp_path):
+        """`--dry-run` makes no call, so requiring a key to find out what Neo
+        would have sent is a barrier with nothing behind it.
+
+        `test_no_scan_dry_run_does_not_require_api_key` in
+        test_cli_global_flags.py covers the `--no-scan` path and caught this
+        when moving the stop into the engine pushed it past adapter
+        construction. This covers the scanning path, which is the one people
+        actually use.
+        """
+        import os
+
+        (tmp_path / "app.py").write_text("def handler():\n    return 1\n")
+        env = {**os.environ, "NEO_SKIP_UPDATE_CHECK": "1"}
+        for key in ("NEO_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                    "GOOGLE_API_KEY"):
+            env.pop(key, None)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "neo", "--dry-run", "fix the handler",
+             "--cwd", str(tmp_path)],
+            capture_output=True, text=True, env=env, timeout=300,
+        )
+        assert result.returncode == 0, result.stderr[-2000:]
+        assert "API key required" not in result.stdout + result.stderr
+        assert "exact prompt that would be sent" in result.stderr

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -103,7 +103,7 @@ class TestEndToEnd:
         # operator needs when the right file is missing.
         assert "files selected, in rank order" in result.stderr
         # ...and the four things the docs promised and did not deliver.
-        assert "exact prompt that would be sent" in result.stderr
+        assert "messages Neo hands the adapter" in result.stderr
         assert "Execution Envelope" in result.stderr
         assert "message 1/" in result.stderr
 
@@ -137,7 +137,7 @@ class TestEndToEnd:
             input=payload, capture_output=True, text=True, timeout=300,
         )
         assert result.returncode == 0
-        assert "exact prompt that would be sent" in result.stderr
+        assert "messages Neo hands the adapter" in result.stderr
 
     def test_dry_run_leaves_the_fact_files_byte_identical(self, tmp_path):
         """A coarse backstop, and labelled as one.
@@ -262,4 +262,94 @@ class TestNoCredentialsRequired:
         )
         assert result.returncode == 0, result.stderr[-2000:]
         assert "API key required" not in result.stdout + result.stderr
-        assert "exact prompt that would be sent" in result.stderr
+        assert "messages Neo hands the adapter" in result.stderr
+
+
+class TestPanelIsSuppressed:
+    """`--dry-run` must not reach `create_adapter("car", ...)`.
+
+    The panel does not reason through `self.lm`: `_build_car_role_factory`
+    builds a real CAR adapter per role and uses `self.lm` only as the fallback
+    for unassigned roles. So `RecordingLM` does not intercept it. On a machine
+    with `car-server` reachable -- this project's documented normal setup,
+    since the observer autostarts off it -- a novel prompt under `--dry-run`
+    would have run the full panel against real models, spent real money, never
+    raised `DryRunComplete`, and printed ordinary output. The flag would have
+    been a no-op that bills you.
+
+    Measured before the fix: 4 `create_adapter("car", ...)` calls (planner,
+    coder, critic, judge).
+    """
+
+    def test_no_car_adapter_is_built(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from neo.engine import NeoEngine
+        from neo.models import NeoInput
+
+        built = []
+        with patch("neo.adapters.create_adapter",
+                   side_effect=lambda *a, **k: (built.append(a), MagicMock())[1]):
+            engine = NeoEngine(lm_adapter=RecordingLM(),
+                               codebase_root=str(tmp_path), dry_run=True)
+            # Force the panel to look fully available.
+            with patch.object(NeoEngine, "_car_route_capability",
+                              return_value=(True, 5, lambda *a, **k: {})):
+                try:
+                    engine.process(NeoInput(
+                        prompt="design a novel distributed consensus scheme",
+                        context_files=[], working_directory=str(tmp_path)))
+                except DryRunComplete:
+                    pass
+                except Exception:  # noqa: BLE001
+                    pass
+
+        assert built == [], f"dry run built real adapters: {built}"
+
+    def test_mode_is_forced_fast(self, tmp_path):
+        from unittest.mock import patch
+
+        from neo.engine import NeoEngine
+        from neo.reasoning_mode import ReasoningMode
+
+        engine = NeoEngine(lm_adapter=RecordingLM(),
+                           codebase_root=str(tmp_path), dry_run=True)
+        with patch.object(NeoEngine, "_car_route_capability",
+                          return_value=(True, 5, lambda *a, **k: {})):
+            decision, route_fn = engine._decide_reasoning_mode({}, "hard", None)
+
+        assert decision.mode is ReasoningMode.FAST
+        assert route_fn is None
+
+
+class TestJsonDryRunKeepsItsContract:
+    """`--json` promises stdout is exactly ONE JSON document and every run
+    ends with `completed` or `FAILED`. Writing the report to stderr broke both
+    at once: zero documents on stdout, no terminal event, and every source
+    line beginning with `{` became a counterfeit event for a host parsing the
+    JSONL stream by that prefix."""
+
+    def test_stdout_is_one_json_document_and_the_stream_terminates(self, tmp_path):
+        (tmp_path / "app.py").write_text("def handler():\n    return 1\n")
+        result = _run(["--dry-run", "--json", "fix the handler",
+                       "--cwd", str(tmp_path)])
+
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)          # raises if not exactly one
+        assert payload["dry_run"] is True
+        assert payload["calls"]
+
+        events = [json.loads(line) for line in result.stderr.splitlines()
+                  if line.startswith("{")]
+        assert any(e.get("type") == "completed" for e in events), (
+            "STARTED-then-silence is what a host cannot tell from a crash"
+        )
+
+    def test_no_prompt_content_leaks_into_the_event_stream(self, tmp_path):
+        (tmp_path / "app.py").write_text('def handler():\n    return {"a": 1}\n')
+        result = _run(["--dry-run", "--json", "fix the handler",
+                       "--cwd", str(tmp_path)])
+
+        for line in result.stderr.splitlines():
+            if line.startswith("{"):
+                json.loads(line)  # every `{`-prefixed line is a real event

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -147,8 +147,10 @@ class TestEndToEnd:
         `detect_implicit_feedback` skip works -- that call is a no-op without
         a prior session, so on a fresh HOME it writes nothing either way.
         Measured: deleting the `not self.dry_run` guard leaves this test
-        GREEN. `test_dry_run_skips_the_one_call_that_saves` is the real guard;
-        this one is a net, not a hook.
+        GREEN. `FactStore(read_only=True)` is the real guard -- it stops the
+        writer this test cannot see, `initialize()`'s prune/demote/purge,
+        which needs an AGED store to fire and so never fires on the cold
+        empty one two fresh runs produce. This is a net, not a hook.
         """
         home = tmp_path / "home"
         home.mkdir(exist_ok=True)
@@ -288,6 +290,7 @@ class TestPanelIsSuppressed:
         from neo.models import NeoInput
 
         built = []
+        reached_the_stop = False
         with patch("neo.adapters.create_adapter",
                    side_effect=lambda *a, **k: (built.append(a), MagicMock())[1]):
             engine = NeoEngine(lm_adapter=RecordingLM(),
@@ -300,11 +303,15 @@ class TestPanelIsSuppressed:
                         prompt="design a novel distributed consensus scheme",
                         context_files=[], working_directory=str(tmp_path)))
                 except DryRunComplete:
-                    pass
+                    reached_the_stop = True
                 except Exception:  # noqa: BLE001
                     pass
 
         assert built == [], f"dry run built real adapters: {built}"
+        # Without this, `assert built == []` also passes when `process()` dies
+        # on its first line -- one unrelated regression from being green for
+        # entirely the wrong reason.
+        assert reached_the_stop, "the run never reached the dry-run stop"
 
     def test_mode_is_forced_fast(self, tmp_path):
         from unittest.mock import patch
@@ -320,6 +327,40 @@ class TestPanelIsSuppressed:
 
         assert decision.mode is ReasoningMode.FAST
         assert route_fn is None
+
+    def test_the_operator_is_told_the_panel_is_never_previewed(self, tmp_path, capsys):
+        """Say it, but do not overclaim it.
+
+        Silence would reproduce one level up the defect this flag exists to
+        expose: fast-path output on a machine that would have deliberated is
+        a report about a run Neo would not have made.
+
+        The obvious version gated the note on `car_available` and announced a
+        "suppressed panel" on any car-server machine -- including for the
+        familiar, low-effort prompts that take the fast path regardless. That
+        is the failure `shown_of` already forbids: a marker that fires when
+        nothing was dropped trains the reader to ignore it. Knowing the real
+        answer needs `capable_model_count` and the effort tier, i.e. a CAR
+        daemon round-trip taken only to decide whether to print a string,
+        under a flag that promises no calls. So the note is unconditional and
+        states only what is unconditionally true.
+        """
+        from unittest.mock import patch
+
+        from neo.engine import NeoEngine
+
+        engine = NeoEngine(lm_adapter=RecordingLM(),
+                           codebase_root=str(tmp_path), dry_run=True)
+
+        for capability in ((True, 5, lambda *a, **k: {}), (False, 0, None)):
+            with patch.object(NeoEngine, "_car_route_capability",
+                              return_value=capability) as probe:
+                engine._decide_reasoning_mode({"prompt": "x"}, "hard", None)
+            note = capsys.readouterr().err
+            assert "always takes the fast path" in note
+            # ...and never asserts that a panel WOULD have run here.
+            assert "suppressed" not in note
+            probe.assert_not_called()
 
 
 class TestJsonDryRunKeepsItsContract:

--- a/tests/test_execution_envelope_truncation.py
+++ b/tests/test_execution_envelope_truncation.py
@@ -104,7 +104,11 @@ class TestRecentAttempts:
             trajectory=TrajectoryContext(iteration=7, attempts=attempts)
         ).prompt_section()
 
-        assert f"[showing {_MAX_RECENT_ATTEMPTS} of {len(attempts)}]" in section
+        # "last", not just a count. `[showing 3 of 7]` reads as a sample of
+        # seven; `[showing last 3 of 7]` says the loop has run seven times and
+        # you are seeing where it is now -- which is the signal a caller needs
+        # to decide whether Neo is going in circles.
+        assert f"[showing last {_MAX_RECENT_ATTEMPTS} of {len(attempts)}]" in section
         # Tail semantics: the most RECENT survive, not the first.
         assert f"a{len(attempts) - 1}" in section
         assert '"a0"' not in section
@@ -145,3 +149,21 @@ class TestNoBareSlicesRemain:
         section = _context(**{attr: items}).prompt_section()
 
         assert shown_of(items, cap) in section
+
+
+class TestTailMarkerIsDistinctFromHead:
+    def test_head_and_tail_markers_do_not_read_the_same(self):
+        """The default must stay the head form: six of the seven `shown_of`
+        call sites are head cuts, so a `last` that leaked into them would be
+        actively false."""
+        from neo.text_budget import shown_of
+
+        items = list(range(20))
+        assert shown_of(items, 3) == " [showing 3 of 20]"
+        assert shown_of(items, 3, tail=True) == " [showing last 3 of 20]"
+
+    def test_neither_form_fires_when_nothing_is_dropped(self):
+        from neo.text_budget import shown_of
+
+        assert shown_of([1, 2], 5) == ""
+        assert shown_of([1, 2], 5, tail=True) == ""

--- a/tests/test_execution_envelope_truncation.py
+++ b/tests/test_execution_envelope_truncation.py
@@ -19,13 +19,20 @@ import pytest
 
 from neo.execution_context import (
     _MAX_CONSTRAINTS,
+    _MAX_HYPOTHESES,
     _MAX_RECENT_ATTEMPTS,
     _MAX_SUCCESS_CRITERIA,
+    _MAX_VALIDATION_GATES,
+    _MAX_VALIDATION_OBSERVATIONS,
     CallerRole,
     DerivedValue,
+    ExecutionIdentity,
+    HypothesisRecord,
     ResolvedExecutionContext,
     SuccessCriterion,
     TrajectoryContext,
+    ValidationGate,
+    ValidationObservation,
 )
 from neo.text_budget import shown_of
 
@@ -37,6 +44,10 @@ def _context(**overrides):
         intent=DerivedValue("i", "explicit", 1.0),
         constraints=[],
         success_criteria=[],
+        validation_gates=[],
+        validation_observations=[],
+        hypotheses=[],
+        execution_identity=ExecutionIdentity(),
         attempt=None,
         outcome=None,
         progress=None,
@@ -131,21 +142,43 @@ class TestRetrievalQueryIsDeliberatelyUnmarked:
         assert "showing" in context.prompt_section()
 
 
+def _items(attr, n):
+    """One over-long list per capped attribute, in that attribute's own type."""
+    if attr == "constraints":
+        return [f"x{i}" for i in range(n)]
+    if attr == "success_criteria":
+        return [SuccessCriterion(type="t", description=f"x{i}") for i in range(n)]
+    if attr == "validation_gates":
+        return [ValidationGate(gate_id=f"g{i}", description=f"x{i}") for i in range(n)]
+    if attr == "validation_observations":
+        return [ValidationObservation(observation_id=f"o{i}", gate_id=f"g{i}")
+                for i in range(n)]
+    if attr == "hypotheses":
+        return [HypothesisRecord(hypothesis_id=f"h{i}", statement=f"x{i}")
+                for i in range(n)]
+    raise AssertionError(f"no item factory for {attr}")
+
+
 class TestNoBareSlicesRemain:
     @pytest.mark.parametrize("attr,cap", [
         ("constraints", _MAX_CONSTRAINTS),
         ("success_criteria", _MAX_SUCCESS_CRITERIA),
+        # The proof-aware execution sections (#200) arrived after this file was
+        # written, as three more bare slices in the one function whose docstring
+        # promises every cut is marked. They are covered here rather than in
+        # their own class precisely because this guard's premise is that a NEW
+        # capped list is the recurrence -- leaving them out would have let the
+        # guard pass while the defect it names sat three lines below the ones
+        # it checks.
+        ("validation_gates", _MAX_VALIDATION_GATES),
+        ("validation_observations", _MAX_VALIDATION_OBSERVATIONS),
+        ("hypotheses", _MAX_HYPOTHESES),
     ])
     def test_every_capped_list_in_the_section_is_annotated(self, attr, cap):
         """Generic guard: for each capped list, an over-long input must
         produce the annotation `shown_of` would generate. Adding a new capped
         list without a marker is the recurrence this file exists to catch."""
-        items = (
-            [f"x{i}" for i in range(cap + 2)]
-            if attr == "constraints"
-            else [SuccessCriterion(type="t", description=f"x{i}")
-                  for i in range(cap + 2)]
-        )
+        items = _items(attr, cap + 2)
         section = _context(**{attr: items}).prompt_section()
 
         assert shown_of(items, cap) in section

--- a/tests/test_execution_envelope_truncation.py
+++ b/tests/test_execution_envelope_truncation.py
@@ -1,0 +1,147 @@
+"""Every cut in the Execution Envelope must be marked.
+
+`ResolvedExecutionContext.prompt_section()` reaches the model through seven
+prompt builders in `engine.py`. Its list cuts were bare slices --
+`constraints[:12]`, `success_criteria[:8]`, `attempts[-3:]` -- so a
+thirteenth constraint vanished with nothing to show it had existed. Under a
+prompt that says "satisfy these constraints", twelve of thirteen read as
+thirteen: the model cannot ask about what it was not told exists, and until
+`--dry-run` was fixed neither could the operator.
+
+This module was missed by the #178 sweep that introduced `text_budget`, for
+the reason that sweep wrote down about itself: it looked for slices inside the
+known prompt builders, and this is a method on a dataclass reached indirectly
+through `_retrieve_context`. A sweep that looks where the last bug was finds
+the last bug.
+"""
+
+import pytest
+
+from neo.execution_context import (
+    _MAX_CONSTRAINTS,
+    _MAX_RECENT_ATTEMPTS,
+    _MAX_SUCCESS_CRITERIA,
+    CallerRole,
+    DerivedValue,
+    ResolvedExecutionContext,
+    SuccessCriterion,
+    TrajectoryContext,
+)
+from neo.text_budget import shown_of
+
+
+def _context(**overrides):
+    base = dict(
+        task="t",
+        goal=DerivedValue("g", "explicit", 1.0),
+        intent=DerivedValue("i", "explicit", 1.0),
+        constraints=[],
+        success_criteria=[],
+        attempt=None,
+        outcome=None,
+        progress=None,
+        trajectory=TrajectoryContext(),
+        role=CallerRole.PLANNER,
+        requested_output="next_action",
+        current_state={},
+    )
+    base.update(overrides)
+    return ResolvedExecutionContext(**base)
+
+
+class TestConstraints:
+    def test_an_elided_constraint_list_says_so(self):
+        constraints = [f"c{i}" for i in range(_MAX_CONSTRAINTS + 5)]
+        section = _context(constraints=constraints).prompt_section()
+
+        assert f"[showing {_MAX_CONSTRAINTS} of {len(constraints)}]" in section
+        # The survivors are still there...
+        assert f"c{_MAX_CONSTRAINTS - 1}" in section
+        # ...and the dropped one is genuinely absent, so the marker is the
+        # only signal the reader gets. That is what makes it load-bearing.
+        assert f"c{_MAX_CONSTRAINTS}" not in section
+
+    def test_a_list_that_fits_gets_no_marker(self):
+        """`shown_of` returns "" when nothing was dropped, so the annotation
+        always means an omission. A marker that appeared on complete lists
+        would train the reader to ignore it."""
+        section = _context(constraints=["only", "two"]).prompt_section()
+
+        assert "showing" not in section
+        assert "Constraints: only; two" in section
+
+    def test_exactly_at_the_cap_is_not_marked(self):
+        """The off-by-one that would make the marker a liar in the other
+        direction."""
+        constraints = [f"c{i}" for i in range(_MAX_CONSTRAINTS)]
+        section = _context(constraints=constraints).prompt_section()
+
+        assert "showing" not in section
+        assert f"c{_MAX_CONSTRAINTS - 1}" in section
+
+
+class TestSuccessCriteria:
+    def test_an_elided_criteria_list_says_so(self):
+        criteria = [
+            SuccessCriterion(type="cmd", description=f"crit{i}")
+            for i in range(_MAX_SUCCESS_CRITERIA + 3)
+        ]
+        section = _context(success_criteria=criteria).prompt_section()
+
+        assert f"[showing {_MAX_SUCCESS_CRITERIA} of {len(criteria)}]" in section
+        assert f"crit{_MAX_SUCCESS_CRITERIA}" not in section
+
+
+class TestRecentAttempts:
+    def test_an_elided_attempt_history_says_so(self):
+        """A TAIL slice, and marked for the same reason the head cuts are:
+        "Recent attempts" names the intent but not the loss, so four attempts
+        shown as three read as the complete history of a loop that has
+        actually run four times -- which is exactly the signal a caller needs
+        when deciding whether Neo is going in circles."""
+        attempts = [{"summary": f"a{i}"} for i in range(_MAX_RECENT_ATTEMPTS + 4)]
+        section = _context(
+            trajectory=TrajectoryContext(iteration=7, attempts=attempts)
+        ).prompt_section()
+
+        assert f"[showing {_MAX_RECENT_ATTEMPTS} of {len(attempts)}]" in section
+        # Tail semantics: the most RECENT survive, not the first.
+        assert f"a{len(attempts) - 1}" in section
+        assert '"a0"' not in section
+
+
+class TestRetrievalQueryIsDeliberatelyUnmarked:
+    def test_no_marker_leaks_into_the_embedding_query(self):
+        """`retrieval_query` is embedded and compared by cosine similarity;
+        it is never read as instructions. A `[showing 8 of 13]` annotation
+        there would be tokens in the query vector, moving every retrieval
+        slightly toward facts about truncation.
+
+        Pinned because the two methods sit next to each other and look
+        identical, so the obvious "consistency" fix is wrong.
+        """
+        constraints = [f"c{i}" for i in range(40)]
+        context = _context(constraints=constraints)
+
+        assert "showing" not in context.retrieval_query()
+        assert "showing" in context.prompt_section()
+
+
+class TestNoBareSlicesRemain:
+    @pytest.mark.parametrize("attr,cap", [
+        ("constraints", _MAX_CONSTRAINTS),
+        ("success_criteria", _MAX_SUCCESS_CRITERIA),
+    ])
+    def test_every_capped_list_in_the_section_is_annotated(self, attr, cap):
+        """Generic guard: for each capped list, an over-long input must
+        produce the annotation `shown_of` would generate. Adding a new capped
+        list without a marker is the recurrence this file exists to catch."""
+        items = (
+            [f"x{i}" for i in range(cap + 2)]
+            if attr == "constraints"
+            else [SuccessCriterion(type="t", description=f"x{i}")
+                  for i in range(cap + 2)]
+        )
+        section = _context(**{attr: items}).prompt_section()
+
+        assert shown_of(items, cap) in section

--- a/tests/test_language_query_yield.py
+++ b/tests/test_language_query_yield.py
@@ -121,16 +121,33 @@ def parser():
 def _captures(parser, language, table, query_name):
     """Capture count for ONE query against its language's fixture.
 
-    Goes through `_compile_cached` + `_run_query` rather than `parse_file`,
-    because the whole point is to attribute a zero to the specific query that
-    produced it instead of letting a sibling mask it.
+    Resolves the query through the SAME accessor production uses, which is
+    the whole point and was got wrong first time round. The original went
+    through `_compile_cached("yieldtest:{lang}:{name}", ...)` -- a private
+    namespace no production path touches -- so it verified the query TEXT
+    while leaving the lookup untested. Two mutations that break real
+    extraction left all 29 tests green: making `_get_query` return None for
+    `java.classes` (production drops every `class:` chunk), and collapsing
+    its cache key to `f"{language}"` so the first query per language wins and
+    its siblings silently receive the wrong compiled object.
+
+    That second one is one query yielding the wrong structure while its
+    neighbours look fine -- the #158 shape this file exists for.
+
+    The two tables resolve differently in production and must be followed
+    separately: chunk queries go through `_get_query` (key `"{lang}:{name}"`),
+    edge queries are compiled inline by `_extract_edges` under a third
+    namespace (`"{lang}:edge:{name}"`) and never touch `_get_query` at all.
     """
     source = FIXTURES[language]
-    compiled = parser._compile_cached(
-        f"yieldtest:{language}:{query_name}", language, table[language][query_name]
-    )
+    if table is QUERIES:
+        compiled = parser._get_query(language, query_name)
+    else:
+        compiled = parser._compile_cached(
+            f"{language}:edge:{query_name}", language, table[language][query_name]
+        )
     if compiled is None:
-        return None  # failed to compile -- reported distinctly below
+        return None  # failed to compile / not found -- reported distinctly below
     tree = parser._get_parser(language).parse(source.encode())
     return len(parser._run_query(compiled, tree.root_node))
 
@@ -163,10 +180,47 @@ class TestEveryEdgeQueryMatches:
         )
 
 
+# What `parse_file` must produce per language, as chunk_type counts. This is
+# the check a capture COUNT cannot make: collapsing `_get_query`'s cache key
+# to `f"{language}"` still returns a compiled query for every name, so every
+# capture count stays non-zero while the wrong query answers -- java yields
+# duplicated methods and zero classes. Only the shape of the output shows it.
+EXPECTED_KINDS = {
+    "c": {"function", "struct"},
+    "go": {"function", "struct"},
+    "java": {"class", "method"},
+    "php": {"class", "function", "method"},
+    "ruby": {"class", "method"},
+}
+
+
 class TestEndToEndYield:
     """The per-query tests above can all pass while the wiring that turns
     captures into `CodeChunk`/`CodeEdge` objects drops them, so assert the
     public surface too."""
+
+    @pytest.mark.parametrize("language", sorted(EXPECTED_KINDS))
+    def test_parse_file_produces_every_declared_kind(self, parser, language):
+        """The kind-level guard, and the reason it exists.
+
+        `_captures` proves each query name resolves to something that
+        matches. It cannot prove the name resolved to the RIGHT query:
+        mutating `_get_query`'s cache key to `f"{language}"` makes the first
+        query per language win and hands its compiled object to every
+        sibling. Every capture count stays positive; java then yields six
+        duplicated `method` chunks and zero `class` chunks. Measured: that
+        mutation left all 29 other tests in this file green.
+        """
+        source = FIXTURES[language]
+        path = pathlib.Path(tempfile.mkdtemp()) / f"a{_EXT[language]}"
+        path.write_text(source)
+
+        kinds = {c.chunk_type for c in (parser.parse_file(path, source) or [])}
+        assert kinds == EXPECTED_KINDS[language], (
+            f"{language} produced {sorted(kinds)}, expected "
+            f"{sorted(EXPECTED_KINDS[language])} -- a query resolved to the "
+            f"wrong compiled object, or a declared kind stopped being emitted"
+        )
 
     @pytest.mark.parametrize("language", sorted(FIXTURES))
     def test_parse_file_produces_chunks(self, parser, language):

--- a/tests/test_language_query_yield.py
+++ b/tests/test_language_query_yield.py
@@ -1,29 +1,31 @@
-"""Every declared language query must match something on real code.
+"""Every declared query must match something on real code -- PER QUERY.
 
 `test_every_chunk_query_compiles` and `test_every_edge_query_compiles` prove
 compilation ONLY. That is the exact gap #158 lived in: a tree-sitter query
 that fails to compile is indistinguishable from one that matches nothing --
-`_get_query` returns None, `parse_file` moves on, and the index is silently
-missing a whole language's worth of structure. Four queries were broken at
-once for months, so TypeScript interfaces and ALL C# inheritance edges were
-absent from every index since they shipped.
+`_get_query` returns None, `parse_file` moves on, and a whole class of
+structure is missing from every index built since. Four queries were broken at
+once, so TypeScript interfaces and ALL C# inheritance edges were absent for
+months.
 
-Compilation tests would not have caught any of them. These would.
+**Per query, not per language.** The first version of this file asserted
+`parse_file(...)` and `extract_edges(...)` were non-empty, which passes as
+long as ANY sibling query in that language survives. Measured against that
+version: all 18 "break every query in a language" mutations were caught, and
+**0 of 28** "break one query" mutations were caught. #158 was TypeScript
+`interfaces` breaking while `functions` and `classes` kept working, and C#
+`inheritance` breaking while `imports` kept working -- so the per-language
+form would not have caught either of the bugs it was written for.
 
-Five languages -- java, go, c, ruby, php -- had no corpus anywhere in the
-local checkout, so until this file they had never been run against real
-source in any form, only compiled. The fixtures are deliberately small and
-hand-written rather than sampled, so each one exercises the specific node
-types its query names.
+The fixtures are hand-written rather than sampled so that each one exercises
+every query its language declares. Writing them surfaced two queries that were
+dead against the earlier fixtures and reported nothing: `java.inheritance`
+(the fixture had `implements` but no `extends`) and `php.functions` (only
+methods, no top-level function).
 
-Two coverage gaps are pinned rather than fixed, because closing them is a
-feature decision and a silent gap is worse than a documented one:
-
-- **ruby has no edge queries at all.** It is the only language in `QUERIES`
-  absent from `EDGE_QUERIES`, so ruby files contribute nodes and no edges.
-- **php has an imports query but no inheritance query**, so `class X
-  implements Y` yields nothing where the java/c_sharp/typescript equivalents
-  yield an edge.
+Five languages -- java, go, c, ruby, php -- have no corpus anywhere in the
+local checkout, so until this file they had never been run against source in
+any form, only compiled.
 """
 
 import pathlib
@@ -33,20 +35,26 @@ import pytest
 
 from neo.index.language_parser import EDGE_QUERIES, QUERIES, TreeSitterParser
 
-# Each fixture exercises the node types its language's queries actually name.
-# `php` uses `use App\Contracts\Greeter;` rather than a bare `namespace`,
-# because the php imports query matches `namespace_use_declaration` -- a
-# fixture that only declares a namespace yields zero and looks like a defect.
+# Each fixture must exercise EVERY query its language declares. When you add a
+# query, extend the matching fixture in the same change -- the parametrized
+# tests below will fail until you do, which is the point.
 FIXTURES = {
-    "java": ("A.java", """package x;
+    "java": """package x;
+
 import java.util.List;
+import java.util.Map;
+
 public interface Greeter { String greet(String n); }
-public class Impl implements Greeter {
+
+abstract class Base { abstract int seed(); }
+
+public class Impl extends Base implements Greeter {
     public String greet(String n) { return "hi " + n; }
+    int seed() { return 1; }
     private int count(List<String> xs) { return xs.size(); }
 }
-"""),
-    "go": ("a.go", """package main
+""",
+    "go": """package main
 
 import "fmt"
 
@@ -57,16 +65,17 @@ type Impl struct{ N int }
 func (i Impl) Greet(n string) string { return fmt.Sprintf("hi %s", n) }
 
 func main() { fmt.Println(Impl{}.Greet("x")) }
-"""),
-    "c": ("a.c", """#include <stdio.h>
+""",
+    "c": """#include <stdio.h>
+#include <stdlib.h>
 
 struct Point { int x; int y; };
 
 int add(int a, int b) { return a + b; }
 
 int main(void) { printf("%d", add(1, 2)); return 0; }
-"""),
-    "ruby": ("a.rb", """require 'set'
+""",
+    "ruby": """require 'set'
 
 module Greetable
   def greet(n)
@@ -85,18 +94,23 @@ class Impl
     @n.size
   end
 end
-"""),
-    "php": ("a.php", """<?php
+""",
+    "php": """<?php
 namespace App;
 
 use App\\Contracts\\Greeter;
+use App\\Support\\Str;
+
+function helper(int $x): int { return $x + 1; }
 
 class Impl implements Greeter {
     public function greet(string $n): string { return "hi $n"; }
     private function total(array $xs): int { return count($xs); }
 }
-"""),
+""",
 }
+
+_EXT = {"java": ".java", "go": ".go", "c": ".c", "ruby": ".rb", "php": ".php"}
 
 
 @pytest.fixture(scope="module")
@@ -104,56 +118,104 @@ def parser():
     return TreeSitterParser()
 
 
-def _parse(parser, lang):
-    name, source = FIXTURES[lang]
-    path = pathlib.Path(tempfile.mkdtemp()) / name
-    path.write_text(source)
-    return (parser.parse_file(path, source) or [],
-            parser.extract_edges(path, source) or [])
+def _captures(parser, language, table, query_name):
+    """Capture count for ONE query against its language's fixture.
+
+    Goes through `_compile_cached` + `_run_query` rather than `parse_file`,
+    because the whole point is to attribute a zero to the specific query that
+    produced it instead of letting a sibling mask it.
+    """
+    source = FIXTURES[language]
+    compiled = parser._compile_cached(
+        f"yieldtest:{language}:{query_name}", language, table[language][query_name]
+    )
+    if compiled is None:
+        return None  # failed to compile -- reported distinctly below
+    tree = parser._get_parser(language).parse(source.encode())
+    return len(parser._run_query(compiled, tree.root_node))
 
 
-class TestChunkQueriesMatchRealCode:
-    @pytest.mark.parametrize("lang", sorted(FIXTURES))
-    def test_language_produces_chunks(self, parser, lang):
-        chunks, _ = _parse(parser, lang)
-        assert chunks, (
-            f"{lang} chunk queries compile but matched nothing -- the #158 "
-            f"failure mode, which is invisible from the outside"
+def _cases(table):
+    return [(lang, name) for lang in sorted(FIXTURES) if lang in table
+            for name in sorted(table[lang])]
+
+
+class TestEveryChunkQueryMatches:
+    @pytest.mark.parametrize("language,query_name", _cases(QUERIES))
+    def test_query_captures_something(self, parser, language, query_name):
+        count = _captures(parser, language, QUERIES, query_name)
+        assert count is not None, f"{language}.{query_name} failed to COMPILE"
+        assert count > 0, (
+            f"{language}.{query_name} compiles and matches nothing -- the "
+            f"#158 failure mode, which is invisible from the outside. Either "
+            f"the query is broken or the fixture does not exercise it; both "
+            f"need fixing here."
         )
 
 
-class TestEdgeQueriesMatchRealCode:
-    @pytest.mark.parametrize("lang", sorted(set(FIXTURES) & set(EDGE_QUERIES) - {"php"}))
-    def test_language_produces_edges(self, parser, lang):
-        _, edges = _parse(parser, lang)
-        assert edges, f"{lang} edge queries compile but matched nothing"
+class TestEveryEdgeQueryMatches:
+    @pytest.mark.parametrize("language,query_name", _cases(EDGE_QUERIES))
+    def test_query_captures_something(self, parser, language, query_name):
+        count = _captures(parser, language, EDGE_QUERIES, query_name)
+        assert count is not None, f"{language}.{query_name} failed to COMPILE"
+        assert count > 0, (
+            f"{language}.{query_name} compiles and matches nothing"
+        )
 
-    def test_php_extracts_imports(self, parser):
-        """php declares only an imports query, so that is all it can yield."""
-        _, edges = _parse(parser, "php")
-        assert edges, "php imports query matched nothing on a `use` statement"
+
+class TestEndToEndYield:
+    """The per-query tests above can all pass while the wiring that turns
+    captures into `CodeChunk`/`CodeEdge` objects drops them, so assert the
+    public surface too."""
+
+    @pytest.mark.parametrize("language", sorted(FIXTURES))
+    def test_parse_file_produces_chunks(self, parser, language):
+        source = FIXTURES[language]
+        path = pathlib.Path(tempfile.mkdtemp()) / f"a{_EXT[language]}"
+        path.write_text(source)
+        assert parser.parse_file(path, source)
+
+    @pytest.mark.parametrize("language", sorted(set(FIXTURES) & set(EDGE_QUERIES)))
+    def test_extract_edges_produces_edges(self, parser, language):
+        source = FIXTURES[language]
+        path = pathlib.Path(tempfile.mkdtemp()) / f"a{_EXT[language]}"
+        path.write_text(source)
+        assert parser.extract_edges(path, source)
 
 
 class TestKnownCoverageGaps:
-    """Pinned so the gaps are visible, and so closing one updates a test
+    """Pinned so the gaps stay visible, and so closing one updates a test
     rather than silently changing behaviour."""
 
     def test_ruby_declares_no_edge_queries(self):
         """Ruby is the only language with chunk queries and no edge queries,
         so ruby files contribute nodes to the graph and never edges. Delete
-        this test when ruby edge queries are added -- its failure is the
-        signal that the gap closed.
+        this test when ruby edge queries land -- its failure is the signal
+        that the gap closed.
         """
         assert set(QUERIES) - set(EDGE_QUERIES) == {"ruby"}
 
     def test_php_has_imports_but_no_inheritance(self, parser):
         """`class Impl implements Greeter` yields an edge in java, c_sharp
-        and typescript, and nothing in php."""
+        and typescript, and nothing in php.
+
+        Asserted on `edge_type`, the field `CodeEdge` actually declares. An
+        earlier version of this test read `getattr(e, "kind", getattr(e,
+        "type", ""))` -- neither attribute exists, so the set was always
+        `{""}` and the assertion could not fail. In a file whose subject is
+        "a query that matches nothing is indistinguishable from one that
+        failed to compile", that was an assertion indistinguishable from no
+        assertion.
+        """
         assert set(EDGE_QUERIES["php"]) == {"imports"}
 
-        _, edges = _parse(parser, "php")
-        kinds = {getattr(e, "kind", getattr(e, "type", "")) for e in edges}
-        assert not any("inherit" in str(k).lower() for k in kinds)
+        source = FIXTURES["php"]
+        path = pathlib.Path(tempfile.mkdtemp()) / "a.php"
+        path.write_text(source)
+        edges = parser.extract_edges(path, source) or []
+
+        assert edges, "fixture should still yield import edges"
+        assert {e.edge_type for e in edges} == {"imports"}
 
     def test_javascript_imports_are_esm_only(self, parser):
         """The js imports query matches `import_statement`. CommonJS
@@ -167,12 +229,8 @@ class TestKnownCoverageGaps:
         (directory / "esm.js").write_text(esm)
         (directory / "cjs.js").write_text(cjs)
 
-        esm_edges = parser.extract_edges(directory / "esm.js", esm) or []
-        cjs_edges = parser.extract_edges(directory / "cjs.js", cjs) or []
-
-        assert esm_edges, "ESM import should yield an edge"
-        assert not cjs_edges, (
-            "CommonJS require yielding edges means the query widened -- "
-            "good news, but update this test and the note in "
-            "docs/tree-sitter-setup.md"
+        assert parser.extract_edges(directory / "esm.js", esm)
+        assert not parser.extract_edges(directory / "cjs.js", cjs), (
+            "CommonJS require yielding edges means the query widened -- good "
+            "news, but update this test and docs/tree-sitter-setup.md"
         )

--- a/tests/test_language_query_yield.py
+++ b/tests/test_language_query_yield.py
@@ -1,0 +1,178 @@
+"""Every declared language query must match something on real code.
+
+`test_every_chunk_query_compiles` and `test_every_edge_query_compiles` prove
+compilation ONLY. That is the exact gap #158 lived in: a tree-sitter query
+that fails to compile is indistinguishable from one that matches nothing --
+`_get_query` returns None, `parse_file` moves on, and the index is silently
+missing a whole language's worth of structure. Four queries were broken at
+once for months, so TypeScript interfaces and ALL C# inheritance edges were
+absent from every index since they shipped.
+
+Compilation tests would not have caught any of them. These would.
+
+Five languages -- java, go, c, ruby, php -- had no corpus anywhere in the
+local checkout, so until this file they had never been run against real
+source in any form, only compiled. The fixtures are deliberately small and
+hand-written rather than sampled, so each one exercises the specific node
+types its query names.
+
+Two coverage gaps are pinned rather than fixed, because closing them is a
+feature decision and a silent gap is worse than a documented one:
+
+- **ruby has no edge queries at all.** It is the only language in `QUERIES`
+  absent from `EDGE_QUERIES`, so ruby files contribute nodes and no edges.
+- **php has an imports query but no inheritance query**, so `class X
+  implements Y` yields nothing where the java/c_sharp/typescript equivalents
+  yield an edge.
+"""
+
+import pathlib
+import tempfile
+
+import pytest
+
+from neo.index.language_parser import EDGE_QUERIES, QUERIES, TreeSitterParser
+
+# Each fixture exercises the node types its language's queries actually name.
+# `php` uses `use App\Contracts\Greeter;` rather than a bare `namespace`,
+# because the php imports query matches `namespace_use_declaration` -- a
+# fixture that only declares a namespace yields zero and looks like a defect.
+FIXTURES = {
+    "java": ("A.java", """package x;
+import java.util.List;
+public interface Greeter { String greet(String n); }
+public class Impl implements Greeter {
+    public String greet(String n) { return "hi " + n; }
+    private int count(List<String> xs) { return xs.size(); }
+}
+"""),
+    "go": ("a.go", """package main
+
+import "fmt"
+
+type Greeter interface { Greet(n string) string }
+
+type Impl struct{ N int }
+
+func (i Impl) Greet(n string) string { return fmt.Sprintf("hi %s", n) }
+
+func main() { fmt.Println(Impl{}.Greet("x")) }
+"""),
+    "c": ("a.c", """#include <stdio.h>
+
+struct Point { int x; int y; };
+
+int add(int a, int b) { return a + b; }
+
+int main(void) { printf("%d", add(1, 2)); return 0; }
+"""),
+    "ruby": ("a.rb", """require 'set'
+
+module Greetable
+  def greet(n)
+    "hi #{n}"
+  end
+end
+
+class Impl
+  include Greetable
+
+  def initialize(n)
+    @n = n
+  end
+
+  def count
+    @n.size
+  end
+end
+"""),
+    "php": ("a.php", """<?php
+namespace App;
+
+use App\\Contracts\\Greeter;
+
+class Impl implements Greeter {
+    public function greet(string $n): string { return "hi $n"; }
+    private function total(array $xs): int { return count($xs); }
+}
+"""),
+}
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return TreeSitterParser()
+
+
+def _parse(parser, lang):
+    name, source = FIXTURES[lang]
+    path = pathlib.Path(tempfile.mkdtemp()) / name
+    path.write_text(source)
+    return (parser.parse_file(path, source) or [],
+            parser.extract_edges(path, source) or [])
+
+
+class TestChunkQueriesMatchRealCode:
+    @pytest.mark.parametrize("lang", sorted(FIXTURES))
+    def test_language_produces_chunks(self, parser, lang):
+        chunks, _ = _parse(parser, lang)
+        assert chunks, (
+            f"{lang} chunk queries compile but matched nothing -- the #158 "
+            f"failure mode, which is invisible from the outside"
+        )
+
+
+class TestEdgeQueriesMatchRealCode:
+    @pytest.mark.parametrize("lang", sorted(set(FIXTURES) & set(EDGE_QUERIES) - {"php"}))
+    def test_language_produces_edges(self, parser, lang):
+        _, edges = _parse(parser, lang)
+        assert edges, f"{lang} edge queries compile but matched nothing"
+
+    def test_php_extracts_imports(self, parser):
+        """php declares only an imports query, so that is all it can yield."""
+        _, edges = _parse(parser, "php")
+        assert edges, "php imports query matched nothing on a `use` statement"
+
+
+class TestKnownCoverageGaps:
+    """Pinned so the gaps are visible, and so closing one updates a test
+    rather than silently changing behaviour."""
+
+    def test_ruby_declares_no_edge_queries(self):
+        """Ruby is the only language with chunk queries and no edge queries,
+        so ruby files contribute nodes to the graph and never edges. Delete
+        this test when ruby edge queries are added -- its failure is the
+        signal that the gap closed.
+        """
+        assert set(QUERIES) - set(EDGE_QUERIES) == {"ruby"}
+
+    def test_php_has_imports_but_no_inheritance(self, parser):
+        """`class Impl implements Greeter` yields an edge in java, c_sharp
+        and typescript, and nothing in php."""
+        assert set(EDGE_QUERIES["php"]) == {"imports"}
+
+        _, edges = _parse(parser, "php")
+        kinds = {getattr(e, "kind", getattr(e, "type", "")) for e in edges}
+        assert not any("inherit" in str(k).lower() for k in kinds)
+
+    def test_javascript_imports_are_esm_only(self, parser):
+        """The js imports query matches `import_statement`. CommonJS
+        `require()` is a call expression and yields nothing, so a codebase on
+        `require` contributes no import edges at all.
+        """
+        esm = "import fs from 'fs';\nexport class A { m() { return 1; } }\n"
+        cjs = "const fs = require('fs');\nclass A { m() { return 1; } }\n"
+        directory = pathlib.Path(tempfile.mkdtemp())
+
+        (directory / "esm.js").write_text(esm)
+        (directory / "cjs.js").write_text(cjs)
+
+        esm_edges = parser.extract_edges(directory / "esm.js", esm) or []
+        cjs_edges = parser.extract_edges(directory / "cjs.js", cjs) or []
+
+        assert esm_edges, "ESM import should yield an edge"
+        assert not cjs_edges, (
+            "CommonJS require yielding edges means the query widened -- "
+            "good news, but update this test and the note in "
+            "docs/tree-sitter-setup.md"
+        )

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -183,13 +183,43 @@ class TestOutputFormatContract:
     """
 
     def _cli_format_string(self):
+        """Recover the f-string template from `cli.py`'s AST, not its text.
+
+        This used to scan source LINES for one holding both `print(` and
+        `bytes (score:`. That is a formatting assertion wearing a contract's
+        clothes: #187 moved the print into a helper and wrapped the literal
+        across two physical lines, leaving `bytes ` on one and `(score:` on
+        the next, and the scan reported "the parser's contract has moved" for
+        a format string that had not changed a character. A guard that fails
+        on a reflow trains the next reader to edit the guard.
+
+        Implicit concatenation of adjacent f-strings is ONE `JoinedStr` node,
+        so the AST sees the template whole however it is wrapped, and still
+        fails loudly if the format itself changes.
+        """
+        import ast
         import inspect
 
         from neo import cli
 
-        for line in inspect.getsource(cli).splitlines():
-            if "bytes (score:" in line and "print(" in line:
-                return line[line.index('f"'):].split('"')[1]
+        for node in ast.walk(ast.parse(inspect.getsource(cli))):
+            if not isinstance(node, ast.JoinedStr):
+                continue
+            parts = []
+            for piece in node.values:
+                if isinstance(piece, ast.Constant):
+                    parts.append(str(piece.value))
+                elif isinstance(piece, ast.FormattedValue):
+                    spec = ""
+                    if piece.format_spec is not None:
+                        spec = ":" + "".join(
+                            str(v.value) for v in piece.format_spec.values
+                            if isinstance(v, ast.Constant)
+                        )
+                    parts.append("{" + ast.unparse(piece.value) + spec + "}")
+            template = "".join(parts)
+            if "bytes (score:" in template:
+                return template
         pytest.fail("the dry-run selected-file print was not found in cli.py -- "
                     "the parser's contract has moved and this test is blind")
 


### PR DESCRIPTION
## Description

`--dry-run` exited in `cli.main` **before the engine was constructed**. It printed the gathered file list and nothing else — while `CLAUDE.md` told operators it "assembles the full context (file selection, fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to the LM." Three of those four never ran.

That matters more than an ordinary documentation slip, because this is the instrument the project tells people to use *before believing any claim about what Neo saw*. It is how the gatherer defect in #186 was found. Invisible through it: the Execution Envelope (which reaches the model through seven prompt builders), every retrieved fact, and the REPOSITORY CONTEXT block carrying the #178 truncation markers — the markers whose entire purpose is that a cut be visible could not be seen through the tool built for seeing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issue

Follow-on from #158, #178 and #186. Found by auditing where else Neo decides what the model sees with no signal when it's wrong.

## Motivation and Context

### `--dry-run` could make real, billed LLM calls

The worst defect, and the one that survived two reviewers before being caught. The multi-agent panel does **not** reason through `self.lm`: `_build_car_role_factory` calls `create_adapter("car", model=m)` per role and uses `self.lm` only as the fallback for unassigned roles. So installing a recording adapter did not intercept it.

With `car-server` reachable — this project's documented normal setup, since the observer autostarts off it — a novel prompt under `--dry-run` ran the full panel against real models, spent real money, never raised the stop signal, and printed ordinary output. The flag was a no-op that bills you. **Measured: 4 real adapters built (planner, coder, critic, judge); now 0.**

It is also the honest scope. The panel's later prompts are built from earlier model responses, so they cannot be shown without making the calls the flag exists to avoid.

### The prompt is recorded, never rebuilt

`RecordingLM` is a real `LMAdapter` in the engine's own `self.lm` slot, so the output is the exact `messages` list Neo hands the adapter. A renderer walking the context dict would be a second implementation of the seven prompt builders, free to drift the moment one changed — the duplicated-rule shape that put `EXCLUDED_DIR_NAMES` in two places and cost a release.

`DryRunComplete` derives from `BaseException` so `_process_guarded`'s `except Exception` cannot report a dry run as a `FAILED` lifecycle event. An ordinary exception is **not** a safe substitute: `_deliberate` has its own `except Exception` that would swallow it and silently degrade to the fast path.

### Three claims narrowed to what actually holds

| claim | why it was false |
|---|---|
| "the exact prompt that would be sent" | Anthropic hoists `system` into a separate kwarg, Google remaps roles and content keys, Ollama flattens to one string, CAR adds `intent_json`. And no provider is resolved at all, because the flag deliberately requires no credentials — so it structurally cannot render the wire payload. |
| "mutates nothing" | `FactStore.initialize` runs prune → demote → purge and then **saves**; `demote_unhelpful_facts` lowers confidence and invalidates facts, all pre-inference. `detect_implicit_feedback` was not "the one" such call, only the one I had found. |
| model params as if sent | Anthropic drops `temperature` on Opus 4.7+/Sonnet 5, CAR lets backend defaults win, `reasoning_effort` reaches only the OpenAI-family adapters. |

`FactStore(read_only=True)` makes `save()` a no-op at the single write choke point — a new caller cannot forget it, which threading a flag through every retrieval path could. `metrics.jsonl` still records, deliberately: the two events a dry run writes are read by neither `citation-stats` nor `learning-stats`.

### Three more defects found while moving the stop into the engine

- **`--stdin-json --dry-run` never stopped at all.** The old early-exit lived inside the plain-text branch, so JSON callers made a real inference call under a flag whose whole promise is that it does not.
- **`--json --dry-run` broke both of its documented invariants**: zero documents on stdout where the contract promises exactly one, no terminal event so `reasoning` stayed `running` forever, and every source line beginning with `{` became a counterfeit event for a host parsing the JSONL stream by that prefix.
- **`--no-scan` left `gathered` unbound**, and `--dry-run` briefly began requiring an API key once the stop moved past adapter resolution.

### The Execution Envelope's cuts are now marked

`prompt_section()` had three bare slices — `constraints[:12]`, `success_criteria[:8]`, `attempts[-3:]`. Under a prompt saying "satisfy these constraints", twelve of thirteen read as thirteen. The #178 sweep missed this module for the reason that sweep wrote down about itself: it looked for slices inside the known prompt builders, and this is a method on a dataclass reached indirectly through `_retrieve_context`.

Caps are unchanged; only the loss is visible. `shown_of(..., tail=True)` renders `[showing last 3 of 20]` for the tail slice, because which end survived is part of the meaning — a loop that has run twenty times is not a sample of twenty. `retrieval_query()` keeps its bare slices deliberately: it is embedded and compared by cosine, never read, so a marker there would be tokens in the query vector.

### Two invariants that were held by comments only

Both are now tested, because a comment is exactly what held `EXCLUDED_DIR_NAMES` in two places while one copy was corrected and the other kept hiding files.

- **The ranking formula stays single-sourced.** Checked: both retrieval paths already call `rank_score` and nothing recomputes it inline. A differential over 60 facts plus an AST walk for stray `success_bonus`/`provenance_bonus` calls now keeps it that way.
- **Every declared tree-sitter query matches real code.** java, go, c, ruby and php had no corpus in the checkout, so they had only ever been compile-tested — the exact gap #158 lived in.

Two coverage gaps are **pinned rather than closed**, because a documented gap beats a silent one: ruby declares no edge queries at all, and php has imports but no inheritance, so `class X implements Y` yields an edge in java, c_sharp and typescript and nothing in php.

## How Has This Been Tested?

- [x] `2119 passed, 8 skipped`; ruff clean
- [x] Panel suppression verified by patching `create_adapter` and forcing `_car_route_capability` to report a full pool: **4 adapters built before, 0 after**
- [x] `facts_global.json` byte-identical across two dry runs; `--json` stdout parses as exactly one document with 1 terminal event and 0 counterfeit events
- [x] Mutation-tested: the three `shown_of` markers, the `detect_implicit_feedback` guard in both directions, and **17 of 17** single-query mutations in the language-yield tests (the per-language form these replaced caught **0 of 28**)
- [x] Two tests that could not fail were found and fixed — a `getattr` chain on attributes `CodeEdge` does not declare, and per-language assertions that let a working query mask a dead one
- [x] Round 3: the VERIFY dry-run path wrote **1 episode + 1 `citation_survival`** and emitted **0 stdout documents** under `--json`; now 0, 0 and one valid document. Both `_get_query` mutations that break real extraction now fail (they left all 29 green)

**Test Configuration**: Python 3.13.9 · macOS 26.5.2 · neo 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Independent of #186** — no file overlap, so the two can merge in either order.

**Reviewers disagreed once, and Linus was right.** Neo proposed making `DryRunComplete` an ordinary `Exception` caught explicitly before the broad handler. That would have been swallowed by `_deliberate`'s own `except Exception` and silently degraded every dry run to the fast path. `BaseException` stays.

**Three review rounds, and every round found defects in the seams the previous round created** — not in what it fixed. Round 3's were: a dry run writing to the episode ledger via VERIFY mode's normal return, `--json` fixed on one exit and not its twin five lines away, and a test file that routed around the very accessor it was testing.

**Some of it was invisible to me locally.** The panel billing bug was undetectable here because `car-server` isn't reachable on this machine, so that path was dead in every test I ran. And a claim I wrote in round 2 ("the two events it writes are read by neither citation-stats nor learning-stats") was measured on the fast path and generalised to a path that did not exist when I measured it.

**Known limits, stated rather than fixed:** the output is the adapter's input, not the wire payload; only the first call is shown, and the panel is suppressed rather than previewed; `metrics.jsonl` still grows.
