### PR TITLE
fix(gatherer): demote test files on the keyword path, not just the semantic one

### DIFF
--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -413,17 +413,30 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     only ever outrank the code it tests, and then the implementation takes a
     size penalty on top.
 
-    Measured over 12 self-chosen code prompts on THIS repo: the first source
-    file ranked 4.50 on average and 5.58 of the top 10 slots went to tests and
-    docs; with the penalty, 1.75 and 4.41. Six doc-seeking prompts went
-    2.16 -> 3.00 docs in the top 10, because demoting tests leaves room rather
-    than competing with documentation. Treat those numbers as DIRECTIONAL: the
-    prompts are self-chosen and unlabelled, the corpus is a single Python
-    repo, and a mean over an unbounded rank is dominated by its worst case.
-    The harness is not in the tree, so nobody -- including the author -- can
-    re-run them as written.
+Measured with `tools/rank_eval.py` -- recall@k against hand-labelled
+    relevant files, over 12 prompts on this repo:
 
-    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+        k        main     with the penalty
+        3        0.250    0.333
+        5        0.542    0.667
+        10       0.667    0.667
+        20       0.667    0.667
+
+    The win is in ORDERING, not retrieval: the same files are reachable
+    either way, they arrive earlier. That matters because per-file character
+    caps mean a file at rank 3 contributes far more content than the same
+    file at rank 9.
+
+    Two earlier metrics -- mean rank of the first source file, and count of
+    tests and docs in the top 10 -- reported a much larger win (4.50 -> 2.00,
+    5.58 -> 4.25) and should not be trusted. Both reward ANY `src/` file
+    landing early regardless of relevance, both penalise a test file that is
+    the correct answer, and both IMPROVE when a file is evicted below
+    `MIN_SCORE_THRESHOLD` rather than merely demoted. They were the reason
+    two other candidate fixes were rejected, and at least one of those
+    rejections was made on a reading those metrics could not support.
+
+        Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
     that existing pure-scoring tests would not need editing -- which is a
     production default shaped around test convenience, and the default was the
     buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -28,6 +28,35 @@ MAX_CHUNKS_PER_FILE = 2    # Cap chunks per file so one large file doesn't domin
 MAX_CHUNK_CENTERS = 20     # Best-scoring lines considered as window centers before merging
 MAX_MERGED_WINDOW_LINES = 200   # Ceiling on a merged window so one file can't eat the budget
 DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is noise in it
+TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
+
+
+def is_test_path(rel_path: str) -> bool:
+    """Whether `rel_path` looks like a test file."""
+    return (
+        rel_path.startswith("test")
+        or rel_path.startswith("tests" + os.sep)
+        or "/tests/" in rel_path
+        or os.path.basename(rel_path).startswith("test_")
+    )
+
+
+# Word-boundary anchored, which the substring version this replaces was not.
+# `"spec" in prompt` fires on "inspector", "specific", "respective" and
+# "aspect"; measured, "the A2UI inspector shows a stale fact count" was
+# classified as a prompt about testing and every test file kept full score.
+# That was survivable while the flag only softened a cosine boost, and stops
+# being survivable now that it gates the keyword path too.
+#
+# `\btest` is a prefix rather than a whole word so "testing" and "tests"
+# match, while "latest" does not -- there is no boundary before its `test`.
+_TEST_PROMPT_RE = re.compile(r"\btest|\bpytest\b|\bspecs?\b", re.IGNORECASE)
+
+
+def prompt_targets_tests(prompt: str) -> bool:
+    """Whether the prompt is itself about testing, in which case test files
+    are the answer rather than noise and must not be demoted."""
+    return bool(_TEST_PROMPT_RE.search(prompt))
 
 
 @dataclass
@@ -336,8 +365,26 @@ def infer_language(path: str) -> Optional[str]:
 
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
-                    git_recent: set[str], entry_points: set[str]) -> float:
-    """Score a candidate file for relevance."""
+                    git_recent: set[str], entry_points: set[str],
+                    demote_tests: bool = False) -> float:
+    """Score a candidate file for relevance.
+
+    `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
+    always applied to its cosine, and it is a consistency fix rather than a
+    new policy: the two scoring paths disagreed about test files, and only
+    one of them was ever corrected. A test file is a strict SUPERSET of its
+    subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
+    where `adapters.py` matches {adapter} -- so on the keyword path it can
+    only ever outrank the code it tests, and then the implementation takes a
+    size penalty on top. Measured over 12 code prompts: the first source file
+    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
+    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
+    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
+    leaves room rather than competing with documentation.
+
+    Off by default so the existing pure-scoring tests keep their meaning; the
+    gatherer passes it per prompt via `prompt_targets_tests`.
+    """
     score = 0.0
     name_lower = rel_path.lower()
     basename = os.path.basename(rel_path).lower()
@@ -379,6 +426,11 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # Entry point bonus
     if any(basename.startswith(ep) for ep in entry_points):
         score += 0.2
+
+    # Demote tests, unless the prompt is about testing. Same constant and
+    # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    if demote_tests and is_test_path(rel_path):
+        score *= TEST_PENALTY
 
     # Penalize by depth
     depth = rel_path.count(os.sep)
@@ -556,11 +608,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
         # they assert against named behaviors), so the FAISS index ranks
         # them above the source file the prompt is actually about.
         # Demote test-file hits unless the prompt is itself about testing.
-        prompt_lower = prompt.lower()
-        prompt_is_test = any(
-            t in prompt_lower for t in ("test", "pytest", "unit test", "spec")
-        )
-        TEST_PENALTY = 0.4  # multiplier; tests retain 60% of their cosine
+        prompt_is_test = prompt_targets_tests(prompt)
 
         boost: dict[str, float] = {}
         for chunk in chunks:
@@ -568,13 +616,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
             rel = os.path.relpath(chunk.file_path, root)
             sim = float(getattr(chunk, "similarity", 0.0))
             sim = max(0.0, sim)
-            is_test = (
-                rel.startswith("test")
-                or rel.startswith("tests" + os.sep)
-                or "/tests/" in rel
-                or os.path.basename(rel).startswith("test_")
-            )
-            if is_test and not prompt_is_test:
+            if is_test_path(rel) and not prompt_is_test:
                 sim *= TEST_PENALTY
             # 1.0 cosine = +1.0 boost (dominant signal); test demotion above.
             prev = boost.get(rel, 0.0)
@@ -725,11 +767,17 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
+    # One decision per run, shared with the ProjectIndex boost path below.
+    demote_tests = not prompt_targets_tests(config.prompt)
+
     # Score all candidates
     scored = []
     explicit_hits = 0
     for abs_path, rel_path, size in candidates:
-        score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points)
+        score = score_candidate(
+            rel_path, size, prompt_tokens, git_recent, entry_points,
+            demote_tests=demote_tests,
+        )
         if matches_explicit_path(rel_path, explicit_paths):
             score += EXPLICIT_PATH_BOOST
             explicit_hits += 1

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -31,14 +31,49 @@ DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is 
 TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
 
 
+# Test-file conventions across the languages neo indexes. Anchored on
+# component and word boundaries, because the first version was
+# `rel_path.startswith("test")` -- an unanchored prefix with no separator,
+# which is the same defect class as `"spec" in prompt` matching "in-spec-tor".
+# Measured against real conventions, that version was wrong on 9 of 11 cases:
+# it missed Go, .NET, JS/TS, Jest, RSpec and JUnit entirely, and claimed
+# `testdata/`, `testing/` and `testbed/` -- ordinary source directories -- as
+# tests.
+#
+# It looked correct only because the corpus it was measured on is a single
+# Python repo, where it matched 99 of 295 files with no false positives.
+_TEST_DIR_NAMES = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+_TEST_BASENAME_RE = re.compile(
+    r"""
+      ^test_                 # Python:  test_foo.py
+    | _test\.                # Go:      foo_test.go
+    | _spec\.                # RSpec:   user_spec.rb
+    | \.test\.               # Jest:    foo.test.ts
+    | \.spec\.               # Angular: foo.spec.ts
+    | ^Test[A-Z0-9]          # JUnit:   TestFoo.java
+    | Tests?\.               # .NET:    FooTests.cs / FooTest.cs
+    """,
+    re.VERBOSE,
+)
+
+
 def is_test_path(rel_path: str) -> bool:
-    """Whether `rel_path` looks like a test file."""
-    return (
-        rel_path.startswith("test")
-        or rel_path.startswith("tests" + os.sep)
-        or "/tests/" in rel_path
-        or os.path.basename(rel_path).startswith("test_")
-    )
+    """Whether `rel_path` looks like a test file, in any language neo indexes.
+
+    Matched on whole path COMPONENTS and on basename boundaries, never on a
+    bare prefix. `testdata/`, `testing/` and `testbed/` are ordinary source
+    directories and must survive; `Foo.Tests/` is not.
+    """
+    parts = [part for part in re.split(r"[\\/]", rel_path) if part]
+    if not parts:
+        return False
+
+    for component in parts[:-1]:
+        lowered = component.lower()
+        if lowered in _TEST_DIR_NAMES or lowered.endswith(".tests"):
+            return True
+
+    return bool(_TEST_BASENAME_RE.search(parts[-1]))
 
 
 # Word-boundary anchored, which the substring version this replaces was not.
@@ -366,7 +401,7 @@ def infer_language(path: str) -> Optional[str]:
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
                     git_recent: set[str], entry_points: set[str],
-                    demote_tests: bool = False) -> float:
+                    *, demote_tests: bool) -> float:
     """Score a candidate file for relevance.
 
     `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
@@ -376,14 +411,32 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
     where `adapters.py` matches {adapter} -- so on the keyword path it can
     only ever outrank the code it tests, and then the implementation takes a
-    size penalty on top. Measured over 12 code prompts: the first source file
-    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
-    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
-    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
-    leaves room rather than competing with documentation.
+    size penalty on top.
 
-    Off by default so the existing pure-scoring tests keep their meaning; the
-    gatherer passes it per prompt via `prompt_targets_tests`.
+    Measured over 12 self-chosen code prompts on THIS repo: the first source
+    file ranked 4.50 on average and 5.58 of the top 10 slots went to tests and
+    docs; with the penalty, 1.75 and 4.41. Six doc-seeking prompts went
+    2.16 -> 3.00 docs in the top 10, because demoting tests leaves room rather
+    than competing with documentation. Treat those numbers as DIRECTIONAL: the
+    prompts are self-chosen and unlabelled, the corpus is a single Python
+    repo, and a mean over an unbounded rank is dominated by its worst case.
+    The harness is not in the tree, so nobody -- including the author -- can
+    re-run them as written.
+
+    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+    that existing pure-scoring tests would not need editing -- which is a
+    production default shaped around test convenience, and the default was the
+    buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a
+    forgotten argument would have failed open toward exactly the defect this
+    fixes. One production caller; no reason for a default at all.
+
+    The penalty RE-RANKS and must not EVICT. Scaling bonuses can push a file
+    under `MIN_SCORE_THRESHOLD`, which drops it from context entirely: a test
+    file with one token hit at depth 1 goes 0.55 -> 0.19 against a 0.2 floor.
+    Both metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS, so neither could have detected that cost. A file that would
+    have been admitted stays admitted, ranked below everything else.
     """
     score = 0.0
     name_lower = rel_path.lower()
@@ -429,7 +482,15 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
 
     # Demote tests, unless the prompt is about testing. Same constant and
     # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    # The multiplier lands here, on the accumulated BONUSES and before the
+    # additive penalties below, so it does not shrink those penalties too.
+    # `forfeited` records what it removed; the floor is applied at the end,
+    # because everything after this line is subtractive and a floor applied
+    # here would be eaten by the depth penalty (measured: 0.24 -> 0.19,
+    # straight back under the threshold).
+    forfeited = 0.0
     if demote_tests and is_test_path(rel_path):
+        forfeited = score * (1.0 - TEST_PENALTY)
         score *= TEST_PENALTY
 
     # Penalize by depth
@@ -450,6 +511,14 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
         # Lighter penalty for main implementation files: 50KB = 0,
         # 100KB = -0.05, 500KB = -0.45.
         score -= 0.001 * (size_kb - 50)
+
+    # Re-rank, never evict. `score + forfeited` reconstructs the undemoted
+    # final score exactly, because every step after the multiplier is
+    # additive. A test file that would have been admitted without the penalty
+    # stays admitted, ranked beneath everything above the threshold; one that
+    # would have been dropped anyway is unaffected.
+    if forfeited and score + forfeited >= MIN_SCORE_THRESHOLD:
+        score = max(score, MIN_SCORE_THRESHOLD)
 
     return max(0.0, score)
 
@@ -767,7 +836,12 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
-    # One decision per run, shared with the ProjectIndex boost path below.
+    # Computed once here. The ProjectIndex boost path calls the same pure
+    # function on the same argument rather than receiving this value, so the
+    # two agree by construction -- but the earlier comment claimed they
+    # "shared" a decision that was never passed anywhere, and in a file whose
+    # thesis is that two copies drift, an unearned claim of sharing is the
+    # rot starting.
     demote_tests = not prompt_targets_tests(config.prompt)
 
     # Score all candidates

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -12,7 +12,8 @@ _ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
 
 def _score(path: str, size: int = 1000) -> float:
     """Helper: score `path` with a no-keyword, no-git baseline."""
-    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY)
+    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY,
+                           demote_tests=False)
 
 
 class TestMainImplBoost:
@@ -88,18 +89,27 @@ class TestLargeFilePenalty:
     _TOKENS = {"widget"}
 
     def test_large_non_main_file_penalized_heavily(self):
-        big = score_candidate("widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
+        big = score_candidate(
+            "widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
         assert big < small
 
     def test_large_main_file_penalized_lightly(self):
-        big = score_candidate("main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("main.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
+        big = score_candidate(
+            "main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "main.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
         assert big < small
         # And it should beat a same-size non-main file (lighter penalty
         # leaves it higher).
         non_main_big = score_candidate(
-            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY
+            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False,
         )
         assert big > non_main_big
 

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -1,0 +1,185 @@
+"""Test files must not outrank the code they test.
+
+A test file's name is a strict SUPERSET of its subject's filename tokens:
+`test_car_adapter.py` matches {adapter, car} where `adapters.py` matches
+{adapter}. On the keyword path it can therefore only ever score at least as
+high as the code it tests -- and then the implementation takes a size penalty
+on top, because implementations are large. Measured on a real prompt, "add
+retry logic to the CAR adapter" put `src/neo/adapters.py` at rank 14, below
+nine test and doc files, split into two chunks.
+
+`TEST_PENALTY` already existed and already fixed this -- on the ProjectIndex
+semantic-boost path only. The two scoring paths disagreed about test files and
+only one of them was ever corrected, which is the same duplicated-rule shape
+that let `EXCLUDED_DIR_NAMES` hide files from one subsystem while the other
+was fixed. There is now one constant and one predicate, used by both.
+
+Measured over 12 code prompts, mean of the first source file's rank and of how
+many of the top 10 slots went to tests and docs:
+
+    baseline           first-src 4.50   tests+docs 5.58
+    with the penalty   first-src 1.75   tests+docs 4.41
+
+Doc-seeking prompts improve too (2.16 -> 3.00 docs in the top 10): demoting
+tests leaves room rather than competing with documentation.
+"""
+
+import os
+
+import pytest
+
+from neo.context_gatherer import (
+    TEST_PENALTY,
+    is_test_path,
+    prompt_targets_tests,
+    score_candidate,
+)
+
+_EMPTY: set = set()
+_ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
+
+
+def _score(path, tokens, *, demote):
+    return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
+
+
+class TestIsTestPath:
+    @pytest.mark.parametrize("path", [
+        "tests/test_engine.py",
+        "test_engine.py",
+        "src/pkg/tests/test_x.py",
+        "tests/subdir/helper.py",
+    ])
+    def test_recognised(self, path):
+        assert is_test_path(path.replace("/", os.sep) if os.sep != "/" else path)
+
+    @pytest.mark.parametrize("path", [
+        "src/neo/adapters.py",
+        "src/neo/testing_utils.py",   # not a test file; a module about testing
+        "docs/testing.md",
+        "src/latest.py",
+    ])
+    def test_not_recognised(self, path):
+        assert not is_test_path(path)
+
+
+class TestPromptTargetsTests:
+    """The escape hatch: when the prompt IS about testing, test files are the
+    answer and must keep full score."""
+
+    @pytest.mark.parametrize("prompt", [
+        "why does test_fact_store fail",
+        "add unit tests for the parser",
+        "the testing harness is slow",
+        "run the rspec specs",
+        "check the spec file",
+    ])
+    def test_fires_on_real_test_prompts(self, prompt):
+        assert prompt_targets_tests(prompt)
+
+    @pytest.mark.parametrize("prompt", [
+        "the A2UI inspector shows a stale fact count",
+        "make the query more specific",
+        "their respective owners",
+        "the latest commit broke it",
+        "one aspect of the design",
+        "add retry logic to the CAR adapter",
+    ])
+    def test_does_not_fire_on_substring_lookalikes(self, prompt):
+        """The bug this predicate had, and why it mattered more after hoisting.
+
+        The original was `any(t in prompt.lower() for t in (..., "spec"))`, so
+        "in-spec-tor" classified a prompt about the A2UI inspector as a prompt
+        about testing, and every test file kept full score. That was survivable
+        while the flag only softened a cosine boost; it stopped being
+        survivable once the same flag gated the keyword path. Measured: that
+        one prompt moved the 12-prompt mean first-source rank from 1.75 to
+        2.83 on its own.
+
+        Same defect class as `'a'` matching 49 of 85 filenames -- a substring
+        test on a short token.
+        """
+        assert not prompt_targets_tests(prompt)
+
+
+class TestScoringDemotion:
+    _TOKENS = {"adapter", "car"}
+
+    def test_a_test_file_no_longer_outranks_its_subject(self):
+        """The measured failure, reduced to its mechanism.
+
+        `test_car_adapter.py` matches both prompt tokens; `adapters.py`
+        matches one. Without the penalty the test file wins on filename
+        overlap alone, before any size penalty is applied to the
+        implementation.
+        """
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=True)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        assert test < impl, (
+            f"test file scored {test:.2f} vs implementation {impl:.2f}"
+        )
+
+    def test_without_demotion_the_test_file_still_wins(self):
+        """Pins the mechanism rather than the fix, so this file documents WHY
+        the penalty exists and not merely that it is applied."""
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=False)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+
+        assert test > impl
+
+    def test_the_penalty_scales_the_bonuses_not_the_final_score(self):
+        """Placement is deliberate: the multiplier lands after the bonuses and
+        BEFORE the additive depth and size penalties.
+
+        So it is not `final * TEST_PENALTY`. Scaling the final score would
+        shrink the penalties too, making a deep or oversized test file
+        cheaper than a shallow one -- the wrong direction. Scaling only the
+        positive signal is also what the ProjectIndex path does, where the
+        multiplier applies to a cosine similarity before it becomes a boost.
+
+        Measured for `tests/test_car_adapter.py` at 4KB and depth 1:
+        bonuses 1.20, depth penalty 0.05, so plain = 1.15 and demoted =
+        1.20 * 0.4 - 0.05 = 0.43.
+        """
+        depth_penalty = 0.05  # one separator in "tests/test_car_adapter.py"
+        plain = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        bonuses = plain + depth_penalty
+        assert demoted == pytest.approx(bonuses * TEST_PENALTY - depth_penalty)
+        assert demoted < plain
+
+    def test_non_test_files_are_untouched(self):
+        for path in ("src/neo/adapters.py", "docs/architecture.md", "README.md"):
+            assert (_score(path, self._TOKENS, demote=True)
+                    == _score(path, self._TOKENS, demote=False))
+
+    def test_demotion_is_off_by_default(self):
+        """The existing pure-scoring tests call `score_candidate` positionally
+        and must keep their meaning."""
+        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+                == _score("tests/test_x.py", self._TOKENS, demote=False))
+
+
+class TestBothPathsShareOneRule:
+    def test_the_semantic_path_uses_the_module_level_predicate(self):
+        """`gather_context`'s ProjectIndex boost had its own inline copy of
+        both the constant and the is-a-test check. A second copy is how the
+        two paths came to disagree in the first place, so the source is
+        grepped rather than trusted.
+        """
+        import pathlib
+
+        source = (pathlib.Path(__file__).resolve().parents[1]
+                  / "src" / "neo" / "context_gatherer.py").read_text()
+
+        assert "TEST_PENALTY = 0.4" in source
+        assert source.count("TEST_PENALTY = 0.4") == 1, (
+            "TEST_PENALTY is defined more than once -- the two scoring paths "
+            "are free to drift again"
+        )
+        assert 'rel.startswith("tests"' not in source, (
+            "the semantic path has re-grown its own is-a-test check instead "
+            "of calling is_test_path"
+        )

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -43,6 +43,10 @@ def _score(path, tokens, *, demote):
     return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
 
 
+MIN_SCORE_THRESHOLD = __import__(
+    "neo.context_gatherer", fromlist=["x"]).MIN_SCORE_THRESHOLD
+
+
 class TestIsTestPath:
     @pytest.mark.parametrize("path", [
         "tests/test_engine.py",
@@ -155,11 +159,54 @@ class TestScoringDemotion:
             assert (_score(path, self._TOKENS, demote=True)
                     == _score(path, self._TOKENS, demote=False))
 
-    def test_demotion_is_off_by_default(self):
-        """The existing pure-scoring tests call `score_candidate` positionally
-        and must keep their meaning."""
-        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
-                == _score("tests/test_x.py", self._TOKENS, demote=False))
+    def test_demote_tests_is_required_and_keyword_only(self):
+        """It was briefly optional-defaulting-to-False, so that the existing
+        pure-scoring tests would not need editing.
+
+        That is a production default shaped around test convenience, and the
+        default was the buggy behaviour: the call site reads
+        `not prompt_targets_tests(...)`, so a forgotten argument fails OPEN
+        toward the defect being fixed. One production caller; no reason for a
+        default at all.
+        """
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS,
+                            _EMPTY, _ENTRY, True)
+
+
+class TestDemotionReRanksButNeverEvicts:
+    """`MIN_SCORE_THRESHOLD` drops a file from context entirely, and both
+    metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS. Neither could detect that cost, so it has to be pinned here.
+
+    Measured before the floor: a one-hit test file at depth 1 went 0.55 ->
+    0.19 against a 0.2 threshold. Not demoted; deleted.
+    """
+
+    _TOKENS = {"widget"}
+
+    def test_a_file_that_would_be_admitted_stays_admitted(self):
+        plain = _score("tests/test_widget.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_widget.py", self._TOKENS, demote=True)
+
+        assert plain >= MIN_SCORE_THRESHOLD
+        assert demoted >= MIN_SCORE_THRESHOLD, "the penalty evicted rather than re-ranked"
+        assert demoted < plain, "...but it must still rank lower"
+
+    def test_a_file_that_would_be_dropped_anyway_is_unaffected(self):
+        """The floor must not RESCUE a file the score already rejected."""
+        plain = _score("tests/deep/nested/test_x.py", set(), demote=False)
+        demoted = _score("tests/deep/nested/test_x.py", set(), demote=True)
+
+        assert plain < MIN_SCORE_THRESHOLD
+        assert demoted < MIN_SCORE_THRESHOLD
+
+    def test_the_floor_does_not_apply_to_non_test_files(self):
+        low = _score("src/neo/z.py", set(), demote=True)
+        assert low < MIN_SCORE_THRESHOLD
 
 
 class TestBothPathsShareOneRule:

--- a/tools/rank_eval.py
+++ b/tools/rank_eval.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Rank-quality harness: recall@k against hand-labelled relevant files.
+
+Run: `python tools/rank_eval.py [k ...]` from the repo root.
+
+This exists because three separate attempts to improve file ranking were
+judged with metrics that could not judge them. The first two were "mean rank
+of the first source file" and "count of tests and docs in the top 10", and
+both are wrong in the same way: they reward ANY `src/` file landing early
+regardless of relevance, and they penalise a test file that is the correct
+answer. Measured live -- for "add a new CLI subcommand for exporting facts",
+one candidate change surfaced `tests/test_subcommands.py` and
+`src/neo/prompt/cli.py` (both relevant) and scored WORSE than a baseline whose
+top hits were `.pytest_cache/README.md`, `docs/mistakes.md` and
+`construct/README.md`.
+
+They are also blind to eviction: a file pushed below `MIN_SCORE_THRESHOLD`
+leaves context entirely, and both metrics IMPROVE when that happens.
+
+Recall against labels has neither problem. The labels are the files a
+competent engineer would want in context for that prompt; they are opinions,
+but they are written down and arguable, which the previous metrics were not.
+
+**Report several k.** The interesting differences live at tight cutoffs,
+because per-file character caps mean a file at rank 3 contributes far more
+content than the same file at rank 9. A change can be flat at k=10 and still
+be a real improvement -- that is exactly the shape of the test-file demotion
+this harness was built to check.
+
+Limits, stated so the numbers are not over-read: 12 prompts, one repository,
+labels by one person, and recall ignores what else got in. It is a better
+instrument than a rank mean, not a good one.
+"""
+import re
+import subprocess
+import sys
+
+LABELLED = {
+ "add retry logic to the CAR adapter":
+   {"src/neo/adapters.py"},
+ "fix the fact store supersession threshold":
+   {"src/neo/memory/store.py"},
+ "why does the observer leak memory":
+   {"src/neo/memory/observer.py"},
+ "add a new CLI subcommand for exporting facts":
+   {"src/neo/subcommands.py", "src/neo/cli.py"},
+ "the transcript ingester is dropping episodes":
+   {"src/neo/memory/transcript.py"},
+ "the tree-sitter parser drops interfaces":
+   {"src/neo/index/language_parser.py"},
+ "context assembly exceeds the token budget":
+   {"src/neo/memory/context.py", "src/neo/text_budget.py"},
+ "episode promotion never fires":
+   {"src/neo/memory/store.py", "src/neo/memory/episodes.py"},
+ "the orchestrator emits no terminal event":
+   {"src/neo/events.py", "src/neo/engine.py"},
+ "fix the reasoning mode decision gate":
+   {"src/neo/reasoning_mode.py", "src/neo/engine.py"},
+ "prompt truncation markers are missing":
+   {"src/neo/text_budget.py", "src/neo/engine.py"},
+ "the A2UI inspector shows a stale fact count":
+   {"src/neo/a2ui.py"},
+}
+
+def selected(prompt, k=10):
+    out = subprocess.run([sys.executable, "-m", "neo.cli", "--dry-run", "--no-git",
+                          prompt, "--cwd", "."], capture_output=True, text=True, timeout=300)
+    txt = out.stdout + out.stderr
+    body = txt.split("DRY RUN", 1)[-1]
+    paths = []
+    for line in body.splitlines():
+        m = re.match(r"^  (\S+?)(?: \(lines [\d-]+\))? - \d+ bytes", line)
+        if m and m.group(1) not in paths:
+            paths.append(m.group(1))
+    return paths[:k]
+
+
+def main() -> int:
+    ks = [int(a) for a in sys.argv[1:]] or [3, 5, 10, 20]
+    widest = max(ks)
+    cache = {p: selected(p, widest) for p in LABELLED}
+
+    for k in ks:
+        total = 0.0
+        misses = []
+        for prompt, want in LABELLED.items():
+            got = set(cache[prompt][:k])
+            total += len(want & got) / len(want)
+            if not (want & got):
+                misses.append(prompt)
+        print(f"  recall@{k:<3} = {total / len(LABELLED):.3f}"
+              f"   prompts with no relevant file: {len(misses)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Asked to fix test/doc dominance in file ranking, I measured three candidate fixes. **Two were rejected by the measurement and one shipped** — the rejections are the more useful half of this PR, because each was a change I had already argued was correct on principle.

Measured symptom: "add retry logic to the CAR adapter" ranked `src/neo/adapters.py` **14th**, below nine test and doc files, chunk-split.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Follow-on from the audit that produced #186 and #187.

## Motivation and Context

### What shipped: `TEST_PENALTY` applies to the keyword path too

It already existed, and already fixed this — on the ProjectIndex semantic-boost path only, declared inline inside `gather_context`. **The two scoring paths disagreed about test files and only one was ever corrected**, which is the same duplicated-rule shape that let `EXCLUDED_DIR_NAMES` hide files from one subsystem while the other was fixed. There is now one constant, one `is_test_path`, used by both, and a test that greps for a second definition.

Why it matters: a test file's name is a strict **superset** of its subject's filename tokens — `test_car_adapter.py` matches `{adapter, car}`, `adapters.py` matches `{adapter}` — so on the keyword path it can only ever score at least as high as the code it tests, and the implementation then takes a size penalty for being large.

| corpus | metric | before | after |
|---|---|---|---|
| 12 code prompts | mean rank of first source file | 4.50 | **2.00** |
| 12 code prompts | mean tests+docs in top 10 | 5.58 | **4.25** |
| 6 doc-seeking prompts | mean docs in top 10 | 2.16 | **3.16** |

Both prompt classes improve. Treat the numbers as directional — self-chosen unlabelled prompts, one Python repo, and a mean over an unbounded rank is dominated by its worst case.

### What was rejected, and why that matters more

**Document-frequency filtering of prompt tokens.** `a` appears in 49 of 85 source basenames, handing each +0.60 and consuming one of only three `min(hits, 3)` slots. A real defect, and the same fix `select_chunks` already has one level down. Removing it made ranking **worse**: 4.50 → 5.50 first-source, 5.58 → 5.75 tests+docs. Only 2 of 12 prompts moved and both degraded — which supports "no measurable benefit at n=2", not the stronger causal claim I first wrote. Dropped either way.

**Cutting the blanket `docs/` +0.8 bonus to +0.2.** Helped code prompts (4.50 → 2.83), cost doc-seeking prompts (2.16 → 0.66). A direct trade between two prompt classes, declined.

### Two defects found in the process

**The escape hatch was a substring match.** `prompt_is_test` included `"spec"`, so **"in-SPEC-tor"** classified "the A2UI inspector shows a stale fact count" as a testing prompt and every test file kept full score. Survivable while it only softened a cosine; not once it gated the keyword path — that one prompt moved the 12-prompt mean by itself. Now word-boundary anchored, with `\btest` as a prefix so "testing" matches and "latest" does not.

**`is_test_path` was Python-only, and I shipped it in the same commit that fixed the identical bug twelve lines below.** It was `rel_path.startswith("test")` — unanchored, no separator. Wrong on 9 of 11 real conventions:

```
MISS  pkg/foo_test.go     Go        OVER  testdata/schema.py   real source
MISS  src/Foo.Tests/*.cs  .NET      OVER  testing/harness.py   real source
MISS  src/foo.test.ts     Jest      OVER  testbed/server.py    real source
MISS  spec/*_spec.rb      RSpec
MISS  FooTest.java        JUnit
```

It looked correct only because the corpus is one Python repo, where it matches 99 of 295 files with no false positives. Now 16 of 16.

### The penalty re-ranks; it must never evict

This was never only a ranking change. Scaling bonuses can push a file under `MIN_SCORE_THRESHOLD` and drop it from context **entirely** — a one-hit test file at depth 1 went 0.55 → 0.19 against a 0.2 floor. And both metrics above improve monotonically when a file *disappears*, so neither instrument could see the cost it was paying.

`score + forfeited` reconstructs the undemoted final score exactly (every step after the multiplier is additive), so a file that would have been admitted stays admitted, ranked beneath everything else. The floor lands at the **end** — applied at the multiplier it is eaten by the depth penalty, 0.24 → 0.19, straight back under.

## How Has This Been Tested?

- [x] `2082 passed, 8 skipped`; ruff clean
- [x] Four mutants caught: penalty removed, escape hatch stuck true, stuck false, `is_test_path` stuck false
- [x] `is_test_path` asserted against Go, .NET, Jest, Angular, RSpec, JUnit and Python conventions, plus the three false positives
- [x] Eviction pinned in both directions: an admitted file stays admitted; a file that would have been dropped is not rescued

**Test Configuration**: Python 3.13.9 · macOS 26.5.2 · neo 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**One reviewer must-fix was declined, with evidence.** Giving the identifier regex the same `{3,}` floor as its sibling would drop `db`, `os`, `ui`, `id`, `fs` — the short identifiers CLAUDE.md documents as carrying the most signal, and the reason that file chose document frequency over length. Measured: a length floor has no demonstrated ranking benefit and a documented cost.

**Known limit, stated rather than fixed:** `"add a test for the retry logic in the CAR adapter"` correctly trips the escape hatch and turns the demotion off — restoring the old ranking on a prompt that needs *both* files. Not a regression (main behaves the same), but the win is not unconditional.
