### PR TITLE
feat(index): give ruby and php the edge queries they never had

### DIFF
--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -28,6 +28,35 @@ MAX_CHUNKS_PER_FILE = 2    # Cap chunks per file so one large file doesn't domin
 MAX_CHUNK_CENTERS = 20     # Best-scoring lines considered as window centers before merging
 MAX_MERGED_WINDOW_LINES = 200   # Ceiling on a merged window so one file can't eat the budget
 DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is noise in it
+TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
+
+
+def is_test_path(rel_path: str) -> bool:
+    """Whether `rel_path` looks like a test file."""
+    return (
+        rel_path.startswith("test")
+        or rel_path.startswith("tests" + os.sep)
+        or "/tests/" in rel_path
+        or os.path.basename(rel_path).startswith("test_")
+    )
+
+
+# Word-boundary anchored, which the substring version this replaces was not.
+# `"spec" in prompt` fires on "inspector", "specific", "respective" and
+# "aspect"; measured, "the A2UI inspector shows a stale fact count" was
+# classified as a prompt about testing and every test file kept full score.
+# That was survivable while the flag only softened a cosine boost, and stops
+# being survivable now that it gates the keyword path too.
+#
+# `\btest` is a prefix rather than a whole word so "testing" and "tests"
+# match, while "latest" does not -- there is no boundary before its `test`.
+_TEST_PROMPT_RE = re.compile(r"\btest|\bpytest\b|\bspecs?\b", re.IGNORECASE)
+
+
+def prompt_targets_tests(prompt: str) -> bool:
+    """Whether the prompt is itself about testing, in which case test files
+    are the answer rather than noise and must not be demoted."""
+    return bool(_TEST_PROMPT_RE.search(prompt))
 
 
 @dataclass
@@ -336,8 +365,26 @@ def infer_language(path: str) -> Optional[str]:
 
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
-                    git_recent: set[str], entry_points: set[str]) -> float:
-    """Score a candidate file for relevance."""
+                    git_recent: set[str], entry_points: set[str],
+                    demote_tests: bool = False) -> float:
+    """Score a candidate file for relevance.
+
+    `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
+    always applied to its cosine, and it is a consistency fix rather than a
+    new policy: the two scoring paths disagreed about test files, and only
+    one of them was ever corrected. A test file is a strict SUPERSET of its
+    subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
+    where `adapters.py` matches {adapter} -- so on the keyword path it can
+    only ever outrank the code it tests, and then the implementation takes a
+    size penalty on top. Measured over 12 code prompts: the first source file
+    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
+    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
+    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
+    leaves room rather than competing with documentation.
+
+    Off by default so the existing pure-scoring tests keep their meaning; the
+    gatherer passes it per prompt via `prompt_targets_tests`.
+    """
     score = 0.0
     name_lower = rel_path.lower()
     basename = os.path.basename(rel_path).lower()
@@ -379,6 +426,11 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # Entry point bonus
     if any(basename.startswith(ep) for ep in entry_points):
         score += 0.2
+
+    # Demote tests, unless the prompt is about testing. Same constant and
+    # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    if demote_tests and is_test_path(rel_path):
+        score *= TEST_PENALTY
 
     # Penalize by depth
     depth = rel_path.count(os.sep)
@@ -556,11 +608,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
         # they assert against named behaviors), so the FAISS index ranks
         # them above the source file the prompt is actually about.
         # Demote test-file hits unless the prompt is itself about testing.
-        prompt_lower = prompt.lower()
-        prompt_is_test = any(
-            t in prompt_lower for t in ("test", "pytest", "unit test", "spec")
-        )
-        TEST_PENALTY = 0.4  # multiplier; tests retain 60% of their cosine
+        prompt_is_test = prompt_targets_tests(prompt)
 
         boost: dict[str, float] = {}
         for chunk in chunks:
@@ -568,13 +616,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
             rel = os.path.relpath(chunk.file_path, root)
             sim = float(getattr(chunk, "similarity", 0.0))
             sim = max(0.0, sim)
-            is_test = (
-                rel.startswith("test")
-                or rel.startswith("tests" + os.sep)
-                or "/tests/" in rel
-                or os.path.basename(rel).startswith("test_")
-            )
-            if is_test and not prompt_is_test:
+            if is_test_path(rel) and not prompt_is_test:
                 sim *= TEST_PENALTY
             # 1.0 cosine = +1.0 boost (dominant signal); test demotion above.
             prev = boost.get(rel, 0.0)
@@ -725,11 +767,17 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
+    # One decision per run, shared with the ProjectIndex boost path below.
+    demote_tests = not prompt_targets_tests(config.prompt)
+
     # Score all candidates
     scored = []
     explicit_hits = 0
     for abs_path, rel_path, size in candidates:
-        score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points)
+        score = score_candidate(
+            rel_path, size, prompt_tokens, git_recent, entry_points,
+            demote_tests=demote_tests,
+        )
         if matches_explicit_path(rel_path, explicit_paths):
             score += EXPLICIT_PATH_BOOST
             explicit_hits += 1

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -31,14 +31,49 @@ DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is 
 TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
 
 
+# Test-file conventions across the languages neo indexes. Anchored on
+# component and word boundaries, because the first version was
+# `rel_path.startswith("test")` -- an unanchored prefix with no separator,
+# which is the same defect class as `"spec" in prompt` matching "in-spec-tor".
+# Measured against real conventions, that version was wrong on 9 of 11 cases:
+# it missed Go, .NET, JS/TS, Jest, RSpec and JUnit entirely, and claimed
+# `testdata/`, `testing/` and `testbed/` -- ordinary source directories -- as
+# tests.
+#
+# It looked correct only because the corpus it was measured on is a single
+# Python repo, where it matched 99 of 295 files with no false positives.
+_TEST_DIR_NAMES = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+_TEST_BASENAME_RE = re.compile(
+    r"""
+      ^test_                 # Python:  test_foo.py
+    | _test\.                # Go:      foo_test.go
+    | _spec\.                # RSpec:   user_spec.rb
+    | \.test\.               # Jest:    foo.test.ts
+    | \.spec\.               # Angular: foo.spec.ts
+    | ^Test[A-Z0-9]          # JUnit:   TestFoo.java
+    | Tests?\.               # .NET:    FooTests.cs / FooTest.cs
+    """,
+    re.VERBOSE,
+)
+
+
 def is_test_path(rel_path: str) -> bool:
-    """Whether `rel_path` looks like a test file."""
-    return (
-        rel_path.startswith("test")
-        or rel_path.startswith("tests" + os.sep)
-        or "/tests/" in rel_path
-        or os.path.basename(rel_path).startswith("test_")
-    )
+    """Whether `rel_path` looks like a test file, in any language neo indexes.
+
+    Matched on whole path COMPONENTS and on basename boundaries, never on a
+    bare prefix. `testdata/`, `testing/` and `testbed/` are ordinary source
+    directories and must survive; `Foo.Tests/` is not.
+    """
+    parts = [part for part in re.split(r"[\\/]", rel_path) if part]
+    if not parts:
+        return False
+
+    for component in parts[:-1]:
+        lowered = component.lower()
+        if lowered in _TEST_DIR_NAMES or lowered.endswith(".tests"):
+            return True
+
+    return bool(_TEST_BASENAME_RE.search(parts[-1]))
 
 
 # Word-boundary anchored, which the substring version this replaces was not.
@@ -366,7 +401,7 @@ def infer_language(path: str) -> Optional[str]:
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
                     git_recent: set[str], entry_points: set[str],
-                    demote_tests: bool = False) -> float:
+                    *, demote_tests: bool) -> float:
     """Score a candidate file for relevance.
 
     `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
@@ -376,14 +411,32 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
     where `adapters.py` matches {adapter} -- so on the keyword path it can
     only ever outrank the code it tests, and then the implementation takes a
-    size penalty on top. Measured over 12 code prompts: the first source file
-    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
-    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
-    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
-    leaves room rather than competing with documentation.
+    size penalty on top.
 
-    Off by default so the existing pure-scoring tests keep their meaning; the
-    gatherer passes it per prompt via `prompt_targets_tests`.
+    Measured over 12 self-chosen code prompts on THIS repo: the first source
+    file ranked 4.50 on average and 5.58 of the top 10 slots went to tests and
+    docs; with the penalty, 1.75 and 4.41. Six doc-seeking prompts went
+    2.16 -> 3.00 docs in the top 10, because demoting tests leaves room rather
+    than competing with documentation. Treat those numbers as DIRECTIONAL: the
+    prompts are self-chosen and unlabelled, the corpus is a single Python
+    repo, and a mean over an unbounded rank is dominated by its worst case.
+    The harness is not in the tree, so nobody -- including the author -- can
+    re-run them as written.
+
+    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+    that existing pure-scoring tests would not need editing -- which is a
+    production default shaped around test convenience, and the default was the
+    buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a
+    forgotten argument would have failed open toward exactly the defect this
+    fixes. One production caller; no reason for a default at all.
+
+    The penalty RE-RANKS and must not EVICT. Scaling bonuses can push a file
+    under `MIN_SCORE_THRESHOLD`, which drops it from context entirely: a test
+    file with one token hit at depth 1 goes 0.55 -> 0.19 against a 0.2 floor.
+    Both metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS, so neither could have detected that cost. A file that would
+    have been admitted stays admitted, ranked below everything else.
     """
     score = 0.0
     name_lower = rel_path.lower()
@@ -429,7 +482,15 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
 
     # Demote tests, unless the prompt is about testing. Same constant and
     # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    # The multiplier lands here, on the accumulated BONUSES and before the
+    # additive penalties below, so it does not shrink those penalties too.
+    # `forfeited` records what it removed; the floor is applied at the end,
+    # because everything after this line is subtractive and a floor applied
+    # here would be eaten by the depth penalty (measured: 0.24 -> 0.19,
+    # straight back under the threshold).
+    forfeited = 0.0
     if demote_tests and is_test_path(rel_path):
+        forfeited = score * (1.0 - TEST_PENALTY)
         score *= TEST_PENALTY
 
     # Penalize by depth
@@ -450,6 +511,14 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
         # Lighter penalty for main implementation files: 50KB = 0,
         # 100KB = -0.05, 500KB = -0.45.
         score -= 0.001 * (size_kb - 50)
+
+    # Re-rank, never evict. `score + forfeited` reconstructs the undemoted
+    # final score exactly, because every step after the multiplier is
+    # additive. A test file that would have been admitted without the penalty
+    # stays admitted, ranked beneath everything above the threshold; one that
+    # would have been dropped anyway is unaffected.
+    if forfeited and score + forfeited >= MIN_SCORE_THRESHOLD:
+        score = max(score, MIN_SCORE_THRESHOLD)
 
     return max(0.0, score)
 
@@ -767,7 +836,12 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
-    # One decision per run, shared with the ProjectIndex boost path below.
+    # Computed once here. The ProjectIndex boost path calls the same pure
+    # function on the same argument rather than receiving this value, so the
+    # two agree by construction -- but the earlier comment claimed they
+    # "shared" a decision that was never passed anywhere, and in a file whose
+    # thesis is that two copies drift, an unearned claim of sharing is the
+    # rot starting.
     demote_tests = not prompt_targets_tests(config.prompt)
 
     # Score all candidates

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -12,7 +12,8 @@ _ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
 
 def _score(path: str, size: int = 1000) -> float:
     """Helper: score `path` with a no-keyword, no-git baseline."""
-    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY)
+    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY,
+                           demote_tests=False)
 
 
 class TestMainImplBoost:
@@ -88,18 +89,27 @@ class TestLargeFilePenalty:
     _TOKENS = {"widget"}
 
     def test_large_non_main_file_penalized_heavily(self):
-        big = score_candidate("widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
+        big = score_candidate(
+            "widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
         assert big < small
 
     def test_large_main_file_penalized_lightly(self):
-        big = score_candidate("main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("main.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
+        big = score_candidate(
+            "main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "main.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
         assert big < small
         # And it should beat a same-size non-main file (lighter penalty
         # leaves it higher).
         non_main_big = score_candidate(
-            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY
+            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False,
         )
         assert big > non_main_big
 

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -1,0 +1,185 @@
+"""Test files must not outrank the code they test.
+
+A test file's name is a strict SUPERSET of its subject's filename tokens:
+`test_car_adapter.py` matches {adapter, car} where `adapters.py` matches
+{adapter}. On the keyword path it can therefore only ever score at least as
+high as the code it tests -- and then the implementation takes a size penalty
+on top, because implementations are large. Measured on a real prompt, "add
+retry logic to the CAR adapter" put `src/neo/adapters.py` at rank 14, below
+nine test and doc files, split into two chunks.
+
+`TEST_PENALTY` already existed and already fixed this -- on the ProjectIndex
+semantic-boost path only. The two scoring paths disagreed about test files and
+only one of them was ever corrected, which is the same duplicated-rule shape
+that let `EXCLUDED_DIR_NAMES` hide files from one subsystem while the other
+was fixed. There is now one constant and one predicate, used by both.
+
+Measured over 12 code prompts, mean of the first source file's rank and of how
+many of the top 10 slots went to tests and docs:
+
+    baseline           first-src 4.50   tests+docs 5.58
+    with the penalty   first-src 1.75   tests+docs 4.41
+
+Doc-seeking prompts improve too (2.16 -> 3.00 docs in the top 10): demoting
+tests leaves room rather than competing with documentation.
+"""
+
+import os
+
+import pytest
+
+from neo.context_gatherer import (
+    TEST_PENALTY,
+    is_test_path,
+    prompt_targets_tests,
+    score_candidate,
+)
+
+_EMPTY: set = set()
+_ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
+
+
+def _score(path, tokens, *, demote):
+    return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
+
+
+class TestIsTestPath:
+    @pytest.mark.parametrize("path", [
+        "tests/test_engine.py",
+        "test_engine.py",
+        "src/pkg/tests/test_x.py",
+        "tests/subdir/helper.py",
+    ])
+    def test_recognised(self, path):
+        assert is_test_path(path.replace("/", os.sep) if os.sep != "/" else path)
+
+    @pytest.mark.parametrize("path", [
+        "src/neo/adapters.py",
+        "src/neo/testing_utils.py",   # not a test file; a module about testing
+        "docs/testing.md",
+        "src/latest.py",
+    ])
+    def test_not_recognised(self, path):
+        assert not is_test_path(path)
+
+
+class TestPromptTargetsTests:
+    """The escape hatch: when the prompt IS about testing, test files are the
+    answer and must keep full score."""
+
+    @pytest.mark.parametrize("prompt", [
+        "why does test_fact_store fail",
+        "add unit tests for the parser",
+        "the testing harness is slow",
+        "run the rspec specs",
+        "check the spec file",
+    ])
+    def test_fires_on_real_test_prompts(self, prompt):
+        assert prompt_targets_tests(prompt)
+
+    @pytest.mark.parametrize("prompt", [
+        "the A2UI inspector shows a stale fact count",
+        "make the query more specific",
+        "their respective owners",
+        "the latest commit broke it",
+        "one aspect of the design",
+        "add retry logic to the CAR adapter",
+    ])
+    def test_does_not_fire_on_substring_lookalikes(self, prompt):
+        """The bug this predicate had, and why it mattered more after hoisting.
+
+        The original was `any(t in prompt.lower() for t in (..., "spec"))`, so
+        "in-spec-tor" classified a prompt about the A2UI inspector as a prompt
+        about testing, and every test file kept full score. That was survivable
+        while the flag only softened a cosine boost; it stopped being
+        survivable once the same flag gated the keyword path. Measured: that
+        one prompt moved the 12-prompt mean first-source rank from 1.75 to
+        2.83 on its own.
+
+        Same defect class as `'a'` matching 49 of 85 filenames -- a substring
+        test on a short token.
+        """
+        assert not prompt_targets_tests(prompt)
+
+
+class TestScoringDemotion:
+    _TOKENS = {"adapter", "car"}
+
+    def test_a_test_file_no_longer_outranks_its_subject(self):
+        """The measured failure, reduced to its mechanism.
+
+        `test_car_adapter.py` matches both prompt tokens; `adapters.py`
+        matches one. Without the penalty the test file wins on filename
+        overlap alone, before any size penalty is applied to the
+        implementation.
+        """
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=True)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        assert test < impl, (
+            f"test file scored {test:.2f} vs implementation {impl:.2f}"
+        )
+
+    def test_without_demotion_the_test_file_still_wins(self):
+        """Pins the mechanism rather than the fix, so this file documents WHY
+        the penalty exists and not merely that it is applied."""
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=False)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+
+        assert test > impl
+
+    def test_the_penalty_scales_the_bonuses_not_the_final_score(self):
+        """Placement is deliberate: the multiplier lands after the bonuses and
+        BEFORE the additive depth and size penalties.
+
+        So it is not `final * TEST_PENALTY`. Scaling the final score would
+        shrink the penalties too, making a deep or oversized test file
+        cheaper than a shallow one -- the wrong direction. Scaling only the
+        positive signal is also what the ProjectIndex path does, where the
+        multiplier applies to a cosine similarity before it becomes a boost.
+
+        Measured for `tests/test_car_adapter.py` at 4KB and depth 1:
+        bonuses 1.20, depth penalty 0.05, so plain = 1.15 and demoted =
+        1.20 * 0.4 - 0.05 = 0.43.
+        """
+        depth_penalty = 0.05  # one separator in "tests/test_car_adapter.py"
+        plain = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        bonuses = plain + depth_penalty
+        assert demoted == pytest.approx(bonuses * TEST_PENALTY - depth_penalty)
+        assert demoted < plain
+
+    def test_non_test_files_are_untouched(self):
+        for path in ("src/neo/adapters.py", "docs/architecture.md", "README.md"):
+            assert (_score(path, self._TOKENS, demote=True)
+                    == _score(path, self._TOKENS, demote=False))
+
+    def test_demotion_is_off_by_default(self):
+        """The existing pure-scoring tests call `score_candidate` positionally
+        and must keep their meaning."""
+        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+                == _score("tests/test_x.py", self._TOKENS, demote=False))
+
+
+class TestBothPathsShareOneRule:
+    def test_the_semantic_path_uses_the_module_level_predicate(self):
+        """`gather_context`'s ProjectIndex boost had its own inline copy of
+        both the constant and the is-a-test check. A second copy is how the
+        two paths came to disagree in the first place, so the source is
+        grepped rather than trusted.
+        """
+        import pathlib
+
+        source = (pathlib.Path(__file__).resolve().parents[1]
+                  / "src" / "neo" / "context_gatherer.py").read_text()
+
+        assert "TEST_PENALTY = 0.4" in source
+        assert source.count("TEST_PENALTY = 0.4") == 1, (
+            "TEST_PENALTY is defined more than once -- the two scoring paths "
+            "are free to drift again"
+        )
+        assert 'rel.startswith("tests"' not in source, (
+            "the semantic path has re-grown its own is-a-test check instead "
+            "of calling is_test_path"
+        )

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -43,6 +43,10 @@ def _score(path, tokens, *, demote):
     return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
 
 
+MIN_SCORE_THRESHOLD = __import__(
+    "neo.context_gatherer", fromlist=["x"]).MIN_SCORE_THRESHOLD
+
+
 class TestIsTestPath:
     @pytest.mark.parametrize("path", [
         "tests/test_engine.py",
@@ -155,11 +159,54 @@ class TestScoringDemotion:
             assert (_score(path, self._TOKENS, demote=True)
                     == _score(path, self._TOKENS, demote=False))
 
-    def test_demotion_is_off_by_default(self):
-        """The existing pure-scoring tests call `score_candidate` positionally
-        and must keep their meaning."""
-        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
-                == _score("tests/test_x.py", self._TOKENS, demote=False))
+    def test_demote_tests_is_required_and_keyword_only(self):
+        """It was briefly optional-defaulting-to-False, so that the existing
+        pure-scoring tests would not need editing.
+
+        That is a production default shaped around test convenience, and the
+        default was the buggy behaviour: the call site reads
+        `not prompt_targets_tests(...)`, so a forgotten argument fails OPEN
+        toward the defect being fixed. One production caller; no reason for a
+        default at all.
+        """
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS,
+                            _EMPTY, _ENTRY, True)
+
+
+class TestDemotionReRanksButNeverEvicts:
+    """`MIN_SCORE_THRESHOLD` drops a file from context entirely, and both
+    metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS. Neither could detect that cost, so it has to be pinned here.
+
+    Measured before the floor: a one-hit test file at depth 1 went 0.55 ->
+    0.19 against a 0.2 threshold. Not demoted; deleted.
+    """
+
+    _TOKENS = {"widget"}
+
+    def test_a_file_that_would_be_admitted_stays_admitted(self):
+        plain = _score("tests/test_widget.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_widget.py", self._TOKENS, demote=True)
+
+        assert plain >= MIN_SCORE_THRESHOLD
+        assert demoted >= MIN_SCORE_THRESHOLD, "the penalty evicted rather than re-ranked"
+        assert demoted < plain, "...but it must still rank lower"
+
+    def test_a_file_that_would_be_dropped_anyway_is_unaffected(self):
+        """The floor must not RESCUE a file the score already rejected."""
+        plain = _score("tests/deep/nested/test_x.py", set(), demote=False)
+        demoted = _score("tests/deep/nested/test_x.py", set(), demote=True)
+
+        assert plain < MIN_SCORE_THRESHOLD
+        assert demoted < MIN_SCORE_THRESHOLD
+
+    def test_the_floor_does_not_apply_to_non_test_files(self):
+        low = _score("src/neo/z.py", set(), demote=True)
+        assert low < MIN_SCORE_THRESHOLD
 
 
 class TestBothPathsShareOneRule:


### PR DESCRIPTION
## Description

Ruby declared **no edge queries at all** — the only language in `QUERIES` absent from `EDGE_QUERIES`. Every ruby file in every index contributed nodes to the graph and never a single relationship: no `require`, no superclass, no mixin. PHP declared imports only, so `class Impl extends BaseImpl implements Greeter` produced nothing where the java, c_sharp and typescript equivalents each produce edges.

Both gaps were found while writing the per-query yield tests in #187 and pinned there as failing-when-fixed assertions. Both pins have now fired.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Follow-on from #158. **Stacked on #187** — see Additional Notes.

## Motivation and Context

### Ruby: the method-call problem, and the predicate that solves it

The existing code carried a comment explaining the omission: *"Ruby imports are method calls (`require`, `require_relative`) rather than syntactic forms — adding them would need either a method-call pattern match or a runtime-style heuristic."* The method-call pattern match is what this uses.

Because `require` is an ordinary call, the pattern matches **any** call taking a string — only the `#match?` predicate separates an import from `puts 'hello'`. That predicate is load-bearing, so its enforcement is a test: if a future tree-sitter stopped applying predicates in `QueryCursor.captures`, the query would keep compiling and start emitting an import edge per string-argument call. Silent, and in the noisiest possible direction.

### The first cut dropped every namespaced supertype, silently

This is the part worth reading. `(base_clause (name) @base)` requires `name` as a **direct** child; the real shape is `base_clause → qualified_name → name`, and Ruby's is `superclass → scope_resolution → constant`. Measured against realistic source, the first version produced:

```
class B extends \Foo\Bar implements \ArrayAccess, Countable {}
  → ONE edge:  B implements Countable

class ApplicationRecord < ActiveRecord::Base
  include ActiveSupport::Concern
  → ONE edge:  ApplicationRecord implements Plain
```

`ActiveRecord::Base` is the single most common inheritance statement in the Ruby ecosystem and produced **nothing**. This is silent *partial* extraction, which is worse than a total miss: the consumer sees a plausible answer with no signal that most of it is absent.

It is also precisely what the `_CS_BASE_TYPES` comment **150 lines above the new code** warns about — and I quoted the other half of that comment in my own rationale while writing the narrow arm.

Note: do **not** copy the C# spelling `(qualified_name name: (name) @x)`. PHP's `qualified_name` has no `name:` field; that pattern fails to compile.

### Two more gaps and one consistency decision

- **PHP 8.1 enums** carry `class_interface_clause` and were uncovered.
- **PHP `use SomeTrait;`** is the same construct Ruby's mixins are. Shipping two languages in one commit with opposite stances on it would not have survived the next maintainer, so traits map to `implements`, as `include`/`extend`/`prepend` do.
- The PHP alternation is now **generated** from `_PHP_BASE_TYPES` across declaration kinds, per the `_CS_INHERITANCE` precedent — it had already grown to three declaration kinds across two queries, hand-copied, which is the exact state that comment exists to prevent.

Query **names** are load-bearing and easy to get wrong: `extract_edges` dispatches on exactly `imports` / `import_from` / `inheritance` / `implements` and silently ignores anything else, so a well-formed query under any other name is a no-op.

### The fixtures were the root cause

They were minimal and written by the same person as the queries, so they agreed with them by construction — 5/5 and 6/6 mutation kills measured the *fixture*, not the grammar. They are now framework-shaped: Rails (`< ActiveRecord::Base`, `include ActiveSupport::Concern`) and PSR/Laravel (`extends \Foo\BaseImpl implements \ArrayAccess`, an 8.1 enum, a trait `use`).

The module docstring's "wait until a real ruby repository is available" limit was also wrong, and that mistaken framing is what let the narrow arms ship: no ruby or php **corpus** exists locally, but the **grammars** are installed. The limit is now stated accurately.

## How Has This Been Tested?

- [x] `2132 passed, 8 skipped`; ruff clean
- [x] Every one of the five new queries mutation-tested individually — 5/5 caught
- [x] Plus four more: stripping the `#match?` predicate, re-narrowing the PHP arms, re-narrowing the Ruby arms, dropping `enum_declaration`
- [x] All 11 expected edges extract from framework-shaped source, verified against the installed grammars

**Test Configuration**: Python 3.13.9 · macOS 26.5.2 · neo 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Stacked on #187, deliberately.** `tests/test_language_query_yield.py` does not exist on `main` — it arrives across three commits of that branch, and the two pins this PR must flip live only there. Rebasing onto `main` would mean either dropping the pins (losing the point) or carrying a duplicate of a 290-line file. **Merge #187 first.**

**Standing limit:** the fixtures are hand-written framework snippets, not a corpus. A green run means the queries work on the shapes we know about, not that they are complete — PHP group `use App\{A, B};` is a known pre-existing gap.
