### PR TITLE
feat(index): give ruby and php the edge queries they never had

### DIFF
--- a/src/neo/index/language_parser.py
+++ b/src/neo/index/language_parser.py
@@ -303,6 +303,62 @@ _CS_INHERITANCE = "[\n" + "\n".join(
 ) + "\n] @class_def"
 
 # Edge queries for relationship extraction (imports, inheritance)
+# PHP supertypes reach the query in two shapes and BOTH must be covered:
+#
+#     implements Countable          -> (name)
+#     extends \Foo\Bar             -> (qualified_name (name))   (everyday PSR)
+#
+# The narrow arm alone compiles perfectly and drops every namespaced
+# supertype without a word -- `class B extends \Foo\Bar implements
+# \ArrayAccess, Countable` yielded exactly one edge, `B implements
+# Countable`, which is worse than a total miss because the consumer has no
+# signal anything is absent. This is the same failure the `_CS_BASE_TYPES`
+# comment above documents, reproduced in a new language 150 lines below it.
+#
+# Do NOT copy the C# spelling `(qualified_name name: (name) @x)` -- PHP's
+# `qualified_name` has no `name:` field and that pattern fails to compile.
+# The unfielded direct child is the last segment, which matches C#'s
+# rightmost-segment convention.
+_PHP_BASE_TYPES = "[(name) @{cap} (qualified_name (name) @{cap})]"
+
+# Generated across declaration kinds rather than written out per kind, for
+# the reason `_CS_INHERITANCE` is generated: a hand-maintained duplicate
+# invites the next widening to be applied to some of the arms and not the
+# rest. PHP 8.1 enums carry `class_interface_clause` too, and were missed by
+# the hand-written version.
+_PHP_EXTENDS_KINDS = ("class_declaration", "interface_declaration")
+_PHP_IMPLEMENTS_KINDS = ("class_declaration", "enum_declaration")
+
+
+def _php_edge_queries() -> dict:
+    base = _PHP_BASE_TYPES.format(cap="base")
+    iface = _PHP_BASE_TYPES.format(cap="interface")
+    extends = " ".join(
+        f"({kind} name: (name) @class_name (base_clause {base}))"
+        for kind in _PHP_EXTENDS_KINDS
+    )
+    implements = " ".join(
+        f"({kind} name: (name) @class_name (class_interface_clause {iface}))"
+        for kind in _PHP_IMPLEMENTS_KINDS
+    )
+    # `use SomeTrait;` inside a class body. Mapped to `implements` for parity
+    # with Ruby's mixins in this same change: both mean "this type gains that
+    # module's surface", and two languages in one commit taking opposite
+    # stances on the same construct would not survive the next maintainer.
+    traits = (
+        f"(class_declaration name: (name) @class_name "
+        f"(declaration_list (use_declaration {iface})))"
+    )
+    return {
+        'imports': """
+            (namespace_use_declaration
+                (namespace_use_clause (qualified_name) @module)) @import
+        """,
+        'inheritance': f"[ {extends} ] @class_def",
+        'implements': f"[ {implements} {traits} ] @class_def",
+    }
+
+
 EDGE_QUERIES = {
     'python': {
         'imports': """
@@ -426,44 +482,16 @@ EDGE_QUERIES = {
             (import_declaration (identifier) @module) @import
         """,
     },
-    'php': {
-        'imports': """
-            (namespace_use_declaration
-                (namespace_use_clause (qualified_name) @module)) @import
-        """,
-        # `base_clause` is `extends`, and BOTH declaration kinds carry it:
-        # `class X extends Y` and `interface X extends Y`. Covering only
-        # `class_declaration` compiles fine and silently drops every
-        # interface hierarchy — the shape that left C# inheritance missing
-        # from every index for months.
-        'inheritance': """
-            [
-                (class_declaration
-                    name: (name) @class_name
-                    (base_clause (name) @base))
-                (interface_declaration
-                    name: (name) @class_name
-                    (base_clause (name) @base))
-            ] @class_def
-        """,
-        # Separate node type from `base_clause`, and it holds a LIST:
-        # `implements Greeter, Countable` yields two `name` children.
-        'implements': """
-            (class_declaration
-                name: (name) @class_name
-                (class_interface_clause (name) @interface)) @class_def
-        """,
-    },
+    'php': _php_edge_queries(),
     'ruby': {
         # Ruby has no syntactic import: `require` and `require_relative` are
         # ordinary method calls, which is why this language had no edge
         # queries at all and contributed nodes to the graph and never edges.
         # The `#match?` predicate is what makes the method-call form
-        # tractable — without it the pattern matches every call taking a
-        # string, so `puts 'hello'` would become an import edge. Verified
-        # that the predicate is actually applied by this tree-sitter version
-        # rather than silently ignored: see
-        # `test_ruby_import_predicate_is_enforced`.
+        # tractable -- without it the pattern matches every call taking a
+        # string, so `puts 'hello'` becomes an import edge. Verified that this
+        # tree-sitter version actually applies predicates rather than
+        # ignoring them; see `test_ruby_import_predicate_is_enforced`.
         'imports': """
             (call
                 method: (identifier) @_method
@@ -472,22 +500,37 @@ EDGE_QUERIES = {
         """,
         # `class Impl < Base`. The node type is `class`, not
         # `class_declaration`, and the name is a `constant`.
+        #
+        # The `scope_resolution` arm is not optional politeness: the first
+        # version matched a bare `(constant)` only, so
+        # `class ApplicationRecord < ActiveRecord::Base` -- the single most
+        # common inheritance statement in the Ruby ecosystem -- produced NO
+        # edge, silently. Same defect the C# comment above warns about.
         'inheritance': """
             (class
                 name: (constant) @class_name
-                (superclass (constant) @base)) @class_def
+                (superclass [
+                    (constant) @base
+                    (scope_resolution name: (constant) @base)
+                ])) @class_def
         """,
-        # Ruby expresses "implements" as a mixin — `include`, `extend` and
+        # Ruby expresses "implements" as a mixin -- `include`, `extend` and
         # `prepend` are again method calls, inside the class body. Mapped to
         # the `implements` edge type because that is what they mean to a
-        # reader: this class gains that module's interface.
+        # reader: this class gains that module's interface. `extend` adds
+        # CLASS methods rather than instance methods, so the direction
+        # differs; both are still "gains this module's surface", which is the
+        # resolution an edge consumer needs.
         'implements': """
             (class
                 name: (constant) @class_name
                 (body_statement
                     (call
                         method: (identifier) @_method
-                        arguments: (argument_list (constant) @interface)
+                        arguments: (argument_list [
+                            (constant) @interface
+                            (scope_resolution name: (constant) @interface)
+                        ])
                         (#match? @_method "^(include|extend|prepend)$")))) @class_def
         """,
     },

--- a/src/neo/index/language_parser.py
+++ b/src/neo/index/language_parser.py
@@ -431,10 +431,66 @@ EDGE_QUERIES = {
             (namespace_use_declaration
                 (namespace_use_clause (qualified_name) @module)) @import
         """,
+        # `base_clause` is `extends`, and BOTH declaration kinds carry it:
+        # `class X extends Y` and `interface X extends Y`. Covering only
+        # `class_declaration` compiles fine and silently drops every
+        # interface hierarchy — the shape that left C# inheritance missing
+        # from every index for months.
+        'inheritance': """
+            [
+                (class_declaration
+                    name: (name) @class_name
+                    (base_clause (name) @base))
+                (interface_declaration
+                    name: (name) @class_name
+                    (base_clause (name) @base))
+            ] @class_def
+        """,
+        # Separate node type from `base_clause`, and it holds a LIST:
+        # `implements Greeter, Countable` yields two `name` children.
+        'implements': """
+            (class_declaration
+                name: (name) @class_name
+                (class_interface_clause (name) @interface)) @class_def
+        """,
     },
-    # Ruby imports are method calls (`require`, `require_relative`) rather
-    # than syntactic forms — skipped here. Adding them would need either
-    # a method-call pattern match or a runtime-style heuristic.
+    'ruby': {
+        # Ruby has no syntactic import: `require` and `require_relative` are
+        # ordinary method calls, which is why this language had no edge
+        # queries at all and contributed nodes to the graph and never edges.
+        # The `#match?` predicate is what makes the method-call form
+        # tractable — without it the pattern matches every call taking a
+        # string, so `puts 'hello'` would become an import edge. Verified
+        # that the predicate is actually applied by this tree-sitter version
+        # rather than silently ignored: see
+        # `test_ruby_import_predicate_is_enforced`.
+        'imports': """
+            (call
+                method: (identifier) @_method
+                arguments: (argument_list (string) @module)
+                (#match? @_method "^(require|require_relative)$")) @import
+        """,
+        # `class Impl < Base`. The node type is `class`, not
+        # `class_declaration`, and the name is a `constant`.
+        'inheritance': """
+            (class
+                name: (constant) @class_name
+                (superclass (constant) @base)) @class_def
+        """,
+        # Ruby expresses "implements" as a mixin — `include`, `extend` and
+        # `prepend` are again method calls, inside the class body. Mapped to
+        # the `implements` edge type because that is what they mean to a
+        # reader: this class gains that module's interface.
+        'implements': """
+            (class
+                name: (constant) @class_name
+                (body_statement
+                    (call
+                        method: (identifier) @_method
+                        arguments: (argument_list (constant) @interface)
+                        (#match? @_method "^(include|extend|prepend)$")))) @class_def
+        """,
+    },
 }
 
 EDGE_QUERIES['tsx'] = EDGE_QUERIES['typescript']

--- a/tests/test_language_query_yield.py
+++ b/tests/test_language_query_yield.py
@@ -26,6 +26,16 @@ methods, no top-level function).
 Five languages -- java, go, c, ruby, php -- have no corpus anywhere in the
 local checkout, so until this file they had never been run against source in
 any form, only compiled.
+
+**Standing limit**: that is still true of the CORPUS, not of the queries. The
+fixtures here are hand-written, so every query is exercised against code
+somebody wrote to exercise it. A hand-written fixture cannot surface the
+constructs a real codebase uses and the fixture author did not think of -- an
+`extends` with a generic parameter, a namespaced base class, a mixin applied
+through `Module.included`. So a green run means "the query works on the shapes
+we know about", not "the query is complete". When a real ruby or php
+repository becomes available, re-run the yield measurement against it before
+trusting these numbers.
 """
 
 import pathlib
@@ -76,6 +86,7 @@ int add(int a, int b) { return a + b; }
 int main(void) { printf("%d", add(1, 2)); return 0; }
 """,
     "ruby": """require 'set'
+require_relative 'helper'
 
 module Greetable
   def greet(n)
@@ -83,7 +94,13 @@ module Greetable
   end
 end
 
-class Impl
+class Base
+  def seed
+    1
+  end
+end
+
+class Impl < Base
   include Greetable
 
   def initialize(n)
@@ -103,7 +120,11 @@ use App\\Support\\Str;
 
 function helper(int $x): int { return $x + 1; }
 
-class Impl implements Greeter {
+interface Extended extends Greeter {}
+
+abstract class BaseImpl {}
+
+class Impl extends BaseImpl implements Greeter, Countable {
     public function greet(string $n): string { return "hi $n"; }
     private function total(array $xs): int { return count($xs); }
 }
@@ -116,6 +137,12 @@ _EXT = {"java": ".java", "go": ".go", "c": ".c", "ruby": ".rb", "php": ".php"}
 @pytest.fixture(scope="module")
 def parser():
     return TreeSitterParser()
+
+
+def parser_edges(path, source):
+    """Module-level edge extraction, so the closure tests below can call it
+    without threading the fixture through."""
+    return TreeSitterParser().extract_edges(path, source) or []
 
 
 def _captures(parser, language, table, query_name):
@@ -237,40 +264,76 @@ class TestEndToEndYield:
         assert parser.extract_edges(path, source)
 
 
-class TestKnownCoverageGaps:
-    """Pinned so the gaps stay visible, and so closing one updates a test
-    rather than silently changing behaviour."""
+class TestClosedCoverageGaps:
+    """These two gaps were pinned as failing-when-fixed tests, and the pins
+    have now fired. Kept as the inverse assertions so a regression that
+    removes the queries fails here rather than going quiet -- which is the
+    whole failure mode this file exists for."""
 
-    def test_ruby_declares_no_edge_queries(self):
-        """Ruby is the only language with chunk queries and no edge queries,
-        so ruby files contribute nodes to the graph and never edges. Delete
-        this test when ruby edge queries land -- its failure is the signal
-        that the gap closed.
+    def test_every_language_with_chunks_also_declares_edges(self):
+        """Ruby used to be the sole exception, contributing nodes to the
+        graph and never edges: no require/inherit/mixin relationship from any
+        ruby file in any index."""
+        assert set(QUERIES) - set(EDGE_QUERIES) == set()
+
+    def test_php_extracts_inheritance_and_interfaces(self):
+        """`class Impl extends BaseImpl implements Greeter, Countable` and
+        `interface Extended extends Greeter` all yield edges now. Previously
+        php declared only `imports`, so every php class hierarchy was absent.
+
+        Asserted on `edge_type`, the field `CodeEdge` actually declares -- an
+        earlier version read `getattr(e, "kind", getattr(e, "type", ""))`,
+        neither of which exists, so the set was always `{""}` and the
+        assertion could not fail.
         """
-        assert set(QUERIES) - set(EDGE_QUERIES) == {"ruby"}
-
-    def test_php_has_imports_but_no_inheritance(self, parser):
-        """`class Impl implements Greeter` yields an edge in java, c_sharp
-        and typescript, and nothing in php.
-
-        Asserted on `edge_type`, the field `CodeEdge` actually declares. An
-        earlier version of this test read `getattr(e, "kind", getattr(e,
-        "type", ""))` -- neither attribute exists, so the set was always
-        `{""}` and the assertion could not fail. In a file whose subject is
-        "a query that matches nothing is indistinguishable from one that
-        failed to compile", that was an assertion indistinguishable from no
-        assertion.
-        """
-        assert set(EDGE_QUERIES["php"]) == {"imports"}
-
         source = FIXTURES["php"]
         path = pathlib.Path(tempfile.mkdtemp()) / "a.php"
         path.write_text(source)
-        edges = parser.extract_edges(path, source) or []
+        edges = parser_edges(path, source)
 
-        assert edges, "fixture should still yield import edges"
-        assert {e.edge_type for e in edges} == {"imports"}
+        assert {e.edge_type for e in edges} == {"imports", "inherits", "implements"}
+        assert ("Impl", "BaseImpl") in {(e.source_symbol, e.target_symbol)
+                                        for e in edges if e.edge_type == "inherits"}
+        assert {"Greeter", "Countable"} <= {e.target_symbol for e in edges
+                                            if e.edge_type == "implements"}
 
+    def test_ruby_extracts_requires_inheritance_and_mixins(self):
+        source = FIXTURES["ruby"]
+        path = pathlib.Path(tempfile.mkdtemp()) / "a.rb"
+        path.write_text(source)
+        edges = parser_edges(path, source)
+
+        by_type = {}
+        for edge in edges:
+            by_type.setdefault(edge.edge_type, set()).add(edge.target_symbol)
+
+        assert by_type["imports"] == {"set", "helper"}
+        assert ("Impl", "Base") in {(e.source_symbol, e.target_symbol)
+                                    for e in edges if e.edge_type == "inherits"}
+        assert "Greetable" in by_type["implements"]
+
+    def test_ruby_import_predicate_is_enforced(self):
+        """`require` is an ordinary method call, so the pattern matches any
+        call taking a string. Only the `#match?` predicate separates an
+        import from `puts 'hello'`.
+
+        If a future tree-sitter release stopped applying predicates in
+        `QueryCursor.captures`, the query would keep compiling and start
+        emitting an import edge per string-argument call -- silent, and in
+        the noisiest possible direction. This is the test that notices.
+        """
+        source = "require 'set'\nputs 'hello'\nlog_error 'boom'\n"
+        path = pathlib.Path(tempfile.mkdtemp()) / "b.rb"
+        path.write_text(source)
+
+        targets = {e.target_symbol for e in parser_edges(path, source)}
+        assert targets == {"set"}, (
+            f"predicate not applied: {targets} -- every string-argument call "
+            f"became an import"
+        )
+
+
+class TestJavascriptGap:
     def test_javascript_imports_are_esm_only(self, parser):
         """The js imports query matches `import_statement`. CommonJS
         `require()` is a call expression and yields nothing, so a codebase on

--- a/tests/test_language_query_yield.py
+++ b/tests/test_language_query_yield.py
@@ -27,15 +27,20 @@ Five languages -- java, go, c, ruby, php -- have no corpus anywhere in the
 local checkout, so until this file they had never been run against source in
 any form, only compiled.
 
-**Standing limit**: that is still true of the CORPUS, not of the queries. The
-fixtures here are hand-written, so every query is exercised against code
-somebody wrote to exercise it. A hand-written fixture cannot surface the
-constructs a real codebase uses and the fixture author did not think of -- an
-`extends` with a generic parameter, a namespaced base class, a mixin applied
-through `Module.included`. So a green run means "the query works on the shapes
-we know about", not "the query is complete". When a real ruby or php
-repository becomes available, re-run the yield measurement against it before
-trusting these numbers.
+**Standing limit, narrower than it first looked.** No ruby or php source
+exists anywhere in the local checkout, which is why these languages went
+unvalidated. But the GRAMMARS are installed, so "wait for a real repository"
+was the wrong conclusion and it cost real bugs: the first version of these
+fixtures used a bare `class Impl < Base` and a bare `implements Greeter`, so
+they agreed with queries that silently dropped `ActiveRecord::Base` and
+`\\Foo\\Bar` -- every namespaced supertype in both ecosystems. A fixture
+written by the query's author proves the query matches the fixture.
+
+The fixtures are now framework-shaped rather than minimal: Rails
+(`< ActiveRecord::Base`, `include ActiveSupport::Concern`) and PSR/Laravel
+(`extends \\Foo\\BaseImpl implements \\ArrayAccess`, an 8.1 enum, a trait
+`use`). Write the next one the same way -- copy a real declaration from a real
+framework, do not invent a tidy one.
 """
 
 import pathlib
@@ -85,6 +90,11 @@ int add(int a, int b) { return a + b; }
 
 int main(void) { printf("%d", add(1, 2)); return 0; }
 """,
+    # Framework-shaped, not hand-shaped. The first version of this fixture
+    # used a bare `class Impl < Base` and a bare `include Greetable`, so it
+    # agreed with a query that could not see `ActiveRecord::Base` -- a fixture
+    # written by the query's author proves the query matches the fixture and
+    # nothing else. `scope_resolution` is what real Ruby looks like.
     "ruby": """require 'set'
 require_relative 'helper'
 
@@ -94,14 +104,10 @@ module Greetable
   end
 end
 
-class Base
-  def seed
-    1
-  end
-end
-
-class Impl < Base
+class ApplicationRecord < ActiveRecord::Base
+  include ActiveSupport::Concern
   include Greetable
+  extend Forwardable
 
   def initialize(n)
     @n = n
@@ -112,6 +118,8 @@ class Impl < Base
   end
 end
 """,
+    # PSR/Laravel-shaped. The earlier fixture had no namespaced supertype, so
+    # it agreed with a query that silently dropped every one of them.
     "php": """<?php
 namespace App;
 
@@ -120,11 +128,15 @@ use App\\Support\\Str;
 
 function helper(int $x): int { return $x + 1; }
 
-interface Extended extends Greeter {}
+interface Extended extends \\Psr\\Log\\LoggerInterface {}
 
-abstract class BaseImpl {}
+trait Loggable { public function log(): void {} }
 
-class Impl extends BaseImpl implements Greeter, Countable {
+enum Status: string implements Greeter { case Active = 'active'; }
+
+class Impl extends \\Foo\\BaseImpl implements \\ArrayAccess, Countable {
+    use Loggable;
+
     public function greet(string $n): string { return "hi $n"; }
     private function total(array $xs): int { return count($xs); }
 }
@@ -277,27 +289,38 @@ class TestClosedCoverageGaps:
         assert set(QUERIES) - set(EDGE_QUERIES) == set()
 
     def test_php_extracts_inheritance_and_interfaces(self):
-        """`class Impl extends BaseImpl implements Greeter, Countable` and
-        `interface Extended extends Greeter` all yield edges now. Previously
-        php declared only `imports`, so every php class hierarchy was absent.
+        """Namespaced supertypes are the point.
 
-        Asserted on `edge_type`, the field `CodeEdge` actually declares -- an
-        earlier version read `getattr(e, "kind", getattr(e, "type", ""))`,
-        neither of which exists, so the set was always `{""}` and the
-        assertion could not fail.
+        `class Impl extends \\Foo\\BaseImpl implements \\ArrayAccess,
+        Countable` yielded exactly ONE edge before this -- `Impl implements
+        Countable` -- because the pattern required `name` as a direct child of
+        `base_clause` and the real shape is `base_clause -> qualified_name ->
+        name`. Silent PARTIAL extraction, which is worse than a total miss:
+        the consumer sees a plausible answer with no signal that two thirds of
+        it is absent. Exactly what the `_CS_BASE_TYPES` comment 150 lines
+        above the query warns about.
         """
         source = FIXTURES["php"]
         path = pathlib.Path(tempfile.mkdtemp()) / "a.php"
         path.write_text(source)
         edges = parser_edges(path, source)
 
-        assert {e.edge_type for e in edges} == {"imports", "inherits", "implements"}
-        assert ("Impl", "BaseImpl") in {(e.source_symbol, e.target_symbol)
-                                        for e in edges if e.edge_type == "inherits"}
-        assert {"Greeter", "Countable"} <= {e.target_symbol for e in edges
-                                            if e.edge_type == "implements"}
+        inherits = {(e.source_symbol, e.target_symbol)
+                    for e in edges if e.edge_type == "inherits"}
+        implements = {(e.source_symbol, e.target_symbol)
+                      for e in edges if e.edge_type == "implements"}
+
+        assert ("Impl", "BaseImpl") in inherits          # namespaced extends
+        assert ("Extended", "LoggerInterface") in inherits  # interface extends
+        assert ("Impl", "ArrayAccess") in implements     # namespaced interface
+        assert ("Impl", "Countable") in implements       # bare interface
+        assert ("Status", "Greeter") in implements       # PHP 8.1 enum
+        assert ("Impl", "Loggable") in implements        # trait use
 
     def test_ruby_extracts_requires_inheritance_and_mixins(self):
+        """`class ApplicationRecord < ActiveRecord::Base` is the single most
+        common inheritance statement in the Ruby ecosystem and produced no
+        edge at all until the `scope_resolution` arm was added."""
         source = FIXTURES["ruby"]
         path = pathlib.Path(tempfile.mkdtemp()) / "a.rb"
         path.write_text(source)
@@ -308,9 +331,11 @@ class TestClosedCoverageGaps:
             by_type.setdefault(edge.edge_type, set()).add(edge.target_symbol)
 
         assert by_type["imports"] == {"set", "helper"}
-        assert ("Impl", "Base") in {(e.source_symbol, e.target_symbol)
-                                    for e in edges if e.edge_type == "inherits"}
-        assert "Greetable" in by_type["implements"]
+        assert ("ApplicationRecord", "Base") in {
+            (e.source_symbol, e.target_symbol)
+            for e in edges if e.edge_type == "inherits"
+        }
+        assert {"Concern", "Greetable", "Forwardable"} <= by_type["implements"]
 
     def test_ruby_import_predicate_is_enforced(self):
         """`require` is an ordinary method call, so the pattern matches any


### PR DESCRIPTION
## Description

Ruby declared **no edge queries at all** — the only language in `QUERIES` absent from `EDGE_QUERIES`. Every ruby file in every index contributed nodes to the graph and never a single relationship: no `require`, no superclass, no mixin. PHP declared imports only, so `class Impl extends BaseImpl implements Greeter` produced nothing where the java, c_sharp and typescript equivalents each produce edges.

Both gaps were found while writing the per-query yield tests in #187 and pinned there as failing-when-fixed assertions. Both pins have now fired.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Follow-on from #158. **Stacked on #187** — see Additional Notes.

## Motivation and Context

### Ruby: the method-call problem, and the predicate that solves it

The existing code carried a comment explaining the omission: *"Ruby imports are method calls (`require`, `require_relative`) rather than syntactic forms — adding them would need either a method-call pattern match or a runtime-style heuristic."* The method-call pattern match is what this uses.

Because `require` is an ordinary call, the pattern matches **any** call taking a string — only the `#match?` predicate separates an import from `puts 'hello'`. That predicate is load-bearing, so its enforcement is a test: if a future tree-sitter stopped applying predicates in `QueryCursor.captures`, the query would keep compiling and start emitting an import edge per string-argument call. Silent, and in the noisiest possible direction.

### The first cut dropped every namespaced supertype, silently

This is the part worth reading. `(base_clause (name) @base)` requires `name` as a **direct** child; the real shape is `base_clause → qualified_name → name`, and Ruby's is `superclass → scope_resolution → constant`. Measured against realistic source, the first version produced:

```
class B extends \Foo\Bar implements \ArrayAccess, Countable {}
  → ONE edge:  B implements Countable

class ApplicationRecord < ActiveRecord::Base
  include ActiveSupport::Concern
  → ONE edge:  ApplicationRecord implements Plain
```

`ActiveRecord::Base` is the single most common inheritance statement in the Ruby ecosystem and produced **nothing**. This is silent *partial* extraction, which is worse than a total miss: the consumer sees a plausible answer with no signal that most of it is absent.

It is also precisely what the `_CS_BASE_TYPES` comment **150 lines above the new code** warns about — and I quoted the other half of that comment in my own rationale while writing the narrow arm.

Note: do **not** copy the C# spelling `(qualified_name name: (name) @x)`. PHP's `qualified_name` has no `name:` field; that pattern fails to compile.

### Two more gaps and one consistency decision

- **PHP 8.1 enums** carry `class_interface_clause` and were uncovered.
- **PHP `use SomeTrait;`** is the same construct Ruby's mixins are. Shipping two languages in one commit with opposite stances on it would not have survived the next maintainer, so traits map to `implements`, as `include`/`extend`/`prepend` do.
- The PHP alternation is now **generated** from `_PHP_BASE_TYPES` across declaration kinds, per the `_CS_INHERITANCE` precedent — it had already grown to three declaration kinds across two queries, hand-copied, which is the exact state that comment exists to prevent.

Query **names** are load-bearing and easy to get wrong: `extract_edges` dispatches on exactly `imports` / `import_from` / `inheritance` / `implements` and silently ignores anything else, so a well-formed query under any other name is a no-op.

### The fixtures were the root cause

They were minimal and written by the same person as the queries, so they agreed with them by construction — 5/5 and 6/6 mutation kills measured the *fixture*, not the grammar. They are now framework-shaped: Rails (`< ActiveRecord::Base`, `include ActiveSupport::Concern`) and PSR/Laravel (`extends \Foo\BaseImpl implements \ArrayAccess`, an 8.1 enum, a trait `use`).

The module docstring's "wait until a real ruby repository is available" limit was also wrong, and that mistaken framing is what let the narrow arms ship: no ruby or php **corpus** exists locally, but the **grammars** are installed. The limit is now stated accurately.

## How Has This Been Tested?

- [x] `2132 passed, 8 skipped`; ruff clean
- [x] Every one of the five new queries mutation-tested individually — 5/5 caught
- [x] Plus four more: stripping the `#match?` predicate, re-narrowing the PHP arms, re-narrowing the Ruby arms, dropping `enum_declaration`
- [x] All 11 expected edges extract from framework-shaped source, verified against the installed grammars

**Test Configuration**: Python 3.13.9 · macOS 26.5.2 · neo 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Stacked on #187, deliberately.** `tests/test_language_query_yield.py` does not exist on `main` — it arrives across three commits of that branch, and the two pins this PR must flip live only there. Rebasing onto `main` would mean either dropping the pins (losing the point) or carrying a duplicate of a 290-line file. **Merge #187 first.**

**Standing limit:** the fixtures are hand-written framework snippets, not a corpus. A green run means the queries work on the shapes we know about, not that they are complete — PHP group `use App\{A, B};` is a known pre-existing gap.
