### PR TITLE
fix(gatherer): select files by content, not by filename and byte count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,9 +541,12 @@
   (1) The venv installs neo EDITABLE against `src/`, so running
   `.venv/bin/python -m neo.cli` from a git worktree of another commit executes THIS
   tree's code against that tree's files — a "baseline" run that is not the baseline.
-  Every A/B needs `PYTHONPATH=<that tree>/src`. Measured on the superseded harness
-  generation: it made main look like MRR 0.613 against a real figure of 0.082 (the
-  current harness puts main at 0.294 — different instrument, same trap). (2) Calling `score_candidate` directly
+  Every A/B needs `PYTHONPATH=<that tree>/src`, and `rank_mine_eval` now REFUSES to
+  run unless the tree it was handed is the tree `import neo` actually resolves to —
+  mandatory is not the same as effective, since the editable `.pth` silently catches
+  a typo'd path and measures the working checkout twice. Measured on the superseded
+  harness generation: it made main look like MRR 0.613 against a real figure of
+  0.082 (the current harness puts main at 0.304 — different instrument, same trap). (2) Calling `score_candidate` directly
   measures the FIRST-PASS ranking only; `gather_context` then re-ranks with
   `pi_boost + hist_boost + _symbol_score` and applies an adaptive limit and a byte
   budget. A first-pass harness overstated R@10 by 0.14 against the real CLI. Validate
@@ -666,7 +669,9 @@
   was never what carried the result.
   **The re-rank is LOAD-BEARING, not redundant** (`pi_boost` + `_symbol_score` +
   `hist_boost`, applied after the first-pass score). Disabling it on the real CLI
-  takes R@1 from 0.344 to **0.044** and MRR from 0.646 to **0.261**. An earlier
+  takes R@1 from 0.344 to **0.044** and MRR from 0.646 to **0.261** — a
+  SUPERSEDED-generation ablation (pre-`--no-git`, uncommitted harness), so read
+  those four numbers against each other and never against the table above. An earlier
   version of this note claimed the opposite, from a weight sweep that landed
   everywhere in 0.66–0.68 — measured at k=10, where every configuration is flat, and
   through an in-process replica that omits the byte budget and adaptive limit, i.e.
@@ -676,7 +681,8 @@
   contributes nothing measurable (identical results with it disabled) while
   `_symbol_score` carries most of the effect.
   RRF fusion with the dense channel LOSES to BM25 alone (0.596 best-weighted vs
-  0.693) — dense returns ~25 files against BM25's ~180 and is half as accurate. Treat
+  0.693, also superseded-generation and unstamped when first recorded) — dense
+  returns ~25 files against BM25's ~180 and is half as accurate. Treat
   that as provisional: it was measured at k=10 before the same cutoff problem was
   understood, and the docstring deferring it to a chunk-allocation fix is stale
   because that fix landed in the same branch. Re-measure at k=3/k=5 before relying on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -644,8 +644,8 @@
   this exact task, and BM25's `b` handles the concern with bounded, corpus-derived
   length normalization. Measured end-to-end over cases mined from git history
   (commit subject = query, changed non-test files = ground truth), R@10 / MRR:
-  neo 0.275→0.732 / 0.294→0.787, car 0.192→0.502 / 0.160→0.398, quip 0.175→0.720 /
-  0.166→0.658, at `CONTENT_WEIGHT = 3.0`. **`tools/rank_mine_eval.py` is the
+  neo 0.301→0.742 / 0.304→0.771, car 0.180→0.472 / 0.162→0.425, quip 0.174→0.696 /
+  0.158→0.643, at `CONTENT_WEIGHT = 3.0`. **`tools/rank_mine_eval.py` is the
   harness** — not `tools/rank_eval.py`, which is a different instrument (12
   hand-labelled prompts, this repo, recall@k, no MRR) and was named here in error
   while the real one went uncommitted, leaving the figures unreproducible. Quoting
@@ -653,14 +653,17 @@
   at 0.969 and 0.507; keep the generation attached. An earlier generation of these
   same figures read neo 0.078→0.603 / 0.082→0.655 — superseded, and not comparable,
   because the harness that produced it no longer exists to re-run.
-  **The absolute values are upper bounds, and the tool says so per run.** The
-  scorer's recency signal holds PATHS, so a case mined below the commit window
-  whose truth file was touched again inside it is still contaminated — 48 of 50
-  cases on this repo, because neo's churn concentrates in exactly the files most
-  likely to be ground truth. `--drop-contaminated` empties the sample outright
-  here rather than cleaning it. Direction is the robust part; treat magnitudes as
-  bounded, and re-run on a CLEAN checkout of both trees, since a dirty working
-  tree puts every edited path into the same signal.
+  **Measure with `--no-git`, which is the default.** The scorer's recency signal
+  reads `git status --porcelain` plus the last 50 commits and holds PATHS, not
+  commits — so a case mined below the window whose truth file was touched again
+  inside it is still handed its own answer key, as is every file dirty in the tree
+  you are measuring from. `--skip-recent` does NOT fix this and a first version of
+  that docstring wrongly said it did. `neo --dry-run --no-git` gates `git_recent`
+  and nothing else (`_history_boost` and the rest of the re-rank stay live), which
+  is what `tools/rank_eval.py` had been doing all along. `--with-git` measures the
+  full pipeline and then reports `contaminated_cases` per run: with it on, 48 of 50
+  neo cases are contaminated, and the figures move by ≤0.03 — the leak is real but
+  was never what carried the result.
   **The re-rank is LOAD-BEARING, not redundant** (`pi_boost` + `_symbol_score` +
   `hist_boost`, applied after the first-pass score). Disabling it on the real CLI
   takes R@1 from 0.344 to **0.044** and MRR from 0.646 to **0.261**. An earlier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,18 +643,29 @@
   this exact task, and BM25's `b` handles the concern with bounded, corpus-derived
   length normalization. Measured end-to-end over cases mined from git history
   (commit subject = query, changed non-test files = ground truth), R@10 / MRR:
-  neo 0.078→0.606 / 0.082→0.644, car 0.210→0.507 / 0.149→0.250, quip 0.213→0.857 /
-  0.188→0.698. `tools/rank_eval.py` is the harness.
-  **Two negative results, recorded so they are not retried.** RRF fusion with the
-  dense channel LOSES to BM25 alone (0.596 best-weighted vs 0.693) — dense returns
-  ~25 files against BM25's ~180 and is half as accurate — even after chunk allocation
-  was fixed. And a sweep of the re-rank weights (`pi_boost`, `_symbol_score`,
-  history: damped to 0.3, to 0.5, each disabled, content doubled) lands everywhere in
-  0.66–0.68, so the re-rank is *redundant* with content ranking rather than fighting
-  it. Four filename-tuning fixes were also measured and rejected; the filename is not
-  the evidence, the file is.
+  neo 0.078→0.603 / 0.082→0.655, car 0.210→0.487 / 0.149→0.233, quip 0.213→0.850 /
+  0.188→0.735, at `CONTENT_WEIGHT = 3.0`. `tools/rank_eval.py` is the harness, and
+  the numbers must be measured through the REAL CLI with `PYTHONPATH` pinned — see
+  the measurement warning above.
+  **The re-rank is LOAD-BEARING, not redundant** (`pi_boost` + `_symbol_score` +
+  `hist_boost`, applied after the first-pass score). Disabling it on the real CLI
+  takes R@1 from 0.344 to **0.044** and MRR from 0.646 to **0.261**. An earlier
+  version of this note claimed the opposite, from a weight sweep that landed
+  everywhere in 0.66–0.68 — measured at k=10, where every configuration is flat, and
+  through an in-process replica that omits the byte budget and adaptive limit, i.e.
+  exactly the stages that make the re-rank matter. Both errors are the ones
+  `tools/rank_eval.py` warns about in its own docstring. Per channel, `hist_boost`
+  contributes nothing measurable (identical results with it disabled) while
+  `_symbol_score` carries most of the effect.
+  RRF fusion with the dense channel LOSES to BM25 alone (0.596 best-weighted vs
+  0.693) — dense returns ~25 files against BM25's ~180 and is half as accurate. Treat
+  that as provisional: it was measured at k=10 before the same cutoff problem was
+  understood, and the docstring deferring it to a chunk-allocation fix is stale
+  because that fix landed in the same branch. Re-measure at k=3/k=5 before relying on
+  it. Four filename-tuning fixes were separately measured and rejected; the filename
+  is not the evidence, the file is.
   **A path named in the prompt is still pinned** (`EXPLICIT_PATH_BOOST=10.0`, chosen
-  to exceed every organic signal combined — content caps at +3.0, the re-rank boosts
+  to exceed every organic signal combined — content caps at +3.0 (`CONTENT_WEIGHT`), the re-rank boosts
   at +1.0 and +1.2). Without it a spelled-out path competed on generic filename-token
   overlap and lost: `src/neo/subcommands.py` ranked **163rd of 296** on a prompt
   naming it, below its own test file, because an 86KB file took a heavy size penalty. The file never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,8 +541,9 @@
   (1) The venv installs neo EDITABLE against `src/`, so running
   `.venv/bin/python -m neo.cli` from a git worktree of another commit executes THIS
   tree's code against that tree's files — a "baseline" run that is not the baseline.
-  Every A/B needs `PYTHONPATH=<that tree>/src`. Measured: it made main look like
-  MRR 0.613 when its real figure is 0.082. (2) Calling `score_candidate` directly
+  Every A/B needs `PYTHONPATH=<that tree>/src`. Measured on the superseded harness
+  generation: it made main look like MRR 0.613 against a real figure of 0.082 (the
+  current harness puts main at 0.294 — different instrument, same trap). (2) Calling `score_candidate` directly
   measures the FIRST-PASS ranking only; `gather_context` then re-ranks with
   `pi_boost + hist_boost + _symbol_score` and applies an adaptive limit and a byte
   budget. A first-pass harness overstated R@10 by 0.14 against the real CLI. Validate
@@ -643,10 +644,23 @@
   this exact task, and BM25's `b` handles the concern with bounded, corpus-derived
   length normalization. Measured end-to-end over cases mined from git history
   (commit subject = query, changed non-test files = ground truth), R@10 / MRR:
-  neo 0.078→0.603 / 0.082→0.655, car 0.210→0.487 / 0.149→0.233, quip 0.213→0.850 /
-  0.188→0.735, at `CONTENT_WEIGHT = 3.0`. `tools/rank_eval.py` is the harness, and
-  the numbers must be measured through the REAL CLI with `PYTHONPATH` pinned — see
-  the measurement warning above.
+  neo 0.275→0.732 / 0.294→0.787, car 0.192→0.502 / 0.160→0.398, quip 0.175→0.720 /
+  0.166→0.658, at `CONTENT_WEIGHT = 3.0`. **`tools/rank_mine_eval.py` is the
+  harness** — not `tools/rank_eval.py`, which is a different instrument (12
+  hand-labelled prompts, this repo, recall@k, no MRR) and was named here in error
+  while the real one went uncommitted, leaving the figures unreproducible. Quoting
+  a number from one under the other's name is how `car` got into the record twice
+  at 0.969 and 0.507; keep the generation attached. An earlier generation of these
+  same figures read neo 0.078→0.603 / 0.082→0.655 — superseded, and not comparable,
+  because the harness that produced it no longer exists to re-run.
+  **The absolute values are upper bounds, and the tool says so per run.** The
+  scorer's recency signal holds PATHS, so a case mined below the commit window
+  whose truth file was touched again inside it is still contaminated — 48 of 50
+  cases on this repo, because neo's churn concentrates in exactly the files most
+  likely to be ground truth. `--drop-contaminated` empties the sample outright
+  here rather than cleaning it. Direction is the robust part; treat magnitudes as
+  bounded, and re-run on a CLEAN checkout of both trees, since a dirty working
+  tree puts every edited path into the same signal.
   **The re-rank is LOAD-BEARING, not redundant** (`pi_boost` + `_symbol_score` +
   `hist_boost`, applied after the first-pass score). Disabling it on the real CLI
   takes R@1 from 0.344 to **0.044** and MRR from 0.646 to **0.261**. An earlier
@@ -654,7 +668,8 @@
   everywhere in 0.66–0.68 — measured at k=10, where every configuration is flat, and
   through an in-process replica that omits the byte budget and adaptive limit, i.e.
   exactly the stages that make the re-rank matter. Both errors are the ones
-  `tools/rank_eval.py` warns about in its own docstring. Per channel, `hist_boost`
+  `tools/rank_mine_eval.py` warns about in its own docstring (`rank_eval.py` was
+  cited here and carries neither warning). Per channel, `hist_boost`
   contributes nothing measurable (identical results with it disabled) while
   `_symbol_score` carries most of the effect.
   RRF fusion with the dense channel LOSES to BM25 alone (0.596 best-weighted vs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,6 +536,17 @@
   asked git for the same remote 3× — ~100 forks/cycle, ~26k/week. Staleness is
   bounded to one cycle because a stale hit would write facts under the wrong
   `project_id`.
+- **Measuring retrieval changes: pin `PYTHONPATH`, and measure the REAL pipeline.**
+  Two traps, both hit during the BM25 work, both producing confident wrong numbers.
+  (1) The venv installs neo EDITABLE against `src/`, so running
+  `.venv/bin/python -m neo.cli` from a git worktree of another commit executes THIS
+  tree's code against that tree's files — a "baseline" run that is not the baseline.
+  Every A/B needs `PYTHONPATH=<that tree>/src`. Measured: it made main look like
+  MRR 0.613 when its real figure is 0.082. (2) Calling `score_candidate` directly
+  measures the FIRST-PASS ranking only; `gather_context` then re-ranks with
+  `pi_boost + hist_boost + _symbol_score` and applies an adaptive limit and a byte
+  budget. A first-pass harness overstated R@10 by 0.14 against the real CLI. Validate
+  any in-process replica against `--dry-run` output before trusting a sweep.
 - Debugging: `neo --dry-run "your query"` assembles the full context (file selection,
   fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
   the LM, then exits without making the LLM call. Faster iteration on context-gatherer
@@ -615,12 +626,38 @@
   `test_every_chunk_query_compiles` /
   `test_every_edge_query_compiles` prove compilation ONLY, so a new query still
   needs its own behavioural assertion.
-- Context selection (`context_gatherer`): **a path named in the prompt is pinned**
-  (`EXPLICIT_PATH_BOOST=10.0`, chosen to exceed every organic signal combined —
-  filename overlap caps at +1.8, the re-rank boosts at +1.0 and +1.2). Without it a
-  spelled-out path competed on generic filename-token overlap and lost:
-  `src/neo/subcommands.py` ranked **163rd of 296** on a prompt naming it, below its
-  own test file, because an 86KB file takes a heavy size penalty. The file never
+- Context selection (`context_gatherer`): **files are ranked by BM25 over their
+  CONTENT** (`neo.file_retrieval`), not by their path. Until 2026-08 they were: the
+  scorer took `(rel_path, size, prompt_tokens, git_recent, entry_points)` and the
+  file was first opened *after* selection, only to chunk what had already been
+  chosen. Every other defect in that scorer followed from having no content signal,
+  and the dominant term was `score -= 0.01 * size_kb`, uncapped, against a realistic
+  positive signal of +0.6 to +2.1 — so a file with one keyword hit was unrankable
+  above 60 KB. `src/neo/memory/store.py` scored **0.000** and ranked 200th of 284 for
+  "fix the fact store supersession threshold", because it is 162 KB. Ground truth ran
+  31–177 KB against a corpus median of 10 KB: central files are large *because* they
+  are central. That had already been noticed once and patched with a seven-name stem
+  whitelist, which rescued `engine.py` (−0.13) and left `store.py` (−1.62) — a 12×
+  disparity decided by whether someone had thought of the name. **The sign was wrong,
+  not the magnitude**: BugLocator's rVSM (ICSE 2012) ranks larger files *higher* for
+  this exact task, and BM25's `b` handles the concern with bounded, corpus-derived
+  length normalization. Measured end-to-end over cases mined from git history
+  (commit subject = query, changed non-test files = ground truth), R@10 / MRR:
+  neo 0.078→0.606 / 0.082→0.644, car 0.210→0.507 / 0.149→0.250, quip 0.213→0.857 /
+  0.188→0.698. `tools/rank_eval.py` is the harness.
+  **Two negative results, recorded so they are not retried.** RRF fusion with the
+  dense channel LOSES to BM25 alone (0.596 best-weighted vs 0.693) — dense returns
+  ~25 files against BM25's ~180 and is half as accurate — even after chunk allocation
+  was fixed. And a sweep of the re-rank weights (`pi_boost`, `_symbol_score`,
+  history: damped to 0.3, to 0.5, each disabled, content doubled) lands everywhere in
+  0.66–0.68, so the re-rank is *redundant* with content ranking rather than fighting
+  it. Four filename-tuning fixes were also measured and rejected; the filename is not
+  the evidence, the file is.
+  **A path named in the prompt is still pinned** (`EXPLICIT_PATH_BOOST=10.0`, chosen
+  to exceed every organic signal combined — content caps at +3.0, the re-rank boosts
+  at +1.0 and +1.2). Without it a spelled-out path competed on generic filename-token
+  overlap and lost: `src/neo/subcommands.py` ranked **163rd of 296** on a prompt
+  naming it, below its own test file, because an 86KB file took a heavy size penalty. The file never
   reached context, so the model correctly refused to patch code it had not seen and
   emitted NO diff — and a suggestion with no diff text can never be git-verified,
   which is a major reason only ~32% of suggestions were verifiable.

--- a/docs/eval-baselines-2026-08.md
+++ b/docs/eval-baselines-2026-08.md
@@ -235,6 +235,25 @@ for r in neo aieweb m365dotnet; do
 done
 ```
 
+**The file at that path changed meaning in #194 — read this before pasting the
+commands above into a later tree.** #194 repurposes `tools/rank_eval.py` back to
+its 12-prompt hand-labelled recall-only form and moves the git-mined,
+cross-repo, MRR-reporting harness — the one that produced every table in this
+document — to `tools/rank_mine_eval.py`. The two are not interchangeable and
+`rank_mine_eval.py` is not a drop-in: it shells out to `neo --dry-run` with
+`--no-git` rather than calling `score_candidate` in-process, so it measures the
+whole pipeline and reports different absolute numbers. Quoting one under the
+other's name is the "same label, different instrument" error `rank_mine_eval.py`
+documents in its own header.
+
+The instrument that produced this document is therefore pinned by revision, not
+by path: `git show 5bbee46:tools/rank_eval.py`. Re-running it against a
+post-#194 tree needs one edit, because `score_candidate` gained two arguments —
+pass `demote_tests=not prompt_targets_tests(query)` and
+`content_relevance=normalize(build_index(cands).scores(query)).get(rel, 0.0)`,
+which is exactly what `gather_context` now passes. #194's PR comment carries the
+before/after table produced that way.
+
 ---
 
 ## M2 — warm-call cost on m365dotnet

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -624,8 +624,8 @@ def _format_selection_report(report: Optional[dict]) -> list[str]:
     if report.get('chunks_capped'):
         lines.append(
             f"[Neo] Kept {report['chunks_kept']} of {report['chunks_extracted']} "
-            f"chunks (cap {report['max_chunks']}); each indexed file keeps its "
-            f"first chunks before any file keeps a second"
+            f"chunks (cap {report['max_chunks']}); slots are apportioned in "
+            f"proportion to each file's symbol count, with a floor of one"
         )
     # A selected file can be absent from the index for two unrelated reasons,
     # and they get separate lines because they have separate remedies — one of

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -625,7 +625,9 @@ def _format_selection_report(report: Optional[dict]) -> list[str]:
         lines.append(
             f"[Neo] Kept {report['chunks_kept']} of {report['chunks_extracted']} "
             f"chunks (cap {report['max_chunks']}); slots are apportioned in "
-            f"proportion to each file's symbol count, with a floor of one"
+            f"proportion to each file's symbol count. Every file keeps at "
+            f"least one UNLESS there are more files than slots, in which case "
+            f"the largest take them"
         )
     # A selected file can be absent from the index for two unrelated reasons,
     # and they get separate lines because they have separate remedies — one of

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -489,10 +489,12 @@ def extract_prompt_tokens(prompt: str) -> set[str]:
     return tokens
 
 
-# Enough to clear any organic score (filename overlap caps at +1.8, the two
-# re-rank boosts at +1.0 and +1.2). Naming a path is the least ambiguous signal
-# a prompt can carry, so it outranks every heuristic rather than competing with
-# them.
+# Enough to clear any organic score: content caps at +3.0 (CONTENT_WEIGHT),
+# filename overlap at +0.45 (0.15 x min(hits, 3)), the two re-rank boosts at
+# +1.0 and +1.2. Naming a path is the least ambiguous signal a prompt can
+# carry, so it outranks every heuristic rather than competing with them.
+# The +1.8 this comment used to claim for filename overlap was the pre-BM25
+# weight; it dropped to a tie-breaker when content became the dominant term.
 EXPLICIT_PATH_BOOST = 10.0
 
 # Loose: real filtering is "does this match a file we actually found", which no

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -30,6 +30,7 @@ MAX_CHUNK_CENTERS = 20     # Best-scoring lines considered as window centers bef
 MAX_MERGED_WINDOW_LINES = 200   # Ceiling on a merged window so one file can't eat the budget
 DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is noise in it
 TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
+CONTENT_WEIGHT = 3.0       # Weight on normalized content BM25; see score_candidate
 
 
 # Test-file conventions across the languages neo indexes. Anchored on
@@ -629,12 +630,11 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     paths disagreed about test files and only one was ever corrected. It
     matters MORE under content BM25 than it did before, because a test file
     contains its subject's identifiers plus test scaffolding and so is often
-    the better lexical match. Measured over cases mined from git history:
-
-        repo    R@10 without   with     MRR without   with
-        neo        0.705       0.783      0.558      0.718
-        car        0.969       0.969      0.680      0.682
-        quip       0.786       0.820      0.583      0.651
+    the better lexical match. The A/B that established this was run on a
+    first-pass harness whose absolute numbers are superseded; the DIRECTION
+    held on every repo and is what the parameter rests on. For current
+    end-to-end figures see `neo.file_retrieval` — one table, one harness
+    generation, deliberately not restated here.
 
     Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
     existing pure-scoring tests would not need editing — a production default
@@ -680,17 +680,16 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # nothing to patch, and content BM25 identifies a central file by what is
     # in it rather than by a list of names someone maintained.
 
-    # Content relevance: the dominant term, and the only one that has read the
-    # file. Normalized to [0, 3] so it outweighs every tie-breaker combined
-    # (0.8 docs + 0.3 git + 0.2 entry = 1.3) while staying far below
-    # EXPLICIT_PATH_BOOST, which encodes an explicit user instruction.
-    score += 3.0 * content_relevance
-
     # Content relevance: the dominant term, and the only one that has read
-    # the file. Normalized to [0, 3] so it outweighs every tie-breaker
+    # the file. Scaled by CONTENT_WEIGHT so it outweighs every tie-breaker
     # combined (0.8 docs + 0.3 git + 0.2 entry + 0.45 filename = 1.75) while
     # staying far below EXPLICIT_PATH_BOOST, which encodes a user instruction.
-    score += 3.0 * content_relevance
+    #
+    # This statement appeared TWICE for three commits — the cherry-pick that
+    # merged #188's scorer with this one kept both blocks, so the effective
+    # weight was 6.0 while every docstring, comment and measurement table
+    # said 3.0. Named constant now, so the value has exactly one home.
+    score += CONTENT_WEIGHT * content_relevance
 
     # Filename overlap, kept as a weak tie-breaker rather than a primary
     # signal. It is a substring test against the whole path, so short prompt

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -29,6 +29,35 @@ MAX_CHUNKS_PER_FILE = 2    # Cap chunks per file so one large file doesn't domin
 MAX_CHUNK_CENTERS = 20     # Best-scoring lines considered as window centers before merging
 MAX_MERGED_WINDOW_LINES = 200   # Ceiling on a merged window so one file can't eat the budget
 DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is noise in it
+TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
+
+
+def is_test_path(rel_path: str) -> bool:
+    """Whether `rel_path` looks like a test file."""
+    return (
+        rel_path.startswith("test")
+        or rel_path.startswith("tests" + os.sep)
+        or "/tests/" in rel_path
+        or os.path.basename(rel_path).startswith("test_")
+    )
+
+
+# Word-boundary anchored, which the substring version this replaces was not.
+# `"spec" in prompt` fires on "inspector", "specific", "respective" and
+# "aspect"; measured, "the A2UI inspector shows a stale fact count" was
+# classified as a prompt about testing and every test file kept full score.
+# That was survivable while the flag only softened a cosine boost, and stops
+# being survivable now that it gates the keyword path too.
+#
+# `\btest` is a prefix rather than a whole word so "testing" and "tests"
+# match, while "latest" does not -- there is no boundary before its `test`.
+_TEST_PROMPT_RE = re.compile(r"\btest|\bpytest\b|\bspecs?\b", re.IGNORECASE)
+
+
+def prompt_targets_tests(prompt: str) -> bool:
+    """Whether the prompt is itself about testing, in which case test files
+    are the answer rather than noise and must not be demoted."""
+    return bool(_TEST_PROMPT_RE.search(prompt))
 
 
 @dataclass
@@ -545,21 +574,24 @@ def infer_language(path: str) -> Optional[str]:
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
                     git_recent: set[str], entry_points: set[str],
-                    content_relevance: float = 0.0) -> float:
+                    demote_tests: bool = False) -> float:
     """Score a candidate file for relevance.
 
-    `content_relevance` is a normalized BM25 score over the file's CONTENT
-    (see `neo.file_retrieval`) and is the dominant term. Everything else here
-    is a tie-breaker, and is scaled to stay one.
+    `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
+    always applied to its cosine, and it is a consistency fix rather than a
+    new policy: the two scoring paths disagreed about test files, and only
+    one of them was ever corrected. A test file is a strict SUPERSET of its
+    subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
+    where `adapters.py` matches {adapter} -- so on the keyword path it can
+    only ever outrank the code it tests, and then the implementation takes a
+    size penalty on top. Measured over 12 code prompts: the first source file
+    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
+    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
+    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
+    leaves room rather than competing with documentation.
 
-    `size` is retained in the signature but is no longer scored. It used to
-    carry `score -= 0.01 * size_kb`, uncapped, which made a file with one
-    keyword hit unrankable above 60 KB — measured, `src/neo/memory/store.py`
-    scored 0.000 and ranked 200th of 284 for a prompt about the fact store,
-    because it is 162 KB. Central files are large *because* they are central,
-    and BM25's length normalization handles the real concern in a bounded,
-    corpus-derived way. The parameter stays so callers and tests are
-    unaffected; drop it only with a deprecation pass.
+    Off by default so the existing pure-scoring tests keep their meaning; the
+    gatherer passes it per prompt via `prompt_targets_tests`.
     """
     score = 0.0
     name_lower = rel_path.lower()
@@ -616,6 +648,11 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # Entry point bonus
     if any(basename.startswith(ep) for ep in entry_points):
         score += 0.2
+
+    # Demote tests, unless the prompt is about testing. Same constant and
+    # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    if demote_tests and is_test_path(rel_path):
+        score *= TEST_PENALTY
 
     # Penalize by depth
     depth = rel_path.count(os.sep)
@@ -783,11 +820,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
         # they assert against named behaviors), so the FAISS index ranks
         # them above the source file the prompt is actually about.
         # Demote test-file hits unless the prompt is itself about testing.
-        prompt_lower = prompt.lower()
-        prompt_is_test = any(
-            t in prompt_lower for t in ("test", "pytest", "unit test", "spec")
-        )
-        TEST_PENALTY = 0.4  # multiplier; tests retain 60% of their cosine
+        prompt_is_test = prompt_targets_tests(prompt)
 
         boost: dict[str, float] = {}
         for chunk in chunks:
@@ -795,13 +828,7 @@ def _project_index_boost(root: str, prompt: str, k: int) -> dict[str, float]:
             rel = os.path.relpath(chunk.file_path, root)
             sim = float(getattr(chunk, "similarity", 0.0))
             sim = max(0.0, sim)
-            is_test = (
-                rel.startswith("test")
-                or rel.startswith("tests" + os.sep)
-                or "/tests/" in rel
-                or os.path.basename(rel).startswith("test_")
-            )
-            if is_test and not prompt_is_test:
+            if is_test_path(rel) and not prompt_is_test:
                 sim *= TEST_PENALTY
             # 1.0 cosine = +1.0 boost (dominant signal); test demotion above.
             prev = boost.get(rel, 0.0)
@@ -952,22 +979,17 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
-    # Read the files. This is the change: selection used to happen on the path
-    # string and the byte count alone, with content first opened afterwards to
-    # chunk whatever had already been chosen.
-    from neo.file_retrieval import build_index, normalize
-
-    file_index = build_index(candidates)
-    relevance = normalize(file_index.scores(config.prompt)) if file_index else {}
-    if relevance:
-        progress.note(f"Content relevance: {len(relevance)} files match the prompt")
+    # One decision per run, shared with the ProjectIndex boost path below.
+    demote_tests = not prompt_targets_tests(config.prompt)
 
     # Score all candidates
     scored = []
     explicit_hits = 0
     for abs_path, rel_path, size in candidates:
-        score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points,
-                                content_relevance=relevance.get(rel_path, 0.0))
+        score = score_candidate(
+            rel_path, size, prompt_tokens, git_recent, entry_points,
+            demote_tests=demote_tests,
+        )
         if matches_explicit_path(rel_path, explicit_paths):
             score += EXPLICIT_PATH_BOOST
             explicit_hits += 1

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -544,8 +544,23 @@ def infer_language(path: str) -> Optional[str]:
 
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
-                    git_recent: set[str], entry_points: set[str]) -> float:
-    """Score a candidate file for relevance."""
+                    git_recent: set[str], entry_points: set[str],
+                    content_relevance: float = 0.0) -> float:
+    """Score a candidate file for relevance.
+
+    `content_relevance` is a normalized BM25 score over the file's CONTENT
+    (see `neo.file_retrieval`) and is the dominant term. Everything else here
+    is a tie-breaker, and is scaled to stay one.
+
+    `size` is retained in the signature but is no longer scored. It used to
+    carry `score -= 0.01 * size_kb`, uncapped, which made a file with one
+    keyword hit unrankable above 60 KB — measured, `src/neo/memory/store.py`
+    scored 0.000 and ranked 200th of 284 for a prompt about the fact store,
+    because it is 162 KB. Central files are large *because* they are central,
+    and BM25's length normalization handles the real concern in a bounded,
+    corpus-derived way. The parameter stays so callers and tests are
+    unaffected; drop it only with a deprecation pass.
+    """
     score = 0.0
     name_lower = rel_path.lower()
     basename = os.path.basename(rel_path).lower()
@@ -570,15 +585,29 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # like an entry point" (entry_points adds +0.2). Files that merely
     # *start* with "main" (e.g. main_v2.py) only get the entry_points
     # bonus — the stacking distinguishes "canonical" from "adjacent."
-    main_impl_stems = {"core", "engine", "main", "index", "app", "server", "lib"}
-    stem = os.path.splitext(basename)[0]
-    is_main_impl = stem in main_impl_stems
-    if is_main_impl:
-        score += 0.4
+    # The `main_impl_stems` whitelist that used to live here is gone. It gave
+    # +0.4 to seven hardcoded stems AND exempted them from the size penalty,
+    # and it existed only because that penalty was killing large central
+    # files: it rescued `engine.py` (-0.13) and left `store.py` (-1.62), a 12x
+    # disparity between two files of near-identical size decided by whether
+    # someone had thought of the name. With the penalty gone the whitelist has
+    # nothing to patch, and content BM25 identifies a central file by what is
+    # in it rather than by a list of names someone maintained.
 
-    # Keyword overlap in filename
+    # Content relevance: the dominant term, and the only one that has read the
+    # file. Normalized to [0, 3] so it outweighs every tie-breaker combined
+    # (0.8 docs + 0.3 git + 0.2 entry = 1.3) while staying far below
+    # EXPLICIT_PATH_BOOST, which encodes an explicit user instruction.
+    score += 3.0 * content_relevance
+
+    # Filename overlap, kept as a weak tie-breaker rather than a primary
+    # signal. It is a substring test against the whole path, so short prompt
+    # tokens match by coincidence -- `a` is inside 49 of 85 basenames here.
+    # That noise was survivable at 0.6 per hit only because nothing better
+    # existed; at 0.15 it can separate two files whose content ranks equally
+    # and little else.
     hits = sum(1 for token in prompt_tokens if token in name_lower)
-    score += 0.6 * min(hits, 3)
+    score += 0.15 * min(hits, 3)
 
     # Git recency bonus
     if rel_path in git_recent:
@@ -592,20 +621,10 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     depth = rel_path.count(os.sep)
     score -= 0.05 * depth
 
-    # Penalize by size (god objects are code smell). main_impl files
-    # (engine.py, server.py, app.py, etc.) get a much gentler penalty
-    # — they're large *because* they're central, and the old 0.002
-    # multiplier was pushing THE relevant file (93KB engine.py) below
-    # threshold on prompts about it. New main_impl penalty is 0.001
-    # per KB-over-50, so 93KB loses 0.043 instead of 0.086.
-    size_kb = size / 1024
-    if size_kb > 10 and not is_main_impl:
-        # Penalty for large files: 10KB = -0.1, 50KB = -0.5, 100KB = -1.0
-        score -= 0.01 * size_kb
-    elif size_kb > 50 and is_main_impl:
-        # Lighter penalty for main implementation files: 50KB = 0,
-        # 100KB = -0.05, 500KB = -0.45.
-        score -= 0.001 * (size_kb - 50)
+    # No size penalty. See the docstring: it was the dominant term and it was
+    # anti-correlated with relevance. BugLocator's rVSM (ICSE 2012) ranks
+    # larger files HIGHER for this exact task; BM25's `b` handles the real
+    # concern with bounded, corpus-derived length normalization.
 
     return max(0.0, score)
 
@@ -933,11 +952,22 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
+    # Read the files. This is the change: selection used to happen on the path
+    # string and the byte count alone, with content first opened afterwards to
+    # chunk whatever had already been chosen.
+    from neo.file_retrieval import build_index, normalize
+
+    file_index = build_index(candidates)
+    relevance = normalize(file_index.scores(config.prompt)) if file_index else {}
+    if relevance:
+        progress.note(f"Content relevance: {len(relevance)} files match the prompt")
+
     # Score all candidates
     scored = []
     explicit_hits = 0
     for abs_path, rel_path, size in candidates:
-        score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points)
+        score = score_candidate(rel_path, size, prompt_tokens, git_recent, entry_points,
+                                content_relevance=relevance.get(rel_path, 0.0))
         if matches_explicit_path(rel_path, explicit_paths):
             score += EXPLICIT_PATH_BOOST
             explicit_hits += 1

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -621,17 +621,30 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     only ever outrank the code it tests, and then the implementation takes a
     size penalty on top.
 
-    Measured over 12 self-chosen code prompts on THIS repo: the first source
-    file ranked 4.50 on average and 5.58 of the top 10 slots went to tests and
-    docs; with the penalty, 1.75 and 4.41. Six doc-seeking prompts went
-    2.16 -> 3.00 docs in the top 10, because demoting tests leaves room rather
-    than competing with documentation. Treat those numbers as DIRECTIONAL: the
-    prompts are self-chosen and unlabelled, the corpus is a single Python
-    repo, and a mean over an unbounded rank is dominated by its worst case.
-    The harness is not in the tree, so nobody -- including the author -- can
-    re-run them as written.
+Measured with `tools/rank_eval.py` -- recall@k against hand-labelled
+    relevant files, over 12 prompts on this repo:
 
-    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+        k        main     with the penalty
+        3        0.250    0.333
+        5        0.542    0.667
+        10       0.667    0.667
+        20       0.667    0.667
+
+    The win is in ORDERING, not retrieval: the same files are reachable
+    either way, they arrive earlier. That matters because per-file character
+    caps mean a file at rank 3 contributes far more content than the same
+    file at rank 9.
+
+    Two earlier metrics -- mean rank of the first source file, and count of
+    tests and docs in the top 10 -- reported a much larger win (4.50 -> 2.00,
+    5.58 -> 4.25) and should not be trusted. Both reward ANY `src/` file
+    landing early regardless of relevance, both penalise a test file that is
+    the correct answer, and both IMPROVE when a file is evicted below
+    `MIN_SCORE_THRESHOLD` rather than merely demoted. They were the reason
+    two other candidate fixes were rejected, and at least one of those
+    rejections was made on a reading those metrics could not support.
+
+        Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
     that existing pure-scoring tests would not need editing -- which is a
     production default shaped around test convenience, and the default was the
     buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -32,14 +32,49 @@ DISCRIMINATIVE_MAX_LINE_FRACTION = 0.25  # A token on >25% of a file's lines is 
 TEST_PENALTY = 0.4         # Multiplier; a test file retains 60% of its score
 
 
+# Test-file conventions across the languages neo indexes. Anchored on
+# component and word boundaries, because the first version was
+# `rel_path.startswith("test")` -- an unanchored prefix with no separator,
+# which is the same defect class as `"spec" in prompt` matching "in-spec-tor".
+# Measured against real conventions, that version was wrong on 9 of 11 cases:
+# it missed Go, .NET, JS/TS, Jest, RSpec and JUnit entirely, and claimed
+# `testdata/`, `testing/` and `testbed/` -- ordinary source directories -- as
+# tests.
+#
+# It looked correct only because the corpus it was measured on is a single
+# Python repo, where it matched 99 of 295 files with no false positives.
+_TEST_DIR_NAMES = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+_TEST_BASENAME_RE = re.compile(
+    r"""
+      ^test_                 # Python:  test_foo.py
+    | _test\.                # Go:      foo_test.go
+    | _spec\.                # RSpec:   user_spec.rb
+    | \.test\.               # Jest:    foo.test.ts
+    | \.spec\.               # Angular: foo.spec.ts
+    | ^Test[A-Z0-9]          # JUnit:   TestFoo.java
+    | Tests?\.               # .NET:    FooTests.cs / FooTest.cs
+    """,
+    re.VERBOSE,
+)
+
+
 def is_test_path(rel_path: str) -> bool:
-    """Whether `rel_path` looks like a test file."""
-    return (
-        rel_path.startswith("test")
-        or rel_path.startswith("tests" + os.sep)
-        or "/tests/" in rel_path
-        or os.path.basename(rel_path).startswith("test_")
-    )
+    """Whether `rel_path` looks like a test file, in any language neo indexes.
+
+    Matched on whole path COMPONENTS and on basename boundaries, never on a
+    bare prefix. `testdata/`, `testing/` and `testbed/` are ordinary source
+    directories and must survive; `Foo.Tests/` is not.
+    """
+    parts = [part for part in re.split(r"[\\/]", rel_path) if part]
+    if not parts:
+        return False
+
+    for component in parts[:-1]:
+        lowered = component.lower()
+        if lowered in _TEST_DIR_NAMES or lowered.endswith(".tests"):
+            return True
+
+    return bool(_TEST_BASENAME_RE.search(parts[-1]))
 
 
 # Word-boundary anchored, which the substring version this replaces was not.
@@ -574,7 +609,7 @@ def infer_language(path: str) -> Optional[str]:
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
                     git_recent: set[str], entry_points: set[str],
-                    demote_tests: bool = False) -> float:
+                    *, demote_tests: bool) -> float:
     """Score a candidate file for relevance.
 
     `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
@@ -584,14 +619,32 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
     where `adapters.py` matches {adapter} -- so on the keyword path it can
     only ever outrank the code it tests, and then the implementation takes a
-    size penalty on top. Measured over 12 code prompts: the first source file
-    ranked 4.50 on average, and 5.58 of the top 10 slots went to tests and
-    docs. With the penalty applied: 1.75 and 4.41. Doc-seeking prompts
-    improve too (2.16 -> 3.00 docs in the top 10), because demoting tests
-    leaves room rather than competing with documentation.
+    size penalty on top.
 
-    Off by default so the existing pure-scoring tests keep their meaning; the
-    gatherer passes it per prompt via `prompt_targets_tests`.
+    Measured over 12 self-chosen code prompts on THIS repo: the first source
+    file ranked 4.50 on average and 5.58 of the top 10 slots went to tests and
+    docs; with the penalty, 1.75 and 4.41. Six doc-seeking prompts went
+    2.16 -> 3.00 docs in the top 10, because demoting tests leaves room rather
+    than competing with documentation. Treat those numbers as DIRECTIONAL: the
+    prompts are self-chosen and unlabelled, the corpus is a single Python
+    repo, and a mean over an unbounded rank is dominated by its worst case.
+    The harness is not in the tree, so nobody -- including the author -- can
+    re-run them as written.
+
+    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+    that existing pure-scoring tests would not need editing -- which is a
+    production default shaped around test convenience, and the default was the
+    buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a
+    forgotten argument would have failed open toward exactly the defect this
+    fixes. One production caller; no reason for a default at all.
+
+    The penalty RE-RANKS and must not EVICT. Scaling bonuses can push a file
+    under `MIN_SCORE_THRESHOLD`, which drops it from context entirely: a test
+    file with one token hit at depth 1 goes 0.55 -> 0.19 against a 0.2 floor.
+    Both metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS, so neither could have detected that cost. A file that would
+    have been admitted stays admitted, ranked below everything else.
     """
     score = 0.0
     name_lower = rel_path.lower()
@@ -651,7 +704,15 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
 
     # Demote tests, unless the prompt is about testing. Same constant and
     # same predicate as the ProjectIndex boost path -- see `is_test_path`.
+    # The multiplier lands here, on the accumulated BONUSES and before the
+    # additive penalties below, so it does not shrink those penalties too.
+    # `forfeited` records what it removed; the floor is applied at the end,
+    # because everything after this line is subtractive and a floor applied
+    # here would be eaten by the depth penalty (measured: 0.24 -> 0.19,
+    # straight back under the threshold).
+    forfeited = 0.0
     if demote_tests and is_test_path(rel_path):
+        forfeited = score * (1.0 - TEST_PENALTY)
         score *= TEST_PENALTY
 
     # Penalize by depth
@@ -662,6 +723,14 @@ def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
     # anti-correlated with relevance. BugLocator's rVSM (ICSE 2012) ranks
     # larger files HIGHER for this exact task; BM25's `b` handles the real
     # concern with bounded, corpus-derived length normalization.
+
+    # Re-rank, never evict. `score + forfeited` reconstructs the undemoted
+    # final score exactly, because every step after the multiplier is
+    # additive. A test file that would have been admitted without the penalty
+    # stays admitted, ranked beneath everything above the threshold; one that
+    # would have been dropped anyway is unaffected.
+    if forfeited and score + forfeited >= MIN_SCORE_THRESHOLD:
+        score = max(score, MIN_SCORE_THRESHOLD)
 
     return max(0.0, score)
 
@@ -979,7 +1048,12 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # with no diff text and could never be verified or learned from.
     explicit_paths = extract_explicit_paths(config.prompt)
 
-    # One decision per run, shared with the ProjectIndex boost path below.
+    # Computed once here. The ProjectIndex boost path calls the same pure
+    # function on the same argument rather than receiving this value, so the
+    # two agree by construction -- but the earlier comment claimed they
+    # "shared" a decision that was never passed anywhere, and in a file whose
+    # thesis is that two copies drift, an unearned claim of sharing is the
+    # rot starting.
     demote_tests = not prompt_targets_tests(config.prompt)
 
     # Score all candidates

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -609,55 +609,43 @@ def infer_language(path: str) -> Optional[str]:
 
 def score_candidate(rel_path: str, size: int, prompt_tokens: set[str],
                     git_recent: set[str], entry_points: set[str],
-                    *, demote_tests: bool) -> float:
-    """Score a candidate file for relevance.
+                    *, demote_tests: bool, content_relevance: float = 0.0) -> float:
+    """
+    Two signals, in order of weight.
 
-    `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost has
-    always applied to its cosine, and it is a consistency fix rather than a
-    new policy: the two scoring paths disagreed about test files, and only
-    one of them was ever corrected. A test file is a strict SUPERSET of its
-    subject's filename tokens -- `test_car_adapter.py` matches {adapter, car}
-    where `adapters.py` matches {adapter} -- so on the keyword path it can
-    only ever outrank the code it tests, and then the implementation takes a
-    size penalty on top.
+    `content_relevance` is a normalized BM25 score over the file's CONTENT
+    (see `neo.file_retrieval`) and is the dominant term. Selection used to
+    score a path string and a byte count and never open the file; the
+    dominant term was then `score -= 0.01 * size_kb`, uncapped, which made a
+    file with one keyword hit unrankable above 60 KB. Measured, the 162 KB
+    `src/neo/memory/store.py` scored 0.000 and ranked 200th of 284 for a
+    prompt about the fact store. That penalty is gone: BugLocator's rVSM
+    (ICSE 2012) ranks larger files HIGHER for this task, and BM25's `b`
+    handles the real concern with bounded, corpus-derived normalization.
+    `size` stays in the signature but is no longer scored.
 
-Measured with `tools/rank_eval.py` -- recall@k against hand-labelled
-    relevant files, over 12 prompts on this repo:
+    `demote_tests` applies the same `TEST_PENALTY` the ProjectIndex boost
+    always applied to its cosine — a consistency fix, since the two scoring
+    paths disagreed about test files and only one was ever corrected. It
+    matters MORE under content BM25 than it did before, because a test file
+    contains its subject's identifiers plus test scaffolding and so is often
+    the better lexical match. Measured over cases mined from git history:
 
-        k        main     with the penalty
-        3        0.250    0.333
-        5        0.542    0.667
-        10       0.667    0.667
-        20       0.667    0.667
+        repo    R@10 without   with     MRR without   with
+        neo        0.705       0.783      0.558      0.718
+        car        0.969       0.969      0.680      0.682
+        quip       0.786       0.820      0.583      0.651
 
-    The win is in ORDERING, not retrieval: the same files are reachable
-    either way, they arrive earlier. That matters because per-file character
-    caps mean a file at rank 3 contributes far more content than the same
-    file at rank 9.
+    Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
+    existing pure-scoring tests would not need editing — a production default
+    shaped around test convenience, where the default was the buggy
+    behaviour and the call site reads `not prompt_targets_tests(...)`, so a
+    forgotten argument failed OPEN toward the defect being fixed.
 
-    Two earlier metrics -- mean rank of the first source file, and count of
-    tests and docs in the top 10 -- reported a much larger win (4.50 -> 2.00,
-    5.58 -> 4.25) and should not be trusted. Both reward ANY `src/` file
-    landing early regardless of relevance, both penalise a test file that is
-    the correct answer, and both IMPROVE when a file is evicted below
-    `MIN_SCORE_THRESHOLD` rather than merely demoted. They were the reason
-    two other candidate fixes were rejected, and at least one of those
-    rejections was made on a reading those metrics could not support.
-
-        Keyword-only and REQUIRED. It was briefly optional-defaulting-to-False so
-    that existing pure-scoring tests would not need editing -- which is a
-    production default shaped around test convenience, and the default was the
-    buggy behaviour. The call site reads `not prompt_targets_tests(...)`, so a
-    forgotten argument would have failed open toward exactly the defect this
-    fixes. One production caller; no reason for a default at all.
-
-    The penalty RE-RANKS and must not EVICT. Scaling bonuses can push a file
-    under `MIN_SCORE_THRESHOLD`, which drops it from context entirely: a test
-    file with one token hit at depth 1 goes 0.55 -> 0.19 against a 0.2 floor.
-    Both metrics used to justify this change -- rank of the first source file,
-    count of tests and docs in the top 10 -- improve monotonically when a file
-    DISAPPEARS, so neither could have detected that cost. A file that would
-    have been admitted stays admitted, ranked below everything else.
+    The penalty RE-RANKS and must not EVICT. Scaling can push a file under
+    `MIN_SCORE_THRESHOLD`, dropping it from context entirely, and rank-based
+    metrics improve when that happens — so a file that would have been
+    admitted stays admitted, ranked below everything else.
     """
     score = 0.0
     name_lower = rel_path.lower()
@@ -696,6 +684,12 @@ Measured with `tools/rank_eval.py` -- recall@k against hand-labelled
     # file. Normalized to [0, 3] so it outweighs every tie-breaker combined
     # (0.8 docs + 0.3 git + 0.2 entry = 1.3) while staying far below
     # EXPLICIT_PATH_BOOST, which encodes an explicit user instruction.
+    score += 3.0 * content_relevance
+
+    # Content relevance: the dominant term, and the only one that has read
+    # the file. Normalized to [0, 3] so it outweighs every tie-breaker
+    # combined (0.8 docs + 0.3 git + 0.2 entry + 0.45 filename = 1.75) while
+    # staying far below EXPLICIT_PATH_BOOST, which encodes a user instruction.
     score += 3.0 * content_relevance
 
     # Filename overlap, kept as a weak tie-breaker rather than a primary
@@ -1069,6 +1063,16 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # rot starting.
     demote_tests = not prompt_targets_tests(config.prompt)
 
+    # Read the files. This is the change: selection used to happen on the path
+    # string and the byte count alone, with content first opened afterwards to
+    # chunk whatever had already been chosen.
+    from neo.file_retrieval import build_index, normalize
+
+    file_index = build_index(candidates)
+    relevance = normalize(file_index.scores(config.prompt)) if file_index else {}
+    if relevance:
+        progress.note(f"Content relevance: {len(relevance)} files match the prompt")
+
     # Score all candidates
     scored = []
     explicit_hits = 0
@@ -1076,6 +1080,7 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
         score = score_candidate(
             rel_path, size, prompt_tokens, git_recent, entry_points,
             demote_tests=demote_tests,
+            content_relevance=relevance.get(rel_path, 0.0),
         )
         if matches_explicit_path(rel_path, explicit_paths):
             score += EXPLICIT_PATH_BOOST

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -230,7 +230,8 @@ def normalize(scores: dict[str, float], ceiling: float = 1.0) -> dict[str, float
     So a ~2x separation between on-topic and off-topic exists in the raw score
     and is currently thrown away. An evidence term — scaling the whole query's
     contribution by `min(1.0, top / SATURATION)` — was implemented and
-    measured at SATURATION 10/15/20 and moved MRR by at most +0.010, which is
+    measured at SATURATION 10/15/20 and moved MRR by at most +0.010 (superseded
+    generation, like every other figure below the table above), which is
     noise. It is NOT shipped, for a reason worth stating: every prompt in the
     evaluation set is an on-topic commit subject, so the harness structurally
     cannot see the prompt class the term exists for. Adding it would be

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -69,9 +69,11 @@ File selection used none of it.
 
 **Fusion is deliberately absent, provisionally.** RRF over BM25 + the existing
 dense channel measured WORSE than BM25 alone (0.596 best-weighted vs 0.693
-R@10): dense returns ~25 files against BM25's ~180 and is roughly half as
-accurate, so equal-weight fusion lets a short low-quality list promote
-mediocre hits, and no weighting recovered past BM25-only.
+R@10 -- SUPERSEDED-generation figures, unstamped when first recorded, and not
+comparable with the table above): dense returns ~25 files against BM25's ~180
+and is roughly half as accurate, so equal-weight fusion lets a short
+low-quality list promote mediocre hits, and no weighting recovered past
+BM25-only.
 
 Two caveats on that number, both found in review and both worth respecting
 before it is treated as settled. It was measured at k=10, and k=10 is where

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -42,18 +42,26 @@ Two more reasons BM25 is the right instrument rather than another bonus:
   identifier and its parts lets a query saying "user by id" reach
   `getUserById`.
 
-Measured END-TO-END through the real CLI, `PYTHONPATH` pinned per tree, over
-cases mined from git history (commit subject as query, changed non-test files
-as ground truth). One table, one harness generation -- an earlier draft of this
-docstring carried FIRST-PASS numbers from a harness that called
-`score_candidate` directly and so never saw the re-rank, the adaptive limit or
-the byte budget, and those numbers disagreed with CLAUDE.md's by enough that
-`car` appeared as both 0.969 and 0.507:
+Measured END-TO-END through the real CLI by `tools/rank_mine_eval.py`, which
+ships alongside this module -- `PYTHONPATH` pinned per tree, cases mined from
+git history (commit subject as query, changed non-test files as ground truth),
+50 per repo, recency signal off (`--no-git`), zero failed cases:
 
     repo   cases   R@10 before -> after     MRR before -> after
-    neo      60        0.078 -> 0.603        0.082 -> 0.655
-    car      50        0.210 -> 0.487        0.149 -> 0.233
-    quip     50        0.213 -> 0.850        0.188 -> 0.735
+    neo      50        0.301 -> 0.742        0.304 -> 0.771
+    car      50        0.180 -> 0.472        0.162 -> 0.425
+    quip     50        0.174 -> 0.696        0.158 -> 0.643
+
+One table, one harness generation -- and note what that discipline costs, since
+this docstring has now broken it twice. An early draft carried FIRST-PASS
+numbers from a harness that called `score_candidate` directly and so never saw
+the re-rank, the adaptive limit or the byte budget; they disagreed with
+CLAUDE.md's by enough that `car` appeared as both 0.969 and 0.507. The draft
+that replaced them (neo 0.078 -> 0.603, car 0.210 -> 0.487, quip 0.213 -> 0.850)
+then outlived its own harness, which was never committed and cannot be re-run.
+Those figures are superseded and are NOT comparable with the table above: a
+different instrument, not a corrected arithmetic. CLAUDE.md's retrieval section
+carries the same table and the same caveat; if you change one, change both.
 
 Neo already shipped this BM25 (`neo.memory.bm25`, Lucene-style with IDF
 smoothing) and already used hybrid dense+sparse fusion for FACT retrieval.

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -1,0 +1,175 @@
+"""Rank candidate files by BM25 over their CONTENT.
+
+The scorer this replaces never read the file. `score_candidate` took
+`(rel_path, size, prompt_tokens, git_recent, entry_points)` and content was
+first opened *after* selection, only to chunk what had already been chosen.
+With no content signal, relevance had to be inferred from a filename and a
+byte count, so the scorer became a stack of hand-tuned additive bonuses whose
+dominant term was anti-correlated with relevance:
+
+    score -= 0.01 * size_kb          # once over 10 KB, uncapped
+
+against a realistic positive signal of +0.6 to +2.1. A file with one keyword
+hit was unrankable above 60 KB. Measured on this repo, for "fix the fact store
+supersession threshold", `src/neo/memory/store.py` scored +0.60 keyword,
+-0.15 depth, -1.62 size = **0.000**, and ranked 200th of 284 — the most
+relevant file in the repository, unrankable, because it is large. Ground-truth
+files measured 31-177 KB against a corpus median of 10 KB, because central
+files are large *because* they are central.
+
+That had already been noticed once and patched with a seven-name stem
+whitelist (`core, engine, main, index, app, server, lib`), which rescued
+`engine.py` at -0.13 and left `store.py` at -1.62 -- a 12x disparity between
+two files of near-identical size, decided by whether someone had thought of
+the name.
+
+**The literature says the sign was wrong, not the magnitude.** This task is
+IR-based bug localization. BugLocator's revised VSM (Zhou et al., ICSE 2012)
+adds a logistic length function that ranks LARGER files HIGHER, because larger
+files are empirically more likely to contain the defect. BM25 addresses the
+same concern properly: its `b` parameter normalizes by document length against
+the corpus average, which is bounded, corpus-derived, and cannot run away to
+-1.62.
+
+Two more reasons BM25 is the right instrument rather than another bonus:
+
+- **IDF is computed from the corpus**, so a term's weight reflects how
+  discriminating it actually is in THIS repository. Two earlier attempts hand-
+  approximated that with a document-frequency filter and a token-length floor;
+  both were measured and both lost.
+- **Code-aware tokenization is what makes it beat dense retrieval.** Splitting
+  identifiers on camelCase and separators while keeping both the whole
+  identifier and its parts lets a query saying "user by id" reach
+  `getUserById`.
+
+Measured over 506 cases mined from git history across three repositories
+(commit subject as query, changed non-test files as ground truth):
+
+    repo   cases   R@10 before   R@10 after    MRR
+    neo      207       0.223        0.697    0.143 -> 0.565
+    car       75       0.382        0.969    0.296 -> 0.621
+    quip     224       0.137        0.762    0.107 -> 0.544
+
+Neo already shipped this BM25 (`neo.memory.bm25`, Lucene-style with IDF
+smoothing) and already used hybrid dense+sparse fusion for FACT retrieval.
+File selection used none of it.
+
+**Fusion is deliberately absent.** RRF over BM25 + the existing dense channel
+measured WORSE than BM25 alone (0.432 vs 0.697 R@10): the dense channel
+returns ~33 files against BM25's 183, so equal-weight fusion lets a short,
+low-quality list promote mediocre hits, and no weighting recovered past
+BM25-only. The dense channel has negative marginal value until its chunk
+allocation is fixed (`store.py` is 7% covered, `text_budget.py` 100%), which
+is tracked separately. Adding fusion here would have made retrieval worse.
+"""
+
+import re
+from typing import Optional
+
+from neo.memory.bm25 import BM25
+
+#: Bytes read per file when building the index. Bounds cost on generated or
+#: vendored files without truncating anything a human wrote — the largest
+#: hand-written file in this repo is 177 KB.
+MAX_INDEXED_BYTES = 200_000
+
+#: The path is indexed alongside the content, repeated, so "a file named for
+#: the thing" stays real evidence without being the ONLY evidence — which is
+#: precisely what the old scorer got wrong. Three is enough to break ties
+#: between files whose content matches equally; it is not enough to let a
+#: lucky filename outrank a file that actually discusses the subject.
+PATH_TOKEN_WEIGHT = 3
+
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]+")
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+def code_tokens(text: str) -> list[str]:
+    """Tokenize code or a prompt into BM25 terms.
+
+    Emits BOTH the whole identifier and its parts: `getUserById` yields
+    `getuserbyid`, `get`, `user`, `by`, `id`. Keeping both is what lets a
+    prompt phrased in prose reach an identifier phrased in camelCase, while a
+    query that names the identifier exactly still gets the stronger whole-token
+    match. Dropping the whole identifier would lose exact matches; dropping the
+    parts would lose every prose query.
+
+    Deliberately NOT length-filtered. `db`, `os`, `fs`, `ui` and `id` are real
+    identifiers, and a token-length floor was measured against this corpus and
+    rejected. BM25's IDF already demotes terms that appear everywhere, which is
+    the corpus-derived version of what a length floor guesses at.
+    """
+    out: list[str] = []
+    for raw in _NON_ALNUM.split(text):
+        if not raw:
+            continue
+        out.append(raw.lower())
+        parts = [p for p in _CAMEL_BOUNDARY.split(raw) if p]
+        if len(parts) > 1:
+            out.extend(p.lower() for p in parts)
+    return out
+
+
+def _read(path: str, limit: int = MAX_INDEXED_BYTES) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as handle:
+            return handle.read(limit)
+    except OSError:
+        return ""
+
+
+class FileIndex:
+    """BM25 over candidate file content, built once per gather.
+
+    Rebuilt per invocation rather than cached. The gatherer already reads every
+    file it selects, and a cache keyed on content would need invalidation that
+    a one-shot CLI cannot amortize. Measure before adding one.
+    """
+
+    __slots__ = ("paths", "_bm25")
+
+    def __init__(self, candidates: list[tuple[str, str, int]]):
+        """`candidates` is the `(abs_path, rel_path, size)` shape `iter_paths`
+        returns."""
+        self.paths: list[str] = []
+        documents: list[list[str]] = []
+        for abs_path, rel_path, _size in candidates:
+            content = _read(abs_path)
+            documents.append(
+                code_tokens(rel_path) * PATH_TOKEN_WEIGHT + code_tokens(content)
+            )
+            self.paths.append(rel_path)
+        self._bm25 = BM25(documents) if documents else None
+
+    def scores(self, prompt: str) -> dict[str, float]:
+        """Per-file BM25 score for `prompt`. Absent files scored 0."""
+        if self._bm25 is None:
+            return {}
+        terms = code_tokens(prompt)
+        if not terms:
+            return {}
+        raw = self._bm25.scores(terms)
+        return {path: score for path, score in zip(self.paths, raw) if score > 0.0}
+
+
+def normalize(scores: dict[str, float], ceiling: float = 1.0) -> dict[str, float]:
+    """Scale BM25 scores into `[0, ceiling]` by the maximum in this result set.
+
+    BM25 is unbounded and its scale varies with corpus and query length, so a
+    raw score cannot be added to the fixed-size bonuses the gatherer still
+    applies (`EXPLICIT_PATH_BOOST` at 10.0, git recency at 0.3). Normalizing
+    per query keeps those calibrated against each other: an explicitly named
+    path still outranks everything, and a tie-breaker still breaks ties rather
+    than deciding the ranking.
+    """
+    if not scores:
+        return {}
+    top = max(scores.values())
+    if top <= 0.0:
+        return {}
+    return {path: (score / top) * ceiling for path, score in scores.items()}
+
+
+def build_index(candidates: list[tuple[str, str, int]]) -> Optional["FileIndex"]:
+    """`FileIndex` for `candidates`, or None when there is nothing to index."""
+    return FileIndex(candidates) if candidates else None

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -42,25 +42,36 @@ Two more reasons BM25 is the right instrument rather than another bonus:
   identifier and its parts lets a query saying "user by id" reach
   `getUserById`.
 
-Measured over 506 cases mined from git history across three repositories
-(commit subject as query, changed non-test files as ground truth):
+Measured END-TO-END through the real CLI, `PYTHONPATH` pinned per tree, over
+cases mined from git history (commit subject as query, changed non-test files
+as ground truth). One table, one harness generation -- an earlier draft of this
+docstring carried FIRST-PASS numbers from a harness that called
+`score_candidate` directly and so never saw the re-rank, the adaptive limit or
+the byte budget, and those numbers disagreed with CLAUDE.md's by enough that
+`car` appeared as both 0.969 and 0.507:
 
-    repo   cases   R@10 before   R@10 after    MRR
-    neo      207       0.223        0.697    0.143 -> 0.565
-    car       75       0.382        0.969    0.296 -> 0.621
-    quip     224       0.137        0.762    0.107 -> 0.544
+    repo   cases   R@10 before -> after     MRR before -> after
+    neo      60        0.078 -> 0.603        0.082 -> 0.655
+    car      50        0.210 -> 0.487        0.149 -> 0.233
+    quip     50        0.213 -> 0.850        0.188 -> 0.735
 
 Neo already shipped this BM25 (`neo.memory.bm25`, Lucene-style with IDF
 smoothing) and already used hybrid dense+sparse fusion for FACT retrieval.
 File selection used none of it.
 
-**Fusion is deliberately absent.** RRF over BM25 + the existing dense channel
-measured WORSE than BM25 alone (0.432 vs 0.697 R@10): the dense channel
-returns ~33 files against BM25's 183, so equal-weight fusion lets a short,
-low-quality list promote mediocre hits, and no weighting recovered past
-BM25-only. The dense channel has negative marginal value until its chunk
-allocation is fixed (`store.py` is 7% covered, `text_budget.py` 100%), which
-is tracked separately. Adding fusion here would have made retrieval worse.
+**Fusion is deliberately absent, provisionally.** RRF over BM25 + the existing
+dense channel measured WORSE than BM25 alone (0.596 best-weighted vs 0.693
+R@10): dense returns ~25 files against BM25's ~180 and is roughly half as
+accurate, so equal-weight fusion lets a short low-quality list promote
+mediocre hits, and no weighting recovered past BM25-only.
+
+Two caveats on that number, both found in review and both worth respecting
+before it is treated as settled. It was measured at k=10, and k=10 is where
+every ranking configuration on this repo is flat — the same cutoff mistake
+that produced a wrong conclusion about the re-rank being redundant. And the
+chunk-allocation defect it blames (`store.py` 7% covered against
+`text_budget.py` at 100%) was FIXED in the same branch, so the stated
+mechanism no longer holds. Re-measure at k=3/k=5 before relying on this.
 """
 
 import re
@@ -68,10 +79,16 @@ from typing import Optional
 
 from neo.memory.bm25 import BM25
 
-#: Bytes read per file when building the index. Bounds cost on generated or
-#: vendored files without truncating anything a human wrote — the largest
-#: hand-written file in this repo is 177 KB.
-MAX_INDEXED_BYTES = 200_000
+#: CHARACTERS read per file when building the index — `TextIOWrapper.read(n)`
+#: counts code points, not bytes, so on non-ASCII source this reads more bytes
+#: than the number suggests. Named for what it measures: `CLAUDE.md` already
+#: records the same defect in `_render_context_files`, where a banner summed
+#: `len(str)` and called the result bytes.
+#:
+#: Bounds cost without truncating anything a human wrote — the largest
+#: hand-written file in this repo is 177 KB. Note `iter_paths` already skips
+#: files over 512 KB, so this only bites the 200-512 KB band.
+MAX_INDEXED_CHARS = 200_000
 
 #: The path is indexed alongside the content, repeated, so "a file named for
 #: the thing" stays real evidence without being the ONLY evidence — which is
@@ -110,11 +127,27 @@ def code_tokens(text: str) -> list[str]:
     return out
 
 
-def _read(path: str, limit: int = MAX_INDEXED_BYTES) -> str:
+def _read(path: str, limit: int = MAX_INDEXED_CHARS) -> str:
+    """File text for indexing, or "" for anything that is not text.
+
+    `errors="ignore"` would happily turn a PDF into thousands of junk tokens.
+    That is not merely wasted work: BM25's length normalization divides by the
+    corpus average document length, so binary blobs make every real file's
+    length penalty depend on how many PDFs happen to sit in the repository.
+    Measured on this repo before the probe: 5 PDFs were 1.7% of documents and
+    **32.9% of all tokens**, and dropping them moved `avgdl` from 2773 to 1892.
+    A size term whose behaviour depends on something unrelated to relevance is
+    the exact defect this module exists to remove; letting it back in through
+    the corpus statistics would be the same bug by another door.
+    """
     try:
-        with open(path, encoding="utf-8", errors="ignore") as handle:
+        with open(path, "rb") as raw:
+            head = raw.read(8192)
+        if b"\x00" in head:
+            return ""
+        with open(path, encoding="utf-8") as handle:
             return handle.read(limit)
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
 
 

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -134,11 +134,21 @@ def _read(path: str, limit: int = MAX_INDEXED_CHARS) -> str:
     That is not merely wasted work: BM25's length normalization divides by the
     corpus average document length, so binary blobs make every real file's
     length penalty depend on how many PDFs happen to sit in the repository.
-    Measured on this repo before the probe: 5 PDFs were 1.7% of documents and
-    **32.9% of all tokens**, and dropping them moved `avgdl` from 2773 to 1892.
     A size term whose behaviour depends on something unrelated to relevance is
     the exact defect this module exists to remove; letting it back in through
     the corpus statistics would be the same bug by another door.
+
+    Measured on this repo, through the real candidate path: the probe catches
+    **8 of 289 candidates (2.8%) carrying 27.5% of all tokens**, and dropping
+    them moves `avgdl` from 2760 to 2059.
+
+    Read those figures with their conditions attached, because they move. Four
+    of the eight are `.ruff_cache` blobs, so the exact share depends on whether
+    anyone has run ruff since the last clean -- an earlier measurement on a
+    cleaner tree recorded 5 PDFs at 1.7% of documents and 32.9% of tokens. What
+    is stable, and what the probe is for, is the shape: a low single-digit
+    percentage of documents carrying roughly a third of the corpus tokens, and
+    an `avgdl` inflated by a third by files no query will ever want.
     """
     try:
         with open(path, "rb") as raw:

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -161,6 +161,29 @@ def normalize(scores: dict[str, float], ceiling: float = 1.0) -> dict[str, float
     per query keeps those calibrated against each other: an explicitly named
     path still outranks everything, and a tie-breaker still breaks ties rather
     than deciding the ranking.
+
+    **Known limit: this preserves ORDER but discards EVIDENCE.** The top file
+    always receives the full ceiling, whether its raw score was 20 or 4. Total
+    abstention works — a query matching nothing yields `{}` and no boost at all
+    — but a WEAK best match is promoted as confidently as a strong one.
+    Measured raw top scores on this repo:
+
+        on-topic   "fix the fact store supersession threshold"   14.79
+        on-topic   "tree-sitter parser drops interfaces"         20.17
+        vague      "make it better"                               6.33
+        off-topic  "how do I bake sourdough bread"                7.48
+        gibberish  "zzqx wibble frobnicate"                       0.00
+
+    So a ~2x separation between on-topic and off-topic exists in the raw score
+    and is currently thrown away. An evidence term — scaling the whole query's
+    contribution by `min(1.0, top / SATURATION)` — was implemented and
+    measured at SATURATION 10/15/20 and moved MRR by at most +0.010, which is
+    noise. It is NOT shipped, for a reason worth stating: every prompt in the
+    evaluation set is an on-topic commit subject, so the harness structurally
+    cannot see the prompt class the term exists for. Adding it would be
+    shipping on reasoning rather than measurement. Revisit with an eval that
+    contains off-topic and vague prompts, where "return nothing" is the
+    correct answer and can be scored.
     """
     if not scores:
         return {}

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -405,21 +405,33 @@ class ProjectIndex:
 
     @staticmethod
     def _cap_chunks(chunks: List[CodeChunk], cap: int) -> List[CodeChunk]:
-        """Trim to `cap` by round-robin across files, never by slicing.
+        """Trim to `cap` by PROPORTIONAL apportionment across files.
 
-        Slicing a language-ordered list is the same defect the file budget
-        was just fixed for, one function later and with the fix's own work
-        as its victim. Chunks arrive grouped by file, and files arrive
-        grouped by language, so `chunks[:1000]` on a 300-file C# repo kept
-        1000 C# chunks and dropped every TypeScript and Python chunk the
-        allocator had just fought to include — 63 of 100 selected files
-        contributed nothing at all.
+        Never by slicing. Chunks arrive grouped by file and files by language,
+        so `chunks[:cap]` on a 300-file C# repo kept 1000 C# chunks and dropped
+        every TypeScript and Python chunk the file allocator had just fought to
+        include — 63 of 100 selected files contributing nothing.
 
-        Round-robin needs no language awareness: taking every file's first
-        chunk before any file's second means the apportionment already done
-        at file-selection time carries through, and every selected file is
-        represented as long as there are at least as many slots as files
-        (100 files against a 1000-chunk cap by default).
+        Round-robin fixed that and introduced a subtler version of the same
+        bias. Taking every file's first chunk before any file's second gives
+        every file the SAME share regardless of how much is in it, so a 9 KB
+        utility was fully represented while the modules the repository is
+        built on were not:
+
+            src/neo/memory/store.py    82 symbols,  6 indexed,   7%
+            src/neo/engine.py          95 symbols,  6 indexed,   6%
+            src/neo/text_budget.py      4 symbols,  4 indexed, 100%
+
+        A file cannot be retrieved for what was never indexed, so the semantic
+        channel was blind to 93% of the two files most likely to be relevant —
+        the same anti-correlation the file scorer's size penalty had, arrived
+        at independently and for a defensible reason.
+
+        Proportional-with-a-floor keeps what round-robin was protecting (every
+        selected file is represented, so none is invisible) and spends the rest
+        where the code is. `_allocate_slots` already implements exactly this
+        apportionment for the file budget, so it is reused rather than
+        reimplemented and the two cannot drift.
         """
         if len(chunks) <= cap:
             return chunks
@@ -428,24 +440,13 @@ class ProjectIndex:
         for chunk in chunks:
             by_file.setdefault(chunk.file_path, []).append(chunk)
 
+        allocation = ProjectIndex._allocate_slots(
+            {path: len(group) for path, group in by_file.items()}, cap
+        )
+
         kept: List[CodeChunk] = []
-        depth = 0
-        while len(kept) < cap:
-            # `added` rather than a precomputed max depth: the early return
-            # above guarantees more chunks than slots, so the cap is always
-            # what stops this — but a loop whose termination depends on an
-            # invariant established elsewhere should still be able to stop
-            # on its own.
-            added = False
-            for group in by_file.values():
-                if depth < len(group):
-                    kept.append(group[depth])
-                    added = True
-                    if len(kept) >= cap:
-                        break
-            if not added:
-                break
-            depth += 1
+        for path, group in by_file.items():
+            kept.extend(group[: allocation.get(path, 0)])
         return kept
 
     def _select_files(

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -15,29 +15,33 @@ def _score(path: str, size: int = 1000) -> float:
     return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY)
 
 
-class TestMainImplBoost:
-    def test_main_py_boosted(self):
-        # main.py beats foo.py — entry point + main_impl bonuses both fire.
-        assert _score("main.py") > _score("foo.py")
+class TestEntryPointBoost:
+    """`entry_points` is the surviving name-based bonus; `main_impl_stems` is not.
 
-    def test_main_go_boosted(self):
-        # The basename is lowercased, so the main_impl substring check
-        # ('main') and the entry_point startswith both apply across
-        # languages.
-        assert _score("main.go") > _score("foo.go")
+    These files still outrank a plain one, but now for ONE reason (+0.2 for an
+    entry-point basename) rather than two. The `main_impl_stems` whitelist that
+    also gave them +0.4 is deleted: it existed to exempt seven hardcoded stems
+    from a size penalty that was killing large central files, and with that
+    penalty gone it has nothing to patch.
+    """
 
-    def test_main_java_capitalcase_boosted(self):
-        # Main.java → main.java after lowercasing — both boosts apply.
-        assert _score("Main.java") > _score("Foo.java")
+    @pytest.mark.parametrize("special,plain", [
+        ("main.py", "foo.py"),
+        ("main.go", "foo.go"),
+        ("Main.java", "Foo.java"),   # basename is lowercased first
+        ("index.js", "widget.js"),
+        ("app.ts", "widget.ts"),
+        ("server.rs", "widget.rs"),
+    ])
+    def test_entry_point_basename_still_boosted(self, special, plain):
+        assert _score(special) > _score(plain)
 
-    def test_index_js_boosted(self):
-        assert _score("index.js") > _score("widget.js")
-
-    def test_app_ts_boosted(self):
-        assert _score("app.ts") > _score("widget.ts")
-
-    def test_server_rs_boosted(self):
-        assert _score("server.rs") > _score("widget.rs")
+    @pytest.mark.parametrize("path", ["main.py", "index.js", "app.ts"])
+    def test_the_gap_is_the_entry_point_bonus_alone(self, path):
+        """Pins the SIZE of the gap, not just its direction — otherwise
+        re-adding a second name-based bonus would pass unnoticed."""
+        plain = "widget" + path[path.rindex("."):]
+        assert _score(path) - _score(plain) == pytest.approx(0.2, abs=0.01)
 
 
 class TestNoNeoBias:
@@ -48,10 +52,13 @@ class TestNoNeoBias:
         assert _score("persistent.py") == _score("widget.py")
         assert _score("structured_parser.py") == _score("widget.py")
 
-    def test_generic_core_boosted(self):
-        # `core` is in the new generic list — boost stays for legitimate
-        # main-implementation names.
-        assert _score("core.py") > _score("widget.py")
+    def test_core_is_no_longer_special_either(self):
+        """`core` was in the `main_impl_stems` whitelist and nowhere else — no
+        entry-point prefix, no other mechanism. With the whitelist gone it
+        scores like any other file, which is the intended change: a central
+        file should be identified by its content, not by whether someone
+        thought of its name."""
+        assert _score("core.py") == _score("widget.py")
 
 
 class TestStemEqualityNotSubstring:
@@ -67,41 +74,82 @@ class TestStemEqualityNotSubstring:
     def test_reindex_not_boosted(self):
         assert _score("reindex.py") == _score("widget.py")
 
-    def test_application_loses_main_impl_boost(self):
-        # Application.java used to get +0.4 from substring `'app' in
-        # 'application'`. Stem-equality drops that. The entry_points
-        # startswith check (separate mechanism) still fires for `app*`,
-        # giving +0.2 — so it still beats Widget.java by less than it
-        # used to.
-        app_score = _score("Application.java")
-        widget_score = _score("Widget.java")
-        assert app_score > widget_score
-        # And the gap is the entry_point bonus (0.2), not main_impl (0.4)
-        # plus entry_point (0.2). Approximate because of depth penalty etc.
-        assert (app_score - widget_score) == pytest.approx(0.2, abs=0.01)
+    def test_application_gets_only_the_entry_point_bonus(self):
+        """`main_impl_stems` is gone; `entry_points` is not.
 
+        The whitelist gave +0.4 to seven hardcoded stems AND exempted them
+        from the size penalty. It existed only because that penalty was
+        killing large central files — it rescued `engine.py` at -0.13 and left
+        `store.py` at -1.62, a 12x disparity between two files of near-identical
+        size decided by whether someone had thought of the name. With the
+        penalty gone it has nothing to patch, and content BM25 identifies a
+        central file by what is in it.
+        """
+        gap = _score("Application.java") - _score("Widget.java")
+        assert gap == pytest.approx(0.2, abs=0.01)  # entry_point only
 
-class TestLargeFilePenalty:
-    # Without some baseline score the max(0.0, …) clamp hides the penalty,
-    # so each test gives the candidate a prompt-token match to lift it
-    # above zero before the size hit lands.
+class TestSizeDoesNotAffectScore:
+    """Size is not scored. It used to be the DOMINANT term, and backwards.
+
+    `score -= 0.01 * size_kb` once over 10 KB, uncapped, against a realistic
+    positive signal of +0.6 to +2.1 — so a file with one keyword hit became
+    unrankable above 60 KB. Measured on this repo, `src/neo/memory/store.py`
+    scored 0.000 and ranked 200th of 284 for "fix the fact store supersession
+    threshold", because it is 162 KB. Ground-truth files ran 31-177 KB against
+    a corpus median of 10 KB: central files are large *because* they are
+    central.
+
+    BugLocator's rVSM (Zhou et al., ICSE 2012) ranks LARGER files HIGHER for
+    exactly this task, on the empirical finding that larger files are more
+    likely to contain the defect. So the sign was wrong, not the magnitude —
+    and BM25's `b` handles the real concern with bounded, corpus-derived
+    length normalization instead.
+
+    The tests replaced here asserted the penalty (`assert big < small`). They
+    pinned the defect, which is why it survived a rewrite of everything around
+    it.
+    """
+
     _TOKENS = {"widget"}
 
-    def test_large_non_main_file_penalized_heavily(self):
-        big = score_candidate("widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
-        assert big < small
+    @pytest.mark.parametrize("path", ["widget.py", "main.py", "src/deep/widget.py"])
+    def test_score_is_independent_of_size(self, path):
+        tiny = score_candidate(path, 1_000, self._TOKENS, _EMPTY, _ENTRY)
+        huge = score_candidate(path, 500 * 1024, self._TOKENS, _EMPTY, _ENTRY)
+        assert tiny == huge, "size is back in the scoring function"
 
-    def test_large_main_file_penalized_lightly(self):
-        big = score_candidate("main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        small = score_candidate("main.py", 1000, self._TOKENS, _EMPTY, _ENTRY)
-        assert big < small
-        # And it should beat a same-size non-main file (lighter penalty
-        # leaves it higher).
-        non_main_big = score_candidate(
-            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY
+    def test_a_large_file_can_outrank_a_small_one_on_content(self):
+        """The property the old scorer made impossible.
+
+        A 162 KB file whose content matches beats a 1 KB file whose content
+        does not, which is the whole point: relevance decides, size does not.
+        """
+        big_relevant = score_candidate(
+            "src/store.py", 162 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            content_relevance=1.0,
         )
-        assert big > non_main_big
+        small_irrelevant = score_candidate(
+            "src/tiny.py", 1_000, self._TOKENS, _EMPTY, _ENTRY,
+            content_relevance=0.0,
+        )
+        assert big_relevant > small_irrelevant
+
+    def test_content_relevance_outweighs_every_tie_breaker_combined(self):
+        """Content must decide the ranking, not the bonuses around it.
+
+        docs 0.8 + git recency 0.3 + entry point 0.2 + filename 0.45 = 1.75,
+        against 3.0 for a full content match. A file the prompt is *about*
+        must beat a file that merely looks promising.
+        """
+        content_only = score_candidate(
+            "src/obscurely_named.py", 5_000, set(), _EMPTY, _ENTRY,
+            content_relevance=1.0,
+        )
+        every_bonus = score_candidate(
+            "docs/main.py", 5_000, {"docs", "main"}, {"docs/main.py"}, _ENTRY,
+            content_relevance=0.0,
+        )
+        assert content_only > every_bonus
 
 
 class TestExplicitPathPinning:

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -12,7 +12,8 @@ _ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
 
 def _score(path: str, size: int = 1000) -> float:
     """Helper: score `path` with a no-keyword, no-git baseline."""
-    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY)
+    return score_candidate(path, size, _EMPTY, _EMPTY, _ENTRY,
+                           demote_tests=False)
 
 
 class TestEntryPointBoost:
@@ -112,21 +113,28 @@ class TestSizeDoesNotAffectScore:
 
     _TOKENS = {"widget"}
 
-    @pytest.mark.parametrize("path", ["widget.py", "main.py", "src/deep/widget.py"])
-    def test_score_is_independent_of_size(self, path):
-        tiny = score_candidate(path, 1_000, self._TOKENS, _EMPTY, _ENTRY)
-        huge = score_candidate(path, 500 * 1024, self._TOKENS, _EMPTY, _ENTRY)
-        assert tiny == huge, "size is back in the scoring function"
+    def test_large_non_main_file_penalized_heavily(self):
+        big = score_candidate(
+            "widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        assert big < small
 
-    def test_a_large_file_can_outrank_a_small_one_on_content(self):
-        """The property the old scorer made impossible.
-
-        A 162 KB file whose content matches beats a 1 KB file whose content
-        does not, which is the whole point: relevance decides, size does not.
-        """
-        big_relevant = score_candidate(
-            "src/store.py", 162 * 1024, self._TOKENS, _EMPTY, _ENTRY,
-            content_relevance=1.0,
+    def test_large_main_file_penalized_lightly(self):
+        big = score_candidate(
+            "main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        small = score_candidate(
+            "main.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False)
+        assert big < small
+        # And it should beat a same-size non-main file (lighter penalty
+        # leaves it higher).
+        non_main_big = score_candidate(
+            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False,
         )
         small_irrelevant = score_candidate(
             "src/tiny.py", 1_000, self._TOKENS, _EMPTY, _ENTRY,

--- a/tests/test_context_gatherer_scoring.py
+++ b/tests/test_context_gatherer_scoring.py
@@ -94,56 +94,44 @@ class TestSizeDoesNotAffectScore:
 
     `score -= 0.01 * size_kb` once over 10 KB, uncapped, against a realistic
     positive signal of +0.6 to +2.1 — so a file with one keyword hit became
-    unrankable above 60 KB. Measured on this repo, `src/neo/memory/store.py`
-    scored 0.000 and ranked 200th of 284 for "fix the fact store supersession
-    threshold", because it is 162 KB. Ground-truth files ran 31-177 KB against
-    a corpus median of 10 KB: central files are large *because* they are
-    central.
+    unrankable above 60 KB. Measured, `src/neo/memory/store.py` scored 0.000
+    and ranked 200th of 284 for "fix the fact store supersession threshold",
+    because it is 162 KB. Ground truth ran 31-177 KB against a corpus median
+    of 10 KB: central files are large *because* they are central.
 
     BugLocator's rVSM (Zhou et al., ICSE 2012) ranks LARGER files HIGHER for
-    exactly this task, on the empirical finding that larger files are more
-    likely to contain the defect. So the sign was wrong, not the magnitude —
-    and BM25's `b` handles the real concern with bounded, corpus-derived
-    length normalization instead.
+    exactly this task. So the sign was wrong, not the magnitude, and BM25's
+    `b` handles the real concern with bounded, corpus-derived normalization.
 
     The tests replaced here asserted the penalty (`assert big < small`). They
-    pinned the defect, which is why it survived a rewrite of everything around
-    it.
+    pinned the defect, which is part of why it survived a rewrite of
+    everything around it.
     """
 
     _TOKENS = {"widget"}
 
-    def test_large_non_main_file_penalized_heavily(self):
-        big = score_candidate(
-            "widget.py", 50 * 1024, self._TOKENS, _EMPTY, _ENTRY,
-            demote_tests=False)
-        small = score_candidate(
-            "widget.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
-            demote_tests=False)
-        assert big < small
+    @pytest.mark.parametrize("path", ["widget.py", "main.py", "src/deep/widget.py"])
+    def test_score_is_independent_of_size(self, path):
+        tiny = score_candidate(path, 1_000, self._TOKENS, _EMPTY, _ENTRY,
+                               demote_tests=False)
+        huge = score_candidate(path, 500 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+                               demote_tests=False)
+        assert tiny == huge, "size is back in the scoring function"
 
-    def test_large_main_file_penalized_lightly(self):
-        big = score_candidate(
-            "main.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
-            demote_tests=False)
-        small = score_candidate(
-            "main.py", 1000, self._TOKENS, _EMPTY, _ENTRY,
-            demote_tests=False)
-        assert big < small
-        # And it should beat a same-size non-main file (lighter penalty
-        # leaves it higher).
-        non_main_big = score_candidate(
-            "widget.py", 80 * 1024, self._TOKENS, _EMPTY, _ENTRY,
-            demote_tests=False,
+    def test_a_large_relevant_file_outranks_a_small_irrelevant_one(self):
+        """The property the old scorer made impossible."""
+        big_relevant = score_candidate(
+            "src/store.py", 162 * 1024, self._TOKENS, _EMPTY, _ENTRY,
+            demote_tests=False, content_relevance=1.0,
         )
         small_irrelevant = score_candidate(
             "src/tiny.py", 1_000, self._TOKENS, _EMPTY, _ENTRY,
-            content_relevance=0.0,
+            demote_tests=False, content_relevance=0.0,
         )
         assert big_relevant > small_irrelevant
 
     def test_content_relevance_outweighs_every_tie_breaker_combined(self):
-        """Content must decide the ranking, not the bonuses around it.
+        """Content decides the ranking, not the bonuses around it.
 
         docs 0.8 + git recency 0.3 + entry point 0.2 + filename 0.45 = 1.75,
         against 3.0 for a full content match. A file the prompt is *about*
@@ -151,11 +139,11 @@ class TestSizeDoesNotAffectScore:
         """
         content_only = score_candidate(
             "src/obscurely_named.py", 5_000, set(), _EMPTY, _ENTRY,
-            content_relevance=1.0,
+            demote_tests=False, content_relevance=1.0,
         )
         every_bonus = score_candidate(
             "docs/main.py", 5_000, {"docs", "main"}, {"docs/main.py"}, _ENTRY,
-            content_relevance=0.0,
+            demote_tests=False, content_relevance=0.0,
         )
         assert content_only > every_bonus
 

--- a/tests/test_file_retrieval.py
+++ b/tests/test_file_retrieval.py
@@ -169,3 +169,105 @@ class TestRealRepository:
             f"store.py ranked {position}; it ranked 200th of 284 under the "
             f"old scorer, because it is 162 KB"
         )
+
+
+class TestConstantsArePinned:
+    """Every constant this module turns on, asserted by VALUE.
+
+    Four survived a mutation sweep because nothing pinned them, and one of the
+    survivors is what shipped: the content term was applied twice for three
+    commits, so the effective weight was 6.0 while every docstring, comment and
+    measurement table said 3.0. The test that should have caught it named 3.0
+    in its docstring and asserted an inequality that 1.76-through-infinity
+    satisfies. Naming a number in prose while asserting a direction is how a
+    constant goes unpinned and looks pinned.
+    """
+
+    def test_content_weight_is_applied_exactly_once(self):
+        """The shipped bug, in the form that would have caught it."""
+        import pathlib
+
+        source = (pathlib.Path(__file__).resolve().parents[1]
+                  / "src" / "neo" / "context_gatherer.py").read_text()
+        assert source.count("CONTENT_WEIGHT * content_relevance") == 1
+
+    def test_content_weight_value(self):
+        from neo.context_gatherer import CONTENT_WEIGHT
+
+        assert CONTENT_WEIGHT == 3.0
+
+    def test_content_weight_outranks_every_tie_breaker_by_the_stated_margin(self):
+        """Equality, not `>`.
+
+        docs 0.8 + git 0.3 + entry 0.2 + filename 0.45 = 1.75. The margin is
+        the claim; asserting only the direction lets the weight drift anywhere
+        above it.
+        """
+        from neo.context_gatherer import CONTENT_WEIGHT
+
+        tie_breakers = 0.8 + 0.3 + 0.2 + 0.45
+        assert CONTENT_WEIGHT > tie_breakers
+        assert CONTENT_WEIGHT == pytest.approx(3.0)
+        assert CONTENT_WEIGHT / tie_breakers == pytest.approx(1.714, abs=0.01)
+
+    def test_normalize_ceiling_default(self):
+        """Mutating the default to 0.05 left all 156 selection tests green and
+        cost R@10 0.875 -> 0.750 on the real CLI."""
+        from neo.file_retrieval import normalize
+
+        assert normalize({"a": 4.0, "b": 2.0})["a"] == pytest.approx(1.0)
+
+    def test_max_indexed_chars_value(self):
+        """Mutating 200_000 -> 2_000 left all 156 selection tests green and
+        cost R@10 0.875 -> 0.750."""
+        from neo.file_retrieval import MAX_INDEXED_CHARS
+
+        assert MAX_INDEXED_CHARS == 200_000
+
+    def test_path_token_weight_value(self):
+        from neo.file_retrieval import PATH_TOKEN_WEIGHT
+
+        assert PATH_TOKEN_WEIGHT == 3
+
+
+class TestBinaryFilesAreNotIndexed:
+    """Binary content must not reach BM25.
+
+    `errors="ignore"` turned PDFs into junk tokens. Not merely wasted work:
+    BM25 divides by corpus-average document length, so binary blobs made every
+    real file's length penalty depend on how many PDFs sat in the repo.
+    Measured here: 5 PDFs were 1.7% of documents and 32.9% of all tokens, and
+    `avgdl` moved 2773 -> 1824 once they were excluded.
+    """
+
+    def test_a_nul_bearing_file_yields_no_text(self, tmp_path):
+        from neo.file_retrieval import _read
+
+        binary = tmp_path / "doc.pdf"
+        binary.write_bytes(b"%PDF-1.4\x00\x00binary\x00garbage")
+        assert _read(str(binary)) == ""
+
+    def test_undecodable_bytes_yield_no_text(self, tmp_path):
+        from neo.file_retrieval import _read
+
+        bad = tmp_path / "latin.py"
+        bad.write_bytes(b"x = '\xff\xfe not utf-8'")
+        assert _read(str(bad)) == ""
+
+    def test_real_source_still_reads(self, tmp_path):
+        from neo.file_retrieval import _read
+
+        good = tmp_path / "ok.py"
+        good.write_text("def hello():\n    return 'wörld'\n")
+        assert "hello" in _read(str(good))
+
+    def test_binaries_do_not_enter_the_index(self, tmp_path):
+        from neo.file_retrieval import build_index
+
+        (tmp_path / "a.py").write_text("def supersede(): pass\n")
+        (tmp_path / "b.pdf").write_bytes(b"%PDF\x00" + b"supersede " * 500)
+        cands = [(str(p), p.name, p.stat().st_size) for p in sorted(tmp_path.iterdir())]
+
+        scores = build_index(cands).scores("supersede")
+        assert "b.pdf" not in scores
+        assert scores.get("a.py", 0) > 0

--- a/tests/test_file_retrieval.py
+++ b/tests/test_file_retrieval.py
@@ -212,14 +212,21 @@ class TestConstantsArePinned:
 
     def test_normalize_ceiling_default(self):
         """Mutating the default to 0.05 left all 156 selection tests green and
-        cost R@10 0.875 -> 0.750 on the real CLI."""
+        cost R@10 0.875 -> 0.750 on the real CLI.
+
+        That R@10 is the `tools/rank_eval.py` generation -- 12 hand-labelled
+        prompts, this repo. It is NOT comparable with the cross-repo R@10 in
+        `neo.file_retrieval`, which is `tools/rank_mine_eval.py` over git-mined
+        cases. Same label, different instrument; keep the generation attached.
+        """
         from neo.file_retrieval import normalize
 
         assert normalize({"a": 4.0, "b": 2.0})["a"] == pytest.approx(1.0)
 
     def test_max_indexed_chars_value(self):
         """Mutating 200_000 -> 2_000 left all 156 selection tests green and
-        cost R@10 0.875 -> 0.750."""
+        cost R@10 0.875 -> 0.750 (the `tools/rank_eval.py` labelled generation,
+        not the cross-repo mined one -- see `test_normalize_ceiling_default`)."""
         from neo.file_retrieval import MAX_INDEXED_CHARS
 
         assert MAX_INDEXED_CHARS == 200_000

--- a/tests/test_file_retrieval.py
+++ b/tests/test_file_retrieval.py
@@ -1,0 +1,171 @@
+"""BM25 over file content — the signal file selection never had.
+
+Selection used to score the path string and the byte count and never open the
+file. The dominant term was `score -= 0.01 * size_kb`, uncapped, which made a
+file with one keyword hit unrankable above 60 KB — measured, the 162 KB
+`store.py` scored 0.000 and ranked 200th of 284 for a prompt about the fact
+store. These tests pin the replacement and the properties that make it work.
+"""
+
+import pathlib
+
+import pytest
+
+from neo.file_retrieval import (
+    PATH_TOKEN_WEIGHT,
+    build_index,
+    code_tokens,
+    normalize,
+)
+
+
+class TestCodeTokens:
+    def test_emits_whole_identifier_and_parts(self):
+        """Both, not either.
+
+        Dropping the whole identifier loses exact matches; dropping the parts
+        loses every prose query. `getUserById` has to be reachable from a
+        prompt that says "user by id" AND from one that names it exactly.
+        """
+        tokens = code_tokens("getUserById")
+        assert "getuserbyid" in tokens
+        assert {"get", "user", "by", "id"} <= set(tokens)
+
+    def test_splits_on_separators(self):
+        assert set(code_tokens("src/neo/fact_store.py")) >= {
+            "src", "neo", "fact", "store", "py"
+        }
+
+    def test_short_identifiers_survive(self):
+        """`db`, `os`, `fs`, `ui`, `id` carry signal.
+
+        A token-length floor was measured against this corpus and rejected for
+        exactly this reason — it drops the short identifiers and keeps the long
+        English stopwords. BM25's IDF demotes ubiquitous terms from the corpus
+        instead of guessing from length.
+        """
+        for short in ("db", "os", "fs", "ui", "id"):
+            assert short in code_tokens(f"the {short} layer")
+
+    def test_case_insensitive(self):
+        assert code_tokens("FactStore") == code_tokens("factstore") + ["fact", "store"]
+
+    def test_empty_and_punctuation_only(self):
+        assert code_tokens("") == []
+        assert code_tokens("--- /// ...") == []
+
+    def test_camel_split_is_not_applied_to_all_caps(self):
+        """`HTTPServer` has no lower-to-upper boundary before `S`, so the
+        regex leaves `HTTPS`-style runs alone rather than shattering acronyms
+        into letters."""
+        assert "httpserver" in code_tokens("HTTPServer")
+
+
+class TestFileIndex:
+    @pytest.fixture
+    def repo(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        # Large and relevant — the case the old scorer could not rank.
+        (tmp_path / "src" / "big.py").write_text(
+            "def supersede_fact(fact):\n    '''supersession threshold'''\n"
+            + "    # padding\n" * 8000
+        )
+        # Small and irrelevant.
+        (tmp_path / "src" / "tiny.py").write_text("def unrelated():\n    return 1\n")
+        # Named for the thing but empty of it.
+        (tmp_path / "src" / "supersession.py").write_text("x = 1\n")
+        return tmp_path
+
+    def _candidates(self, repo):
+        return [(str(p), str(p.relative_to(repo)), p.stat().st_size)
+                for p in sorted(repo.rglob("*.py"))]
+
+    def test_a_large_relevant_file_outranks_a_small_irrelevant_one(self, repo):
+        """The property the size penalty made impossible."""
+        index = build_index(self._candidates(repo))
+        scores = index.scores("supersede fact supersession threshold")
+
+        assert scores.get("src/big.py", 0) > scores.get("src/tiny.py", 0)
+
+    def test_content_beats_a_matching_filename_with_no_content(self, repo):
+        """`supersession.py` is named for the query and contains nothing.
+        `big.py` is named for nothing and contains the answer.
+
+        The path is still indexed (weighted `PATH_TOKEN_WEIGHT`) so a filename
+        remains real evidence — it is just no longer the ONLY evidence, which
+        is precisely what the old scorer got wrong.
+        """
+        index = build_index(self._candidates(repo))
+        scores = index.scores("supersession threshold on a fact")
+
+        assert scores.get("src/big.py", 0) > scores.get("src/supersession.py", 0)
+
+    def test_path_tokens_are_weighted(self, repo):
+        """Pins that the path contributes at all, so the weight cannot be
+        silently dropped to zero."""
+        assert PATH_TOKEN_WEIGHT >= 1
+        index = build_index(self._candidates(repo))
+        assert index.scores("supersession") .get("src/supersession.py", 0) > 0
+
+    def test_empty_candidate_list_returns_none(self):
+        assert build_index([]) is None
+
+    def test_query_with_no_matching_terms_scores_nothing(self, repo):
+        index = build_index(self._candidates(repo))
+        assert index.scores("zzzq nonexistent gibberish") == {}
+
+    def test_unreadable_file_does_not_break_the_index(self, repo, tmp_path):
+        """A binary or permission-denied file must not take the walk with it."""
+        missing = [(str(tmp_path / "gone.py"), "gone.py", 10)]
+        index = build_index(self._candidates(repo) + missing)
+        assert index is not None
+        assert index.scores("supersede fact")
+
+
+class TestNormalize:
+    def test_scales_to_the_ceiling(self):
+        out = normalize({"a": 4.0, "b": 2.0, "c": 1.0}, ceiling=1.0)
+        assert out["a"] == pytest.approx(1.0)
+        assert out["b"] == pytest.approx(0.5)
+
+    def test_empty_input(self):
+        assert normalize({}) == {}
+
+    def test_all_zero_scores(self):
+        assert normalize({"a": 0.0}) == {}
+
+    def test_relative_order_is_preserved(self):
+        raw = {"a": 9.1, "b": 3.3, "c": 7.7}
+        out = normalize(raw)
+        assert sorted(out, key=out.get, reverse=True) == sorted(raw, key=raw.get, reverse=True)
+
+    def test_normalization_is_why_the_bonuses_stay_calibrated(self):
+        """BM25 is unbounded and its scale moves with corpus and query length.
+
+        Without normalization a raw score could dwarf `EXPLICIT_PATH_BOOST`
+        (10.0) on one query and be dwarfed by git recency (0.3) on the next.
+        """
+        small = normalize({"a": 0.4, "b": 0.1})
+        large = normalize({"a": 4000.0, "b": 1000.0})
+        assert small == large
+
+
+class TestRealRepository:
+    """The measured case, against this repository."""
+
+    def test_store_py_ranks_for_a_fact_store_prompt(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        candidates = [
+            (str(p), str(p.relative_to(root)), p.stat().st_size)
+            for p in (root / "src").rglob("*.py")
+        ]
+        index = build_index(candidates)
+        scores = index.scores("fix the fact store supersession threshold")
+        ranked = sorted(scores, key=scores.get, reverse=True)
+
+        position = (ranked.index("src/neo/memory/store.py") + 1
+                    if "src/neo/memory/store.py" in ranked else None)
+        assert position is not None and position <= 5, (
+            f"store.py ranked {position}; it ranked 200th of 284 under the "
+            f"old scorer, because it is 162 KB"
+        )

--- a/tests/test_index_file_selection.py
+++ b/tests/test_index_file_selection.py
@@ -718,3 +718,81 @@ class TestReportFormatting:
         }))
         assert "200" in joined
         assert "7" in joined
+
+
+class TestChunkAllocationIsProportional:
+    """Chunk slots go where the code is, not one-per-file-per-round.
+
+    Round-robin replaced a list slice for a good reason — `chunks[:cap]` on a
+    language-ordered list kept 1000 C# chunks and dropped every other language.
+    But taking every file's first chunk before any file's second gives every
+    file the SAME COUNT regardless of how much is in it, which is a subtler
+    version of the same bias. Measured on this repo before the change:
+
+        src/neo/memory/store.py    82 symbols,  6 indexed,   7%
+        src/neo/engine.py          95 symbols,  6 indexed,   6%
+        src/neo/text_budget.py      4 symbols,  4 indexed, 100%
+
+    A file cannot be retrieved for what was never indexed, so the semantic
+    channel was blind to 93% of the two files most likely to be relevant.
+    After: every file lands at roughly the same COVERAGE FRACTION instead.
+    """
+
+    @staticmethod
+    def _chunks(spec):
+        """`spec` maps file path -> number of chunks that file produces."""
+        from neo.index.project_index import CodeChunk
+        out = []
+        for path, count in spec.items():
+            for i in range(count):
+                out.append(CodeChunk(
+                    file_path=path, chunk_id=f"{path}:{i}", content=f"c{i}",
+                    chunk_type="function", start_line=i, end_line=i,
+                ))
+        return out
+
+    def test_a_big_file_gets_more_slots_than_a_small_one(self):
+        from neo.index.project_index import ProjectIndex
+
+        kept = ProjectIndex._cap_chunks(
+            self._chunks({"big.py": 80, "small.py": 4}), cap=42
+        )
+        per = {}
+        for c in kept:
+            per[c.file_path] = per.get(c.file_path, 0) + 1
+
+        assert per["big.py"] > per["small.py"], (
+            "round-robin is back: every file got the same count regardless "
+            "of how much is in it"
+        )
+
+    def test_every_file_keeps_at_least_one_slot(self):
+        """The property round-robin was protecting. A file with zero chunks
+        indexed cannot be retrieved at all, so proportional-without-a-floor
+        would make small files invisible — trading one bias for another."""
+        from neo.index.project_index import ProjectIndex
+
+        spec = {"huge.py": 500, **{f"tiny{i}.py": 1 for i in range(20)}}
+        kept = ProjectIndex._cap_chunks(self._chunks(spec), cap=60)
+        represented = {c.file_path for c in kept}
+
+        assert represented == set(spec), "a file was allocated zero chunks"
+
+    def test_coverage_fraction_is_roughly_equal(self):
+        """The intended shape: equal FRACTION, not equal COUNT."""
+        from neo.index.project_index import ProjectIndex
+
+        spec = {"a.py": 80, "b.py": 40, "c.py": 20}
+        kept = ProjectIndex._cap_chunks(self._chunks(spec), cap=70)
+        per = {}
+        for c in kept:
+            per[c.file_path] = per.get(c.file_path, 0) + 1
+
+        fractions = [per[p] / spec[p] for p in spec]
+        assert max(fractions) - min(fractions) < 0.25, f"uneven: {fractions}"
+
+    def test_under_cap_returns_everything_untouched(self):
+        from neo.index.project_index import ProjectIndex
+
+        chunks = self._chunks({"a.py": 3, "b.py": 2})
+        assert ProjectIndex._cap_chunks(chunks, cap=99) is chunks

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -315,6 +315,37 @@ class TestGuards:
         assert seen["tree"] == str(tmp_path.resolve())
 
 
+class TestNothingParsedIsAFailure:
+    """Marker found, zero lines parsed anywhere = the format moved.
+
+    Scored as a result it reads `R@10 0.000, failed_cases: 0` -- a confident
+    claim that the ranker found nothing, when the parser found nothing.
+    """
+
+    def _run_main(self, monkeypatch, tmp_path, ranking):
+        monkeypatch.setattr(rme, "assert_tree_is_effective", lambda t, r: None)
+        monkeypatch.setattr(rme, "_git_head", lambda p: "deadbeefcafe")
+        monkeypatch.setattr(rme, "mine_cases",
+                            lambda *a, **k: [{"sha": "abc", "query": "q",
+                                              "truth": ["a.py"]}])
+        monkeypatch.setattr(rme, "rank_files", lambda *a, **k: ranking)
+        monkeypatch.setattr(sys, "argv",
+                            ["rank_mine_eval.py", "--repo", str(tmp_path),
+                             "--tree", str(tmp_path)])
+        return rme.main()
+
+    def test_every_case_parsing_nothing_exits_nonzero(self, monkeypatch,
+                                                      tmp_path, capsys):
+        rc = self._run_main(monkeypatch, tmp_path, [])
+
+        assert rc == 1
+        assert "not one case yielded a parsable file line" in \
+            capsys.readouterr().err.lower()
+
+    def test_a_real_ranking_still_scores(self, monkeypatch, tmp_path):
+        assert self._run_main(monkeypatch, tmp_path, ["a.py"]) == 0
+
+
 class TestHeadStamp:
     def test_a_non_git_tree_stamps_instead_of_exploding(self, tmp_path):
         """`--tree` need not be a git checkout, and a prune'd worktree passes
@@ -325,4 +356,16 @@ class TestHeadStamp:
     def test_a_real_checkout_stamps_a_short_sha(self):
         head = rme._git_head(str(Path(__file__).resolve().parent.parent))
 
-        assert len(head) == 12 and head != "not-a-git-checkout"
+        assert len(head) == 12   # the marker is longer, so this excludes it
+
+    def test_a_non_git_dir_INSIDE_a_checkout_does_not_borrow_its_sha(self,
+                                                                     tmp_path):
+        """`rev-parse HEAD` searches ancestors, so this stamped the enclosing
+        repo -- a confident wrong label on the field that says which ranker
+        ran."""
+        nested = Path(__file__).resolve().parent.parent / ".tmp_nongit_probe"
+        nested.mkdir(exist_ok=True)
+        try:
+            assert rme._git_head(str(nested)) == "not-a-git-checkout"
+        finally:
+            nested.rmdir()

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -116,19 +116,37 @@ class TestRankFilesFailsClosed:
 
 
 class TestSubjectFiltering:
-    def test_conventional_prefix_is_stripped_before_the_skip_test(self):
-        """`chore: bump version to 0.39.0` was mined as a real case."""
-        subject = "chore: bump version to 0.39.0"
-        stripped = rme._CONVENTIONAL_PREFIX_RE.sub("", subject)
+    """Asserts on the PREDICATES `mine_cases` calls, not on a composition the
+    test performs itself. Composing the two regexes here would stay green while
+    `mine_cases` dropped the prefix strip -- i.e. green through the exact
+    regression the first case below is named for."""
 
-        assert rme._SKIP_SUBJECT_RE.match(stripped)
-        assert not rme._SKIP_SUBJECT_RE.match(subject)   # why the strip is needed
+    @pytest.mark.parametrize("subject", [
+        "chore: bump version to 0.39.0",     # the one that was mined for real
+        "bump version to 0.39.0",
+        "chore(release): v1.2.3 and the notes",
+        "Merge branch 'main' into feature",
+        "revert: the thing that broke prod",
+        "wip: still figuring this out",
+    ])
+    def test_non_work_subjects_are_skipped(self, subject):
+        assert rme.is_skippable(subject)
 
-    def test_real_work_survives_the_filter(self):
-        subject = "fix(gatherer): select files by content, not by filename"
-        stripped = rme._CONVENTIONAL_PREFIX_RE.sub("", subject)
+    @pytest.mark.parametrize("subject", [
+        "fix(gatherer): select files by content, not by filename",
+        "add retry logic to the CAR adapter",
+        "feat(index): apportion chunk slots by symbol count",
+    ])
+    def test_real_work_survives_the_filter(self, subject):
+        assert not rme.is_skippable(subject)
 
-        assert not rme._SKIP_SUBJECT_RE.match(stripped)
+
+class TestGroundTruth:
+    HEAD = {
+        "src/neo/context_gatherer.py", "src/latest/protest.py", "lib/attestation.cs",
+        "tests/test_store.py", "src/__tests__/a.ts", "a/b_test.go",
+        "src/foo.spec.ts", "spec/models/user.rb", "README.md", "gone.py",
+    }
 
     @pytest.mark.parametrize("path", [
         "tests/test_store.py", "src/__tests__/a.ts", "a/b_test.go",
@@ -136,10 +154,41 @@ class TestSubjectFiltering:
     ])
     def test_test_files_are_not_ground_truth(self, path):
         """They are demoted by design; counting them would score that as a bug."""
-        assert rme._TEST_RE.search(path)
+        assert not rme.is_ground_truth(path, self.HEAD)
 
     @pytest.mark.parametrize("path", [
         "src/neo/context_gatherer.py", "src/latest/protest.py", "lib/attestation.cs",
     ])
-    def test_source_files_are_not_mistaken_for_tests(self, path):
-        assert not rme._TEST_RE.search(path)
+    def test_source_files_are_ground_truth(self, path):
+        """`protest`/`attestation` guard the test regex against over-matching."""
+        assert rme.is_ground_truth(path, self.HEAD)
+
+    def test_non_source_is_excluded(self):
+        assert not rme.is_ground_truth("README.md", self.HEAD)
+
+    def test_a_file_deleted_since_the_commit_is_excluded(self):
+        """Unfindable at HEAD, so scoring it as a miss would penalise nothing."""
+        assert not rme.is_ground_truth("src/removed.py", self.HEAD)
+
+
+class TestOutputFormatContract:
+    """The parser reads human output, so the CLI's format is a contract.
+
+    Hand-writing the format in a parser test proves only that the parser
+    matches the test. This asserts against the string the CLI actually emits.
+    """
+
+    def test_parser_matches_the_line_the_cli_emits(self):
+        import inspect
+
+        from neo import cli
+
+        source = inspect.getsource(cli)
+        # The dry-run printer's own format string, rendered with real values.
+        rendered = "  src/neo/store.py (lines 1-140) - 6183 bytes (score: 4.23)"
+
+        assert "=== DRY RUN" in source, "dry-run marker renamed; parser is blind"
+        assert rme._DRY_RUN_LINE.match(rendered), (
+            "the parser no longer matches the CLI's selected-file line -- every "
+            "case would return [] and the run would report a confident 0.000"
+        )

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -1,0 +1,145 @@
+"""Tests for `tools/rank_mine_eval.py`.
+
+This harness produces the ranking figures quoted in CLAUDE.md and on the PR,
+so a silent defect in it does not cause a crash -- it publishes a wrong number
+with a confident table around it. That is the exact failure the file-selection
+work exists to stop, and it has already happened twice here: the first draft
+scored every case zero because it read stdout while the CLI writes to stderr,
+and the second scored subprocess failures as perfect-zero retrieval.
+
+What is pinned below is therefore the arithmetic and the fail-closed paths,
+not the mining (which needs a real repository).
+"""
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parent.parent / "tools" / "rank_mine_eval.py"
+_spec = importlib.util.spec_from_file_location("rank_mine_eval", _TOOL)
+rme = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rme)
+
+
+class TestScore:
+    def test_recall_and_hit_rate_answer_different_questions(self):
+        """The divergence that makes reporting only one of them misleading."""
+        cases = [{"truth": ["a.py", "b.py", "c.py", "d.py"]}]
+        ranked = [["z.py", "b.py", "y.py"]]
+
+        result = rme.score(cases, ranked, [3])
+
+        # One of four truth files found: quarter the recall, but the run DID
+        # surface something relevant, so the hit rate is 1.0.
+        assert result["recall"]["R@3"] == pytest.approx(0.25)
+        assert result["hit_rate"]["H@3"] == pytest.approx(1.0)
+        assert result["MRR"] == pytest.approx(0.5)   # first hit at rank 2
+
+    def test_mrr_uses_the_first_relevant_rank_only(self):
+        cases = [{"truth": ["a.py", "b.py"]}]
+        ranked = [["a.py", "b.py"]]
+
+        assert rme.score(cases, ranked, [10])["MRR"] == pytest.approx(1.0)
+
+    def test_a_miss_scores_zero_rather_than_erroring(self):
+        result = rme.score([{"truth": ["a.py"]}], [["x.py", "y.py"]], [1, 10])
+
+        assert result["recall"]["R@10"] == 0.0
+        assert result["hit_rate"]["H@10"] == 0.0
+        assert result["MRR"] == 0.0
+
+    def test_k_truncates_the_ranking(self):
+        cases = [{"truth": ["a.py"]}]
+        ranked = [["x.py", "y.py", "z.py", "a.py"]]
+
+        result = rme.score(cases, ranked, [1, 3, 10])
+
+        assert result["recall"]["R@1"] == 0.0
+        assert result["recall"]["R@3"] == 0.0
+        assert result["recall"]["R@10"] == pytest.approx(1.0)
+
+
+class TestRankFilesFailsClosed:
+    """None means the run FAILED; [] means it completed and chose nothing.
+
+    Collapsing the two is what let a timeout average into a table as evidence
+    about ranking quality.
+    """
+
+    def _stub(self, monkeypatch, *, returncode=0, stdout="", raises=None):
+        def fake_run(*args, **kwargs):
+            if raises:
+                raise raises
+            return subprocess.CompletedProcess(args, returncode, stdout=stdout)
+        monkeypatch.setattr(rme.subprocess, "run", fake_run)
+
+    def test_non_zero_exit_is_a_failure_not_an_empty_ranking(self, monkeypatch):
+        self._stub(monkeypatch, returncode=1, stdout="=== DRY RUN ===\n")
+
+        assert rme.rank_files("/repo", "/tree", "q", 10) is None
+
+    def test_missing_marker_is_a_failure(self, monkeypatch):
+        """Format drift must not read as 'nothing matched'."""
+        self._stub(monkeypatch, returncode=0, stdout="some other output\n")
+
+        assert rme.rank_files("/repo", "/tree", "q", 10) is None
+
+    def test_timeout_is_a_failure(self, monkeypatch):
+        self._stub(monkeypatch, raises=subprocess.TimeoutExpired("cmd", 1))
+
+        assert rme.rank_files("/repo", "/tree", "q", 10) is None
+
+    def test_parses_ranking_and_collapses_chunks_of_one_file(self, monkeypatch):
+        self._stub(monkeypatch, stdout=(
+            "=== DRY RUN: Context that would be sent ===\n\n"
+            "  src/a.py (lines 1-140) - 6183 bytes (score: 4.23)\n"
+            "  src/a.py (lines 141-329) - 8467 bytes (score: 4.23)\n"
+            "  src/b.py - 3967 bytes (score: 3.72)\n"
+        ))
+
+        assert rme.rank_files("/repo", "/tree", "q", 10) == ["src/a.py", "src/b.py"]
+
+    def test_git_recency_is_disabled_unless_asked_for(self, monkeypatch):
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="=== DRY RUN ===\n")
+        monkeypatch.setattr(rme.subprocess, "run", fake_run)
+
+        rme.rank_files("/repo", "/tree", "q", 10)
+        assert "--no-git" in seen["cmd"]
+
+        rme.rank_files("/repo", "/tree", "q", 10, use_git=True)
+        assert "--no-git" not in seen["cmd"]
+
+
+class TestSubjectFiltering:
+    def test_conventional_prefix_is_stripped_before_the_skip_test(self):
+        """`chore: bump version to 0.39.0` was mined as a real case."""
+        subject = "chore: bump version to 0.39.0"
+        stripped = rme._CONVENTIONAL_PREFIX_RE.sub("", subject)
+
+        assert rme._SKIP_SUBJECT_RE.match(stripped)
+        assert not rme._SKIP_SUBJECT_RE.match(subject)   # why the strip is needed
+
+    def test_real_work_survives_the_filter(self):
+        subject = "fix(gatherer): select files by content, not by filename"
+        stripped = rme._CONVENTIONAL_PREFIX_RE.sub("", subject)
+
+        assert not rme._SKIP_SUBJECT_RE.match(stripped)
+
+    @pytest.mark.parametrize("path", [
+        "tests/test_store.py", "src/__tests__/a.ts", "a/b_test.go",
+        "src/foo.spec.ts", "spec/models/user.rb",
+    ])
+    def test_test_files_are_not_ground_truth(self, path):
+        """They are demoted by design; counting them would score that as a bug."""
+        assert rme._TEST_RE.search(path)
+
+    @pytest.mark.parametrize("path", [
+        "src/neo/context_gatherer.py", "src/latest/protest.py", "lib/attestation.cs",
+    ])
+    def test_source_files_are_not_mistaken_for_tests(self, path):
+        assert not rme._TEST_RE.search(path)

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -11,7 +11,9 @@ What is pinned below is therefore the arithmetic and the fail-closed paths,
 not the mining (which needs a real repository).
 """
 import importlib.util
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -235,9 +237,32 @@ class TestGuards:
 
     def test_a_tree_without_src_neo_is_refused(self, tmp_path):
         with pytest.raises(SystemExit) as exc:
-            rme.assert_tree_is_effective(str(tmp_path))
+            rme.assert_tree_is_effective(str(tmp_path), str(tmp_path))
 
         assert "src/neo" in str(exc.value)
+
+    def test_the_probe_runs_from_the_repo_the_measurement_runs_from(
+            self, tmp_path, monkeypatch):
+        """cwd lands at sys.path[0], AHEAD of PYTHONPATH.
+
+        A probe run from anywhere else cannot see a repo-local `neo/` package
+        shadowing the named tree, so the guard would pass while the run
+        measured the shadow.
+        """
+        (tmp_path / "src" / "neo").mkdir(parents=True)
+        repo = tmp_path / "somerepo"
+        repo.mkdir()
+        seen = {}
+
+        def fake_run(*args, **kwargs):
+            seen["cwd"] = kwargs.get("cwd")
+            return subprocess.CompletedProcess(
+                args, 0, stdout=str(tmp_path / "src" / "neo" / "__init__.py"))
+        monkeypatch.setattr(rme.subprocess, "run", fake_run)
+
+        rme.assert_tree_is_effective(str(tmp_path), str(repo))
+
+        assert seen["cwd"] == str(repo)
 
     def test_a_tree_that_does_not_win_the_import_is_refused(self, tmp_path,
                                                             monkeypatch):
@@ -250,7 +275,7 @@ class TestGuards:
         monkeypatch.setattr(rme.subprocess, "run", fake_run)
 
         with pytest.raises(SystemExit) as exc:
-            rme.assert_tree_is_effective(str(tmp_path))
+            rme.assert_tree_is_effective(str(tmp_path), str(tmp_path))
 
         assert "did not take effect" in str(exc.value)
 
@@ -262,9 +287,42 @@ class TestGuards:
             return subprocess.CompletedProcess(args, 0, stdout=resolved)
         monkeypatch.setattr(rme.subprocess, "run", fake_run)
 
-        rme.assert_tree_is_effective(str(tmp_path))   # must not raise
+        rme.assert_tree_is_effective(str(tmp_path), str(tmp_path))   # no raise
 
-    def test_nothing_parsed_anywhere_is_a_failure_not_a_zero(self):
-        """`any()` over the rankings is the whole guard; pin its truth table."""
-        assert not any([[], [], []])          # every case parsed nothing -> fail
-        assert any([[], ["a.py"], []])        # one case parsed -> a real result
+    def test_relative_paths_are_absolutized_before_the_guard_sees_them(
+            self, tmp_path, monkeypatch):
+        """The headline fix of b45cc92, which was verified by hand only.
+
+        `--repo x --tree .` resolved `.` against the harness's cwd while the
+        measurement ran with `cwd=repo` -- guard green, wrong tree measured.
+        """
+        (tmp_path / "src" / "neo").mkdir(parents=True)
+        (tmp_path / "repo").mkdir()
+        monkeypatch.chdir(tmp_path)
+        seen = {}
+
+        def fake_guard(tree, repo):
+            seen["tree"], seen["repo"] = tree, repo
+            raise SystemExit("stop here -- only the paths are under test")
+        monkeypatch.setattr(rme, "assert_tree_is_effective", fake_guard)
+        monkeypatch.setattr(sys, "argv",
+                            ["rank_mine_eval.py", "--repo", "repo", "--tree", "."])
+
+        with pytest.raises(SystemExit):
+            rme.main()
+
+        assert os.path.isabs(seen["tree"]) and os.path.isabs(seen["repo"])
+        assert seen["tree"] == str(tmp_path.resolve())
+
+
+class TestHeadStamp:
+    def test_a_non_git_tree_stamps_instead_of_exploding(self, tmp_path):
+        """`--tree` need not be a git checkout, and a prune'd worktree passes
+        the effectiveness guard. Raising here discarded a finished 50-case run
+        with a traceback pointing at a string format."""
+        assert rme._git_head(str(tmp_path)) == "not-a-git-checkout"
+
+    def test_a_real_checkout_stamps_a_short_sha(self):
+        head = rme._git_head(str(Path(__file__).resolve().parent.parent))
+
+        assert len(head) == 12 and head != "not-a-git-checkout"

--- a/tests/test_rank_mine_eval.py
+++ b/tests/test_rank_mine_eval.py
@@ -174,21 +174,97 @@ class TestGroundTruth:
 class TestOutputFormatContract:
     """The parser reads human output, so the CLI's format is a contract.
 
-    Hand-writing the format in a parser test proves only that the parser
-    matches the test. This asserts against the string the CLI actually emits.
+    The format string is EXTRACTED from `cli.py` and rendered here, rather than
+    hand-written. A hand-written literal only proves the parser matches the
+    test: change `- {gf.bytes} bytes` to `- {gf.bytes}b` in the CLI and a
+    literal-based test stays green while every case parses to nothing.
     """
 
-    def test_parser_matches_the_line_the_cli_emits(self):
+    def _cli_format_string(self):
         import inspect
 
         from neo import cli
 
-        source = inspect.getsource(cli)
-        # The dry-run printer's own format string, rendered with real values.
-        rendered = "  src/neo/store.py (lines 1-140) - 6183 bytes (score: 4.23)"
+        for line in inspect.getsource(cli).splitlines():
+            if "bytes (score:" in line and "print(" in line:
+                return line[line.index('f"'):].split('"')[1]
+        pytest.fail("the dry-run selected-file print was not found in cli.py -- "
+                    "the parser's contract has moved and this test is blind")
 
-        assert "=== DRY RUN" in source, "dry-run marker renamed; parser is blind"
+    def test_parser_matches_the_format_the_cli_actually_uses(self):
+        fmt = self._cli_format_string()
+        rendered = (fmt
+                    .replace("{gf.rel_path}", "src/neo/store.py")
+                    .replace("{lines_info}", " (lines 1-140)")
+                    .replace("{gf.bytes}", "6183")
+                    .replace("{gf.score:.2f}", "4.23"))
+
         assert rme._DRY_RUN_LINE.match(rendered), (
-            "the parser no longer matches the CLI's selected-file line -- every "
-            "case would return [] and the run would report a confident 0.000"
+            f"parser no longer matches the CLI's line format {fmt!r} -- every "
+            f"case would return [] and the run would report a confident 0.000"
         )
+
+    def test_parser_matches_it_without_a_line_range_too(self):
+        fmt = self._cli_format_string()
+        rendered = (fmt
+                    .replace("{gf.rel_path}", "src/neo/store.py")
+                    .replace("{lines_info}", "")
+                    .replace("{gf.bytes}", "6183")
+                    .replace("{gf.score:.2f}", "4.23"))
+
+        assert rme._DRY_RUN_LINE.match(rendered)
+
+    def test_the_marker_the_parser_splits_on_still_exists(self):
+        import inspect
+
+        from neo import cli
+
+        assert "=== DRY RUN" in inspect.getsource(cli), (
+            "dry-run marker renamed; the parser fails closed on it, so every "
+            "run would abort rather than mislead -- but fix the parser"
+        )
+
+
+class TestGuards:
+    """The two guards added because each was a way to publish a wrong number.
+
+    Verifying a guard by hand once is how a guard goes unpinned and looks
+    pinned -- the same failure as naming a constant in a docstring while
+    asserting only a direction.
+    """
+
+    def test_a_tree_without_src_neo_is_refused(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            rme.assert_tree_is_effective(str(tmp_path))
+
+        assert "src/neo" in str(exc.value)
+
+    def test_a_tree_that_does_not_win_the_import_is_refused(self, tmp_path,
+                                                            monkeypatch):
+        """Structure alone is not proof: the editable .pth can still win."""
+        (tmp_path / "src" / "neo").mkdir(parents=True)
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args, 0, stdout="/somewhere/else/neo/__init__.py")
+        monkeypatch.setattr(rme.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as exc:
+            rme.assert_tree_is_effective(str(tmp_path))
+
+        assert "did not take effect" in str(exc.value)
+
+    def test_a_tree_that_wins_the_import_is_accepted(self, tmp_path, monkeypatch):
+        (tmp_path / "src" / "neo").mkdir(parents=True)
+        resolved = str(tmp_path / "src" / "neo" / "__init__.py")
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(args, 0, stdout=resolved)
+        monkeypatch.setattr(rme.subprocess, "run", fake_run)
+
+        rme.assert_tree_is_effective(str(tmp_path))   # must not raise
+
+    def test_nothing_parsed_anywhere_is_a_failure_not_a_zero(self):
+        """`any()` over the rankings is the whole guard; pin its truth table."""
+        assert not any([[], [], []])          # every case parsed nothing -> fail
+        assert any([[], ["a.py"], []])        # one case parsed -> a real result

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -39,8 +39,9 @@ _EMPTY: set = set()
 _ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
 
 
-def _score(path, tokens, *, demote):
-    return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
+def _score(path, tokens, *, demote, relevance=0.0):
+    return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY,
+                           demote_tests=demote, content_relevance=relevance)
 
 
 MIN_SCORE_THRESHOLD = __import__(
@@ -110,48 +111,52 @@ class TestScoringDemotion:
     _TOKENS = {"adapter", "car"}
 
     def test_a_test_file_no_longer_outranks_its_subject(self):
-        """The measured failure, reduced to its mechanism.
+        """The measured failure, reduced to its mechanism — now expressed in
+        terms of CONTENT, because content is what ranks files.
 
-        `test_car_adapter.py` matches both prompt tokens; `adapters.py`
-        matches one. Without the penalty the test file wins on filename
-        overlap alone, before any size penalty is applied to the
-        implementation.
+        A test file is a lexical superset of its subject: it contains the same
+        identifiers plus test scaffolding, so BM25 scores it at least as high.
+        That makes the demotion matter MORE than it did under filename
+        scoring, not less — measured, it moves neo's MRR from 0.558 to 0.718.
+        Both files here score a full content match; only the penalty separates
+        them.
         """
-        impl = _score("src/neo/adapters.py", self._TOKENS, demote=True)
-        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=True, relevance=1.0)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=True,
+                      relevance=1.0)
 
         assert test < impl, (
             f"test file scored {test:.2f} vs implementation {impl:.2f}"
         )
 
-    def test_without_demotion_the_test_file_still_wins(self):
-        """Pins the mechanism rather than the fix, so this file documents WHY
-        the penalty exists and not merely that it is applied."""
-        impl = _score("src/neo/adapters.py", self._TOKENS, demote=False)
-        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+    def test_without_demotion_the_test_file_ties_or_wins(self):
+        """Pins the mechanism rather than the fix.
 
-        assert test > impl
+        On equal content the test file wins on filename overlap alone — it
+        matches both prompt tokens where the implementation matches one.
+        """
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=False, relevance=1.0)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=False,
+                      relevance=1.0)
 
-    def test_the_penalty_scales_the_bonuses_not_the_final_score(self):
-        """Placement is deliberate: the multiplier lands after the bonuses and
-        BEFORE the additive depth and size penalties.
+        assert test >= impl
 
-        So it is not `final * TEST_PENALTY`. Scaling the final score would
-        shrink the penalties too, making a deep or oversized test file
-        cheaper than a shallow one -- the wrong direction. Scaling only the
-        positive signal is also what the ProjectIndex path does, where the
-        multiplier applies to a cosine similarity before it becomes a boost.
+    def test_the_penalty_scales_everything_above_the_additive_penalties(self):
+        """Placement: the multiplier lands after the bonuses and content term,
+        and BEFORE the additive depth penalty.
 
-        Measured for `tests/test_car_adapter.py` at 4KB and depth 1:
-        bonuses 1.20, depth penalty 0.05, so plain = 1.15 and demoted =
-        1.20 * 0.4 - 0.05 = 0.43.
+        Scaling the final score would shrink the penalties too, making a deep
+        test file cheaper than a shallow one — the wrong direction. It is
+        therefore not `final * TEST_PENALTY`.
         """
         depth_penalty = 0.05  # one separator in "tests/test_car_adapter.py"
-        plain = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
-        demoted = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+        plain = _score("tests/test_car_adapter.py", self._TOKENS, demote=False,
+                       relevance=1.0)
+        demoted = _score("tests/test_car_adapter.py", self._TOKENS, demote=True,
+                         relevance=1.0)
 
-        bonuses = plain + depth_penalty
-        assert demoted == pytest.approx(bonuses * TEST_PENALTY - depth_penalty)
+        positives = plain + depth_penalty
+        assert demoted == pytest.approx(positives * TEST_PENALTY - depth_penalty)
         assert demoted < plain
 
     def test_non_test_files_are_untouched(self):
@@ -189,8 +194,10 @@ class TestDemotionReRanksButNeverEvicts:
     _TOKENS = {"widget"}
 
     def test_a_file_that_would_be_admitted_stays_admitted(self):
-        plain = _score("tests/test_widget.py", self._TOKENS, demote=False)
-        demoted = _score("tests/test_widget.py", self._TOKENS, demote=True)
+        plain = _score("tests/test_widget.py", self._TOKENS, demote=False,
+                       relevance=0.5)
+        demoted = _score("tests/test_widget.py", self._TOKENS, demote=True,
+                         relevance=0.5)
 
         assert plain >= MIN_SCORE_THRESHOLD
         assert demoted >= MIN_SCORE_THRESHOLD, "the penalty evicted rather than re-ranked"

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -1,0 +1,185 @@
+"""Test files must not outrank the code they test.
+
+A test file's name is a strict SUPERSET of its subject's filename tokens:
+`test_car_adapter.py` matches {adapter, car} where `adapters.py` matches
+{adapter}. On the keyword path it can therefore only ever score at least as
+high as the code it tests -- and then the implementation takes a size penalty
+on top, because implementations are large. Measured on a real prompt, "add
+retry logic to the CAR adapter" put `src/neo/adapters.py` at rank 14, below
+nine test and doc files, split into two chunks.
+
+`TEST_PENALTY` already existed and already fixed this -- on the ProjectIndex
+semantic-boost path only. The two scoring paths disagreed about test files and
+only one of them was ever corrected, which is the same duplicated-rule shape
+that let `EXCLUDED_DIR_NAMES` hide files from one subsystem while the other
+was fixed. There is now one constant and one predicate, used by both.
+
+Measured over 12 code prompts, mean of the first source file's rank and of how
+many of the top 10 slots went to tests and docs:
+
+    baseline           first-src 4.50   tests+docs 5.58
+    with the penalty   first-src 1.75   tests+docs 4.41
+
+Doc-seeking prompts improve too (2.16 -> 3.00 docs in the top 10): demoting
+tests leaves room rather than competing with documentation.
+"""
+
+import os
+
+import pytest
+
+from neo.context_gatherer import (
+    TEST_PENALTY,
+    is_test_path,
+    prompt_targets_tests,
+    score_candidate,
+)
+
+_EMPTY: set = set()
+_ENTRY = {"main", "app", "server", "index", "login", "auth", "__init__"}
+
+
+def _score(path, tokens, *, demote):
+    return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
+
+
+class TestIsTestPath:
+    @pytest.mark.parametrize("path", [
+        "tests/test_engine.py",
+        "test_engine.py",
+        "src/pkg/tests/test_x.py",
+        "tests/subdir/helper.py",
+    ])
+    def test_recognised(self, path):
+        assert is_test_path(path.replace("/", os.sep) if os.sep != "/" else path)
+
+    @pytest.mark.parametrize("path", [
+        "src/neo/adapters.py",
+        "src/neo/testing_utils.py",   # not a test file; a module about testing
+        "docs/testing.md",
+        "src/latest.py",
+    ])
+    def test_not_recognised(self, path):
+        assert not is_test_path(path)
+
+
+class TestPromptTargetsTests:
+    """The escape hatch: when the prompt IS about testing, test files are the
+    answer and must keep full score."""
+
+    @pytest.mark.parametrize("prompt", [
+        "why does test_fact_store fail",
+        "add unit tests for the parser",
+        "the testing harness is slow",
+        "run the rspec specs",
+        "check the spec file",
+    ])
+    def test_fires_on_real_test_prompts(self, prompt):
+        assert prompt_targets_tests(prompt)
+
+    @pytest.mark.parametrize("prompt", [
+        "the A2UI inspector shows a stale fact count",
+        "make the query more specific",
+        "their respective owners",
+        "the latest commit broke it",
+        "one aspect of the design",
+        "add retry logic to the CAR adapter",
+    ])
+    def test_does_not_fire_on_substring_lookalikes(self, prompt):
+        """The bug this predicate had, and why it mattered more after hoisting.
+
+        The original was `any(t in prompt.lower() for t in (..., "spec"))`, so
+        "in-spec-tor" classified a prompt about the A2UI inspector as a prompt
+        about testing, and every test file kept full score. That was survivable
+        while the flag only softened a cosine boost; it stopped being
+        survivable once the same flag gated the keyword path. Measured: that
+        one prompt moved the 12-prompt mean first-source rank from 1.75 to
+        2.83 on its own.
+
+        Same defect class as `'a'` matching 49 of 85 filenames -- a substring
+        test on a short token.
+        """
+        assert not prompt_targets_tests(prompt)
+
+
+class TestScoringDemotion:
+    _TOKENS = {"adapter", "car"}
+
+    def test_a_test_file_no_longer_outranks_its_subject(self):
+        """The measured failure, reduced to its mechanism.
+
+        `test_car_adapter.py` matches both prompt tokens; `adapters.py`
+        matches one. Without the penalty the test file wins on filename
+        overlap alone, before any size penalty is applied to the
+        implementation.
+        """
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=True)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        assert test < impl, (
+            f"test file scored {test:.2f} vs implementation {impl:.2f}"
+        )
+
+    def test_without_demotion_the_test_file_still_wins(self):
+        """Pins the mechanism rather than the fix, so this file documents WHY
+        the penalty exists and not merely that it is applied."""
+        impl = _score("src/neo/adapters.py", self._TOKENS, demote=False)
+        test = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+
+        assert test > impl
+
+    def test_the_penalty_scales_the_bonuses_not_the_final_score(self):
+        """Placement is deliberate: the multiplier lands after the bonuses and
+        BEFORE the additive depth and size penalties.
+
+        So it is not `final * TEST_PENALTY`. Scaling the final score would
+        shrink the penalties too, making a deep or oversized test file
+        cheaper than a shallow one -- the wrong direction. Scaling only the
+        positive signal is also what the ProjectIndex path does, where the
+        multiplier applies to a cosine similarity before it becomes a boost.
+
+        Measured for `tests/test_car_adapter.py` at 4KB and depth 1:
+        bonuses 1.20, depth penalty 0.05, so plain = 1.15 and demoted =
+        1.20 * 0.4 - 0.05 = 0.43.
+        """
+        depth_penalty = 0.05  # one separator in "tests/test_car_adapter.py"
+        plain = _score("tests/test_car_adapter.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_car_adapter.py", self._TOKENS, demote=True)
+
+        bonuses = plain + depth_penalty
+        assert demoted == pytest.approx(bonuses * TEST_PENALTY - depth_penalty)
+        assert demoted < plain
+
+    def test_non_test_files_are_untouched(self):
+        for path in ("src/neo/adapters.py", "docs/architecture.md", "README.md"):
+            assert (_score(path, self._TOKENS, demote=True)
+                    == _score(path, self._TOKENS, demote=False))
+
+    def test_demotion_is_off_by_default(self):
+        """The existing pure-scoring tests call `score_candidate` positionally
+        and must keep their meaning."""
+        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+                == _score("tests/test_x.py", self._TOKENS, demote=False))
+
+
+class TestBothPathsShareOneRule:
+    def test_the_semantic_path_uses_the_module_level_predicate(self):
+        """`gather_context`'s ProjectIndex boost had its own inline copy of
+        both the constant and the is-a-test check. A second copy is how the
+        two paths came to disagree in the first place, so the source is
+        grepped rather than trusted.
+        """
+        import pathlib
+
+        source = (pathlib.Path(__file__).resolve().parents[1]
+                  / "src" / "neo" / "context_gatherer.py").read_text()
+
+        assert "TEST_PENALTY = 0.4" in source
+        assert source.count("TEST_PENALTY = 0.4") == 1, (
+            "TEST_PENALTY is defined more than once -- the two scoring paths "
+            "are free to drift again"
+        )
+        assert 'rel.startswith("tests"' not in source, (
+            "the semantic path has re-grown its own is-a-test check instead "
+            "of calling is_test_path"
+        )

--- a/tests/test_test_file_demotion.py
+++ b/tests/test_test_file_demotion.py
@@ -43,6 +43,10 @@ def _score(path, tokens, *, demote):
     return score_candidate(path, 4000, tokens, _EMPTY, _ENTRY, demote_tests=demote)
 
 
+MIN_SCORE_THRESHOLD = __import__(
+    "neo.context_gatherer", fromlist=["x"]).MIN_SCORE_THRESHOLD
+
+
 class TestIsTestPath:
     @pytest.mark.parametrize("path", [
         "tests/test_engine.py",
@@ -155,11 +159,54 @@ class TestScoringDemotion:
             assert (_score(path, self._TOKENS, demote=True)
                     == _score(path, self._TOKENS, demote=False))
 
-    def test_demotion_is_off_by_default(self):
-        """The existing pure-scoring tests call `score_candidate` positionally
-        and must keep their meaning."""
-        assert (score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
-                == _score("tests/test_x.py", self._TOKENS, demote=False))
+    def test_demote_tests_is_required_and_keyword_only(self):
+        """It was briefly optional-defaulting-to-False, so that the existing
+        pure-scoring tests would not need editing.
+
+        That is a production default shaped around test convenience, and the
+        default was the buggy behaviour: the call site reads
+        `not prompt_targets_tests(...)`, so a forgotten argument fails OPEN
+        toward the defect being fixed. One production caller; no reason for a
+        default at all.
+        """
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS, _EMPTY, _ENTRY)
+        with pytest.raises(TypeError):
+            score_candidate("tests/test_x.py", 4000, self._TOKENS,
+                            _EMPTY, _ENTRY, True)
+
+
+class TestDemotionReRanksButNeverEvicts:
+    """`MIN_SCORE_THRESHOLD` drops a file from context entirely, and both
+    metrics used to justify this change -- rank of the first source file,
+    count of tests and docs in the top 10 -- improve monotonically when a file
+    DISAPPEARS. Neither could detect that cost, so it has to be pinned here.
+
+    Measured before the floor: a one-hit test file at depth 1 went 0.55 ->
+    0.19 against a 0.2 threshold. Not demoted; deleted.
+    """
+
+    _TOKENS = {"widget"}
+
+    def test_a_file_that_would_be_admitted_stays_admitted(self):
+        plain = _score("tests/test_widget.py", self._TOKENS, demote=False)
+        demoted = _score("tests/test_widget.py", self._TOKENS, demote=True)
+
+        assert plain >= MIN_SCORE_THRESHOLD
+        assert demoted >= MIN_SCORE_THRESHOLD, "the penalty evicted rather than re-ranked"
+        assert demoted < plain, "...but it must still rank lower"
+
+    def test_a_file_that_would_be_dropped_anyway_is_unaffected(self):
+        """The floor must not RESCUE a file the score already rejected."""
+        plain = _score("tests/deep/nested/test_x.py", set(), demote=False)
+        demoted = _score("tests/deep/nested/test_x.py", set(), demote=True)
+
+        assert plain < MIN_SCORE_THRESHOLD
+        assert demoted < MIN_SCORE_THRESHOLD
+
+    def test_the_floor_does_not_apply_to_non_test_files(self):
+        low = _score("src/neo/z.py", set(), demote=True)
+        assert low < MIN_SCORE_THRESHOLD
 
 
 class TestBothPathsShareOneRule:

--- a/tools/rank_eval.py
+++ b/tools/rank_eval.py
@@ -1,189 +1,97 @@
 #!/usr/bin/env python3
-"""File-selection retrieval evaluation: recall@k and MRR against ground truth.
+"""Rank-quality harness: recall@k against hand-labelled relevant files.
 
-    python tools/rank_eval.py --build-from-git . > cases.json
-    python tools/rank_eval.py --eval . cases.json
+Run: `python tools/rank_eval.py [k ...]` from the repo root.
 
-Why this exists: file ranking was tuned three times against metrics that could
-not judge it ("mean rank of the first source file", "count of tests and docs in
-the top 10"). Both reward ANY src/ file landing early regardless of relevance,
-both penalise a test file that is the correct answer, and both IMPROVE when a
-file is evicted from context entirely. Recall against labels has none of those
-properties.
+This exists because three separate attempts to improve file ranking were
+judged with metrics that could not judge them. The first two were "mean rank
+of the first source file" and "count of tests and docs in the top 10", and
+both are wrong in the same way: they reward ANY `src/` file landing early
+regardless of relevance, and they penalise a test file that is the correct
+answer. Measured live -- for "add a new CLI subcommand for exporting facts",
+one candidate change surfaced `tests/test_subcommands.py` and
+`src/neo/prompt/cli.py` (both relevant) and scored WORSE than a baseline whose
+top hits were `.pytest_cache/README.md`, `docs/mistakes.md` and
+`construct/README.md`.
 
-Labels come from git history -- commit subject as the query, changed non-test
-files as ground truth, keeping commits that touch 1-3 files. That is the
-standard construction in the bug-localization literature and it removes the two
-worst properties of a hand-written set: prompts chosen by the person evaluating
-the change, and labels that are that person's opinion.
+They are also blind to eviction: a file pushed below `MIN_SCORE_THRESHOLD`
+leaves context entirely, and both metrics IMPROVE when that happens.
 
-Report several k. Differences live at tight cutoffs, because per-file character
-caps mean a file at rank 3 contributes far more content than the same file at
-rank 9.
+Recall against labels has neither problem. The labels are the files a
+competent engineer would want in context for that prompt; they are opinions,
+but they are written down and arguable, which the previous metrics were not.
 
-Limits: commit subjects are terser and better-formed than real prompts; ground
-truth is what a commit CHANGED, a subset of what a developer needed to READ;
-content is read at HEAD while the commit is historical.
+**Report several k.** The interesting differences live at tight cutoffs,
+because per-file character caps mean a file at rank 3 contributes far more
+content than the same file at rank 9. A change can be flat at k=10 and still
+be a real improvement -- that is exactly the shape of the test-file demotion
+this harness was built to check.
 
-Diagnosis and plan: ~/git/working/2026-08-10-neo-file-selection-plan.md
+Limits, stated so the numbers are not over-read: 12 prompts, one repository,
+labels by one person, and recall ignores what else got in. It is a better
+instrument than a rank mean, not a good one.
 """
-
-import json
+import re
 import subprocess
 import sys
-import os
-import re
 
-def build(repo, max_commits=400, exts=(".py",".ts",".tsx",".js",".cs",".go",".rb",".php",".java")):
-    log = subprocess.run(
-        ["git","-C",repo,"log","--no-merges","-n",str(max_commits),
-         "--pretty=format:%H%x1f%s","--name-only"],
-        capture_output=True, text=True).stdout
-    cases=[]
-    for block in log.split("\n\n"):
-        lines = [ln for ln in block.strip().splitlines() if ln.strip()]
-        if not lines:
-            continue
-        head=lines[0]
-        if "\x1f" not in head:
-            continue
-        sha, subject = head.split("\x1f",1)
-        files=[f for f in lines[1:] if f.endswith(exts)]
-        files=[f for f in files if not re.search(r'(^|/)(tests?|spec)/|(^|/)test_|_test\.', f)]
-        # A usable case: a focused commit. Huge commits have no single answer;
-        # zero-file commits (docs-only) have no answer at all.
-        if 1 <= len(files) <= 3 and len(subject) > 15:
-            cases.append({"sha": sha, "query": subject, "files": sorted(set(files))})
-    return cases
+LABELLED = {
+ "add retry logic to the CAR adapter":
+   {"src/neo/adapters.py"},
+ "fix the fact store supersession threshold":
+   {"src/neo/memory/store.py"},
+ "why does the observer leak memory":
+   {"src/neo/memory/observer.py"},
+ "add a new CLI subcommand for exporting facts":
+   {"src/neo/subcommands.py", "src/neo/cli.py"},
+ "the transcript ingester is dropping episodes":
+   {"src/neo/memory/transcript.py"},
+ "the tree-sitter parser drops interfaces":
+   {"src/neo/index/language_parser.py"},
+ "context assembly exceeds the token budget":
+   {"src/neo/memory/context.py", "src/neo/text_budget.py"},
+ "episode promotion never fires":
+   {"src/neo/memory/store.py", "src/neo/memory/episodes.py"},
+ "the orchestrator emits no terminal event":
+   {"src/neo/events.py", "src/neo/engine.py"},
+ "fix the reasoning mode decision gate":
+   {"src/neo/reasoning_mode.py", "src/neo/engine.py"},
+ "prompt truncation markers are missing":
+   {"src/neo/text_budget.py", "src/neo/engine.py"},
+ "the A2UI inspector shows a stale fact count":
+   {"src/neo/a2ui.py"},
+}
 
-
-from collections import Counter  # noqa: E402
-from neo.context_gatherer import (iter_paths, extract_prompt_tokens, score_candidate,  # noqa: E402
-                                  get_git_recent_files)
-from neo.memory.bm25 import BM25  # noqa: E402
-
-ENTRY = {'main','app','server','index','login','auth','__init__'}
-_SPLIT = re.compile(r"[^A-Za-z0-9]+")
-_CAMEL = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
-
-def code_tokens(text):
-    """Code-aware tokenization: split identifiers on camelCase and separators,
-    and keep BOTH the whole identifier and its parts. The literature finds this
-    is what makes BM25 beat dense retrieval on code."""
-    out = []
-    for raw in _SPLIT.split(text):
-        if not raw:
-            continue
-        low = raw.lower()
-        out.append(low)
-        parts = [p.lower() for p in _CAMEL.split(raw) if p]
-        if len(parts) > 1:
-            out.extend(parts)
-    return out
-
-def load_corpus(root, cands, cap=200_000):
-    docs, paths = [], []
-    for abs_p, rel, size in cands:
-        try:
-            with open(abs_p, encoding="utf-8", errors="ignore") as f:
-                content = f.read(cap)
-        except OSError:
-            continue
-        # Path tokens are repeated so the filename still carries weight —
-        # a file named for the thing is real evidence, just not the only one.
-        docs.append(code_tokens(rel) * 3 + code_tokens(content))
-        paths.append(rel)
-    return docs, paths
-
-def rrf(rankings, k=60):
-    """Reciprocal rank fusion. Rank-based, so it needs no score normalization
-    and no weight tuning between channels on different scales."""
-    fused = Counter()
-    for ranked in rankings:
-        for i, p in enumerate(ranked):
-            fused[p] += 1.0 / (k + i + 1)
-    return [p for p, _ in fused.most_common()]
-
-def evaluate(root, cases, ks=(1,3,5,10,20)):
-    cands = iter_paths(root, [], [], None)
-    cands = [c for c in cands if c[1].endswith((".py",".ts",".tsx",".js",".cs",".go",".rb",".php",".java"))]
-    sizes = {rel: sz for _, rel, sz in cands}
-    gr = get_git_recent_files(root)
-    docs, paths = load_corpus(root, cands)
-    bm = BM25(docs)
-    try:
-        from neo.index.project_index import ProjectIndex
-        idx = ProjectIndex(root)
-        has_idx = bool(idx.chunks)
-    except Exception:
-        idx, has_idx = None, False
-
-    strategies = ["neo_current", "bm25_content", "dense", "rrf_bm25_dense"]
-    hits = {s: {k: 0.0 for k in ks} for s in strategies}
-    mrr = {s: 0.0 for s in strategies}
-    n = 0
-
-    for case in cases:
-        want = set(case["files"])
-        if not (want & set(paths)):
-            continue  # ground truth no longer in the tree
-        n += 1
-        q = case["query"]
-
-        toks = extract_prompt_tokens(q)
-        cur = sorted(((score_candidate(r, sizes[r], toks, gr, ENTRY), r) for _, r, _ in cands), reverse=True)
-        cur = [r for _, r in cur]
-
-        qt = code_tokens(q)
-        bs = bm.scores(qt)
-        bmr = [paths[i] for i in sorted(range(len(paths)), key=lambda i: -bs[i])]
-
-        if has_idx:
-            best = {}
-            for ch in idx.retrieve(q, 60):
-                p = os.path.relpath(ch.file_path, root) if os.path.isabs(ch.file_path) else ch.file_path
-                best[p] = max(best.get(p, 0.0), float(getattr(ch, "similarity", 0.0)))
-            dn = [p for p, _ in sorted(best.items(), key=lambda kv: -kv[1])]
-        else:
-            dn = []
-
-        ranked = {"neo_current": cur, "bm25_content": bmr, "dense": dn,
-                  "rrf_bm25_dense": rrf([bmr, dn]) if dn else bmr}
-        for s, r in ranked.items():
-            for k in ks:
-                hits[s][k] += len(want & set(r[:k])) / len(want)
-            pos = next((i + 1 for i, p in enumerate(r) if p in want), None)
-            mrr[s] += 1.0 / pos if pos else 0.0
-
-    print(f"  {n} evaluable cases (of {len(cases)})\n")
-    print(f"  {'strategy':<18}" + "".join(f"{'R@'+str(k):>8}" for k in ks) + f"{'MRR':>8}")
-    for s in strategies:
-        print(f"  {s:<18}" + "".join(f"{hits[s][k]/n:>8.3f}" for k in ks) + f"{mrr[s]/n:>8.3f}")
+def selected(prompt, k=10):
+    out = subprocess.run([sys.executable, "-m", "neo.cli", "--dry-run", "--no-git",
+                          prompt, "--cwd", "."], capture_output=True, text=True, timeout=300)
+    txt = out.stdout + out.stderr
+    body = txt.split("DRY RUN", 1)[-1]
+    paths = []
+    for line in body.splitlines():
+        m = re.match(r"^  (\S+?)(?: \(lines [\d-]+\))? - \d+ bytes", line)
+        if m and m.group(1) not in paths:
+            paths.append(m.group(1))
+    return paths[:k]
 
 
-def _cli() -> int:
-    import argparse
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--build-from-git", metavar="REPO",
-                    help="mine an eval set from that repo's git history, to stdout")
-    ap.add_argument("--eval", nargs=2, metavar=("REPO", "CASES"),
-                    help="evaluate strategies for REPO against a cases file")
-    args = ap.parse_args()
+def main() -> int:
+    ks = [int(a) for a in sys.argv[1:]] or [3, 5, 10, 20]
+    widest = max(ks)
+    cache = {p: selected(p, widest) for p in LABELLED}
 
-    if args.build_from_git:
-        cases = build(args.build_from_git)
-        print(json.dumps(cases, indent=1))
-        print(f"# {len(cases)} cases", file=sys.stderr)
-        return 0
-    if args.eval:
-        repo, casefile = args.eval
-        cases = [c for c in json.load(open(casefile))
-                 if not c["query"].lower().startswith("release ")]
-        evaluate(repo, cases)
-        return 0
-    ap.print_help()
-    return 1
+    for k in ks:
+        total = 0.0
+        misses = []
+        for prompt, want in LABELLED.items():
+            got = set(cache[prompt][:k])
+            total += len(want & got) / len(want)
+            if not (want & got):
+                misses.append(prompt)
+        print(f"  recall@{k:<3} = {total / len(LABELLED):.3f}"
+              f"   prompts with no relevant file: {len(misses)}")
+    return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(_cli())
+    raise SystemExit(main())

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -207,7 +207,23 @@ def mine_cases(repo: str, want: int, skip_recent: int, max_files: int) -> list[d
     return cases
 
 
-def assert_tree_is_effective(tree: str) -> None:
+def _git_head(path: str) -> str:
+    """Short HEAD, or a marker -- never an exception.
+
+    `--tree` is not required to be a git checkout, and stamping it must not be
+    able to destroy a run. Computed BEFORE the case loop for the same reason:
+    a `git worktree prune`d checkout still has `src/neo`, so it passes the
+    effectiveness guard, ranks all 50 cases, and only then discovers it cannot
+    be stamped -- ~100 seconds of subprocess work thrown away with a traceback
+    pointing at a string format instead of at the real problem.
+    """
+    try:
+        return _git(path, "rev-parse", "HEAD").strip()[:12]
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return "not-a-git-checkout"
+
+
+def assert_tree_is_effective(tree: str, repo: str) -> None:
     """Prove `--tree` actually won, rather than trusting that it did.
 
     Mandatory is not the same as effective. The venv's editable install is a
@@ -218,12 +234,20 @@ def assert_tree_is_effective(tree: str) -> None:
     against 0.082 error (superseded generation, see the module docstring),
     unguarded, inside the tool written to prevent it.
 
-    Caller MUST pass an absolute path. This resolves from the HARNESS's cwd
-    while `rank_files` hands the same string to a child running with
-    `cwd=repo`, so a relative `--tree` checks one directory and measures
-    another -- and Python drops a nonexistent `PYTHONPATH` entry without a
-    word, which leaves this guard green while the run uses the installed copy.
-    `main` absolutizes both paths before calling here.
+    Two ways this guard could check one directory while the run measured
+    another, both closed here, and the second is why it takes `repo`:
+
+    1. A RELATIVE `--tree` resolved against the harness's cwd while
+       `rank_files` handed the same string to a child running with `cwd=repo`.
+       Python drops a nonexistent `PYTHONPATH` entry without a word, so the
+       guard stayed green while the run used the installed copy. `main`
+       absolutizes both paths before calling here.
+    2. The PROBE must run from `cwd=repo`, exactly as `rank_files` does.
+       Python puts the cwd at `sys.path[0]`, AHEAD of `PYTHONPATH`, for both
+       `-c` and `-m` -- so a repo containing a top-level `neo/` package
+       shadows the named tree in the measurement while a probe run from
+       anywhere else sees nothing wrong. None of neo, car or quip has such a
+       directory today; a guard is the one place that is not an argument.
     """
     src = os.path.join(tree, "src")
     if not os.path.isdir(os.path.join(src, "neo")):
@@ -232,6 +256,7 @@ def assert_tree_is_effective(tree: str) -> None:
                          f"code twice")
     loaded = subprocess.run(
         [sys.executable, "-c", "import neo, sys; sys.stdout.write(neo.__file__)"],
+        cwd=repo,   # resolve imports the way the measurement does; see above
         env={**os.environ, "PYTHONPATH": src}, capture_output=True, text=True,
         timeout=120,
     ).stdout.strip()
@@ -359,7 +384,10 @@ def main() -> int:
     # put the guard green while both arms ran the installed copy.
     args.tree = os.path.abspath(args.tree)
     args.repo = os.path.abspath(args.repo)
-    assert_tree_is_effective(args.tree)
+    assert_tree_is_effective(args.tree, args.repo)
+    # Stamped up front: nothing about identifying the two inputs should be
+    # discoverable only after a 50-case run has already been spent.
+    repo_head, tree_head = _git_head(args.repo), _git_head(args.tree)
     cases = mine_cases(args.repo, args.cases, args.skip_recent, args.max_truth_files)
     if not cases:
         print("no eligible cases mined -- widen --max-truth-files or lower "
@@ -415,11 +443,11 @@ def main() -> int:
     # HEADs score different case sets. Without this stamp a delta between runs
     # cannot be attributed to the change under test rather than to the window
     # having moved -- which has already happened once on this branch.
-    result["repo_head"] = _git(args.repo, "rev-parse", "HEAD").strip()[:12]
+    result["repo_head"] = repo_head
     # And the TREE's revision, which is the object the two arms actually differ
     # by. `result["tree"]` is a mutable path, not a generation: it says where
     # the ranker was read from, never which ranker it was.
-    result["tree_head"] = _git(args.tree, "rev-parse", "HEAD").strip()[:12]
+    result["tree_head"] = tree_head
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -50,12 +50,18 @@ by two paths that are routine rather than exotic:
    the arm you care about most.
 
 So the default is to switch the leaking signal OFF. `neo --dry-run` already
-takes `--no-git`, which gates `git_recent` and nothing else -- `_history_boost`
-and every other re-rank channel stay live -- and `tools/rank_eval.py` has been
-passing it all along. Measuring with recency enabled costs a real signal
-(ablated at +0.021 R@10) but buys absolute numbers that are not partly an echo
-of the answer key, which is the better trade for an A/B whose whole purpose is
-comparing two rankers.
+takes `--no-git`, which gates `git_recent` and nothing else, and
+`tools/rank_eval.py` has been passing it all along. Turning it off costs a real
+signal (ablated at +0.021 R@10 on the superseded harness generation -- an
+unstamped figure, quoted here for scale, not as a current measurement) and buys
+absolute numbers that are not partly an echo of the answer key, which is the
+better trade for an A/B whose whole purpose is comparing two rankers.
+
+`_history_boost` and the other re-rank channels stay live under `--no-git`.
+That means UNGATED, not clean: `_history_boost` reads the FactStore, which past
+neo runs against this same repo populated. Different provenance, same family.
+CLAUDE.md measures its contribution as nil, so it is not moving these numbers,
+but do not read "stays live" as "is uncontaminated".
 
 `--with-git` re-enables it to measure the full shipped pipeline. That run is
 contaminated by construction, so it also reports `contaminated_cases` (ground
@@ -79,6 +85,17 @@ at HEAD. That keeps small, well-described, surviving implementation changes and
 discards broad refactors, test-only work, deleted and renamed-away files, and
 every commit whose author wrote a poor message. Read the result as a proxy for
 focused maintenance prompts, not as a fair sample of what a developer asks.
+
+**The leak that no flag removes.** Cases are queried with a commit subject and
+scored against the files as they exist at HEAD -- that is, AFTER that commit
+landed. The subject's terms are in the file partly because the commit put them
+there, so the ranker is reading a corpus that has already seen the answer.
+BugLocator, cited approvingly by the module this measures, indexes the pre-fix
+snapshot for exactly this reason; this harness does not. `--no-git` does
+nothing about it. Both arms inherit it, so the direction survives -- but it is
+why the absolutes remain upper bounds even at the default, and it is the reason
+not to read a headline R@10 as "the ranker finds the right file 74% of the
+time" on prompts written before the work exists.
 
 Then the metric's own validity: a commit subject is terser and better-formed
 than a real prompt, and ground truth is what the commit CHANGED, which is
@@ -117,6 +134,35 @@ _SKIP_SUBJECT_RE = re.compile(
 _DRY_RUN_LINE = re.compile(r"^\s{2}(\S.*?)(?:\s+\(lines\s[\d-]+\))?\s+-\s+[\d,]+\s+bytes")
 
 
+def is_skippable(subject: str) -> bool:
+    """A subject that names no work is not a query.
+
+    The prefix strip and the skip test live TOGETHER here rather than being
+    composed at the call site: `chore: bump version to 0.39.0` was mined as a
+    real case because `_SKIP_SUBJECT_RE` anchors at `^` and the conventional
+    prefix sat in front of it. Composed at the call site, a test can only pin
+    the composition it performs itself, which stays green while `mine_cases`
+    drops the strip.
+
+    Tested BOTH ways round, because some skip words are themselves valid
+    conventional-commit types: `revert: the thing that broke prod` and `wip:
+    still figuring this out` have their own skip word consumed as a prefix and
+    read as ordinary work on the stripped subject alone. A revert's changed
+    files are a removal, which is not ground truth for its own subject.
+    """
+    stripped = _CONVENTIONAL_PREFIX_RE.sub("", subject)
+    return bool(_SKIP_SUBJECT_RE.match(subject) or _SKIP_SUBJECT_RE.match(stripped))
+
+
+def is_ground_truth(path: str, head_files: set[str]) -> bool:
+    """Whether a changed file counts as an answer for the case it came from."""
+    return (
+        path in head_files                               # still exists to be found
+        and os.path.splitext(path)[1] in _SOURCE_EXTS
+        and not _TEST_RE.search(path)                    # demoted by design
+    )
+
+
 def _git(repo: str, *args: str) -> str:
     # Timeout so a hung git (a lock, a prompting credential helper) fails the
     # run instead of parking it forever with no output.
@@ -142,18 +188,11 @@ def mine_cases(repo: str, want: int, skip_recent: int, max_files: int) -> list[d
             continue
         sha, subject = line.split("\x1f", 1)
         subject = subject.strip()
-        if len(subject) < 20 or _SKIP_SUBJECT_RE.match(
-            _CONVENTIONAL_PREFIX_RE.sub("", subject)
-        ):
+        if len(subject) < 20 or is_skippable(subject):
             continue
 
         changed = _git(repo, "show", "--name-only", "--format=", sha).splitlines()
-        truth = {
-            f for f in changed
-            if f in head_files                       # still exists to be found
-            and os.path.splitext(f)[1] in _SOURCE_EXTS
-            and not _TEST_RE.search(f)
-        }
+        truth = {f for f in changed if is_ground_truth(f, head_files)}
         # A 40-file sweep commit is one case with 40 equal answers -- noise, not
         # a query anyone would type. A 0-file case has nothing to find.
         if not 1 <= len(truth) <= max_files:
@@ -165,11 +204,42 @@ def mine_cases(repo: str, want: int, skip_recent: int, max_files: int) -> list[d
     return cases
 
 
+def assert_tree_is_effective(tree: str) -> None:
+    """Prove `--tree` actually won, rather than trusting that it did.
+
+    Mandatory is not the same as effective. The venv's editable install is a
+    `.pth` naming this checkout, so a `--tree` that points at a typo, a pruned
+    worktree or one directory too high does not fail -- `import neo` quietly
+    falls through to the working tree, BOTH arms run the same code, and the run
+    completes with a full ranking and `failed_cases: 0`. That is the 0.613
+    against 0.082 error, unguarded, inside the tool written to prevent it.
+    """
+    src = os.path.join(tree, "src")
+    if not os.path.isdir(os.path.join(src, "neo")):
+        raise SystemExit(f"--tree {tree!r} has no src/neo -- it would silently "
+                         f"fall back to the installed copy and measure the same "
+                         f"code twice")
+    loaded = subprocess.run(
+        [sys.executable, "-c", "import neo, sys; sys.stdout.write(neo.__file__)"],
+        env={**os.environ, "PYTHONPATH": src}, capture_output=True, text=True,
+        timeout=120,
+    ).stdout.strip()
+    if not loaded.startswith(os.path.realpath(src)) and \
+            not loaded.startswith(src):
+        raise SystemExit(f"--tree {tree!r} did not take effect: `import neo` "
+                         f"resolved to {loaded!r}. Every figure from this run "
+                         f"would describe that tree, not the one you named.")
+
+
 def recent_files(repo: str, window: int = 50) -> set[str]:
     """The recency set the scorer actually reads -- history AND working tree.
 
     Mirrors `context_gatherer.get_git_recent_files` so a run can report how much
-    of its own ground truth the scorer was handed for free.
+    of its own ground truth the scorer was handed for free. `window` MUST match
+    that function's hardcoded `-50`; it is deliberately not wired to
+    `--skip-recent`, which is a different quantity (how far back to start
+    mining). Passing the latter here under-reports contamination whenever it is
+    lowered -- an error in the flattering direction.
     """
     recent = set()
     for line in _git(repo, "status", "--porcelain").splitlines():
@@ -271,6 +341,7 @@ def main() -> int:
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
 
+    assert_tree_is_effective(args.tree)
     cases = mine_cases(args.repo, args.cases, args.skip_recent, args.max_truth_files)
     if not cases:
         print("no eligible cases mined -- widen --max-truth-files or lower "
@@ -293,11 +364,24 @@ def main() -> int:
               "CLI invocation", file=sys.stderr)
         return 1
 
+    # Fail-closed on the HEADER is not enough. A per-line format change keeps
+    # the banner and parses to nothing, so every case returns [] and the run
+    # reports a confident R@10 0.000 with failed_cases: 0 -- "scored every case
+    # zero" coming back through a different door. A live trigger exists today:
+    # the CLI's second dry-run printer emits ABSOLUTE paths, which parse fine
+    # and match no repo-relative ground truth. Nothing parsed anywhere is a
+    # broken instrument, never a result.
+    if not any(scored_ranks):
+        print("the CLI ran and the DRY RUN banner was found, but NOT ONE case "
+              "yielded a parsable file line -- the output format has moved. "
+              "This is a parser failure, not a score of zero.", file=sys.stderr)
+        return 1
+
     # Only meaningful when the recency signal is live; with --no-git the scorer
     # never reads it, so reporting a count would imply a leak that cannot occur.
     contaminated = dirty = None
     if args.with_git:
-        recent = recent_files(args.repo, args.skip_recent)
+        recent = recent_files(args.repo)   # the scorer's window, not --skip-recent
         contaminated = sum(1 for c in scored_cases if set(c["truth"]) & recent)
         dirty = bool(_git(args.repo, "status", "--porcelain").strip())
 
@@ -309,6 +393,11 @@ def main() -> int:
     result["repo"] = args.repo
     result["tree"] = args.tree
     result["skip_recent"] = args.skip_recent
+    # --skip-recent counts back from HEAD, so two arms measured at different
+    # HEADs score different case sets. Without this stamp a delta between runs
+    # cannot be attributed to the change under test rather than to the window
+    # having moved -- which has already happened once on this branch.
+    result["repo_head"] = _git(args.repo, "rev-parse", "HEAD").strip()[:12]
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -49,12 +49,19 @@ by two paths that are routine rather than exotic:
    branch you are editing, from the tree you are editing it in, contaminates
    the arm you care about most.
 
-So this tool MEASURES the leak instead of asserting it away: every run reports
-`contaminated_cases` (cases whose ground truth intersects the live recent set)
-and refuses to stay quiet about a dirty tree. Run it on a clean checkout, and
-read the absolute figures as an upper bound on any run where that count is not
-zero. Both arms inherit the leak, so direction is the robust part -- but
-"direction survives" is not a licence to quote the magnitudes.
+So the default is to switch the leaking signal OFF. `neo --dry-run` already
+takes `--no-git`, which gates `git_recent` and nothing else -- `_history_boost`
+and every other re-rank channel stay live -- and `tools/rank_eval.py` has been
+passing it all along. Measuring with recency enabled costs a real signal
+(ablated at +0.021 R@10) but buys absolute numbers that are not partly an echo
+of the answer key, which is the better trade for an A/B whose whole purpose is
+comparing two rankers.
+
+`--with-git` re-enables it to measure the full shipped pipeline. That run is
+contaminated by construction, so it also reports `contaminated_cases` (ground
+truth intersecting the live recent set) and warns on a dirty tree; read its
+absolutes as upper bounds. Both arms inherit the leak, so direction survives --
+but "direction survives" is not a licence to quote the magnitudes.
 
 **Recall@k and hit-rate@k are different questions and are both reported.**
 A case whose commit changed 4 files scores 0.25 recall on one hit and 1.0 hit
@@ -111,8 +118,11 @@ _DRY_RUN_LINE = re.compile(r"^\s{2}(\S.*?)(?:\s+\(lines\s[\d-]+\))?\s+-\s+[\d,]+
 
 
 def _git(repo: str, *args: str) -> str:
+    # Timeout so a hung git (a lock, a prompting credential helper) fails the
+    # run instead of parking it forever with no output.
     return subprocess.run(
-        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+        timeout=120,
     ).stdout
 
 
@@ -171,7 +181,8 @@ def recent_files(repo: str, window: int = 50) -> set[str]:
     return {f for f in recent if f}
 
 
-def rank_files(repo: str, tree: str, query: str, timeout: int) -> Optional[list[str]]:
+def rank_files(repo: str, tree: str, query: str, timeout: int,
+               use_git: bool = False) -> Optional[list[str]]:
     """The ranked, de-duplicated file list the model would have been sent.
 
     Returns None for a run that FAILED and [] for one that completed and chose
@@ -190,8 +201,11 @@ def rank_files(repo: str, tree: str, query: str, timeout: int) -> Optional[list[
         # stderr is MERGED, not discarded: the CLI writes its progress notices
         # AND the dry-run listing to stderr, so reading stdout alone returns an
         # empty ranking for every case and scores a working pipeline at zero.
+        cmd = [sys.executable, "-m", "neo.cli", "--dry-run"]
+        if not use_git:
+            cmd.append("--no-git")     # gates git_recent only; see module docstring
         proc = subprocess.run(
-            [sys.executable, "-m", "neo.cli", "--dry-run", query],
+            [*cmd, query],
             cwd=repo, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             text=True, timeout=timeout,
         )
@@ -247,43 +261,26 @@ def main() -> int:
                     help="commits to skip so ground truth stays outside the "
                          "git-recency window the scorer reads (default 50)")
     ap.add_argument("--max-truth-files", type=int, default=5)
-    ap.add_argument("--drop-contaminated", action="store_true",
-                    help="score only cases whose ground truth is OUTSIDE the "
-                         "scorer's recent-file set. Shrinks the sample -- often "
-                         "sharply, because central files are edited often and are "
-                         "also the likeliest ground truth -- in exchange for "
-                         "absolute figures that mean what they say")
+    ap.add_argument("--with-git", action="store_true",
+                    help="measure the full shipped pipeline, recency signal "
+                         "included. Off by default because that signal is fed "
+                         "the answer key: the run is contaminated by "
+                         "construction and its absolutes are upper bounds")
     ap.add_argument("--timeout", type=int, default=180)
     ap.add_argument("--k", type=int, nargs="+", default=[1, 3, 10])
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
 
-    # Mined BEFORE the contamination filter, so --drop-contaminated still gets
-    # a full-sized sample to select from rather than a filtered remnant.
-    over_mine = args.cases * 4 if args.drop_contaminated else args.cases
-    cases = mine_cases(args.repo, over_mine, args.skip_recent, args.max_truth_files)
-    if args.drop_contaminated:
-        recent_now = recent_files(args.repo, args.skip_recent)
-        cases = [c for c in cases if not (set(c["truth"]) & recent_now)][: args.cases]
+    cases = mine_cases(args.repo, args.cases, args.skip_recent, args.max_truth_files)
     if not cases:
-        # Naming the wrong knob is its own defect: these two emptinesses have
-        # nothing to do with each other, and only one of them is a settings problem.
-        if args.drop_contaminated:
-            print("every mined case was dropped as contaminated: all of their "
-                  "ground truth sits in the scorer's recent-file set. On a repo "
-                  "whose churn concentrates in a few central files this is the "
-                  "expected outcome, and it means absolute figures here cannot "
-                  "be decontaminated by sampling -- raise --skip-recent to widen "
-                  "the gap, or drop the flag and read the figures as bounds.",
-                  file=sys.stderr)
-        else:
-            print("no eligible cases mined -- widen --max-truth-files or lower "
-                  "--skip-recent", file=sys.stderr)
+        print("no eligible cases mined -- widen --max-truth-files or lower "
+              "--skip-recent", file=sys.stderr)
         return 1
 
     raw = []
     for i, case in enumerate(cases, start=1):
-        raw.append(rank_files(args.repo, args.tree, case["query"], args.timeout))
+        raw.append(rank_files(args.repo, args.tree, case["query"], args.timeout,
+                              use_git=args.with_git))
         print(f"  {i}/{len(cases)}", end="\r", file=sys.stderr, flush=True)
 
     # A failed case is DROPPED, not scored as a zero. Scoring it would let a
@@ -296,12 +293,17 @@ def main() -> int:
               "CLI invocation", file=sys.stderr)
         return 1
 
-    recent = recent_files(args.repo, args.skip_recent)
-    contaminated = sum(1 for c in scored_cases if set(c["truth"]) & recent)
-    dirty = bool(_git(args.repo, "status", "--porcelain").strip())
+    # Only meaningful when the recency signal is live; with --no-git the scorer
+    # never reads it, so reporting a count would imply a leak that cannot occur.
+    contaminated = dirty = None
+    if args.with_git:
+        recent = recent_files(args.repo, args.skip_recent)
+        contaminated = sum(1 for c in scored_cases if set(c["truth"]) & recent)
+        dirty = bool(_git(args.repo, "status", "--porcelain").strip())
 
     result = score(scored_cases, scored_ranks, sorted(args.k))
     result["failed_cases"] = failed
+    result["git_recency"] = bool(args.with_git)
     result["contaminated_cases"] = contaminated
     result["repo_dirty"] = dirty
     result["repo"] = args.repo
@@ -311,8 +313,9 @@ def main() -> int:
     if args.json:
         print(json.dumps(result, indent=2))
     else:
-        print(f"\nrepo={args.repo}  tree={args.tree}  "
-              f"cases={result['cases']}  skip_recent={args.skip_recent}")
+        print(f"\nrepo={args.repo}  tree={args.tree}  cases={result['cases']}  "
+              f"skip_recent={args.skip_recent}  "
+              f"git_recency={'ON' if args.with_git else 'off (--no-git)'}")
         if failed:
             print(f"  WARNING: {failed} case(s) failed (timeout or non-zero exit) "
                   f"and were DROPPED, not scored")

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Rank-quality harness: git-mined cases, scored through the REAL CLI.
+
+Run: `python tools/rank_mine_eval.py --repo /path/to/repo --tree /path/to/tree`
+
+This is the harness behind the cross-repo R@k / MRR figures. It is separate
+from `tools/rank_eval.py` on purpose, and the two are NOT interchangeable:
+
+    rank_eval.py       12 hand-labelled prompts, THIS repo, recall@k only.
+                       Labels are opinions, written down and arguable.
+    rank_mine_eval.py  Cases mined from git history, ANY repo, R@k + MRR.
+                       Ground truth is what a commit actually changed.
+
+Quoting a number from one under the other's name is the "same label, different
+instrument" failure this branch spent a review round untangling -- `car` once
+appeared as both 0.969 and 0.507 for what was called the same quantity. Every
+figure this tool prints carries the generation stamp in its header; keep them
+together when you copy a table out.
+
+Two traps, both hit while this work was being done, both of which produced
+confident wrong numbers:
+
+1. **The venv installs neo EDITABLE against `src/`.** Running the CLI from a
+   worktree of another commit executes THIS tree's code against THAT tree's
+   files. A "baseline" run that is not the baseline: it made main look like
+   MRR 0.613 when its real figure is 0.082. `--tree` is therefore mandatory
+   and is exported as `PYTHONPATH`; there is no default.
+2. **`score_candidate` is not the pipeline.** `gather_context` re-ranks with
+   `pi_boost + hist_boost + _symbol_score`, then applies an adaptive limit and
+   a byte budget -- exactly the stages that decide the tight cutoffs. An
+   in-process replica overstated R@10 by 0.14. This tool shells out to
+   `neo --dry-run` and parses what the model would actually have been sent.
+   That costs ~2 s per case and is the only honest way to run it.
+
+**Recency contamination: reduced, NOT removed. Read this before quoting a number.**
+`get_git_recent_files` feeds the scorer the files touched by the last 50
+commits PLUS everything dirty in `git status --porcelain`. Mining a case from
+inside that window hands the scorer its own answer key. `--skip-recent`
+(default 50) starts mining below the window, which removes the direct hit --
+and an earlier version of this docstring claimed that settled it. It does not,
+by two paths that are routine rather than exotic:
+
+1. **The recency signal stores paths, not commits.** A case mined at commit 80
+   whose truth file was touched AGAIN in commit 10 is back in the recent set.
+   Central files are edited often, so the leak concentrates on exactly the
+   files most likely to be ground truth.
+2. **A dirty working tree leaks regardless of history.** Editing a file puts it
+   in `git status --porcelain`, and it collects the same boost. Measuring the
+   branch you are editing, from the tree you are editing it in, contaminates
+   the arm you care about most.
+
+So this tool MEASURES the leak instead of asserting it away: every run reports
+`contaminated_cases` (cases whose ground truth intersects the live recent set)
+and refuses to stay quiet about a dirty tree. Run it on a clean checkout, and
+read the absolute figures as an upper bound on any run where that count is not
+zero. Both arms inherit the leak, so direction is the robust part -- but
+"direction survives" is not a licence to quote the magnitudes.
+
+**Recall@k and hit-rate@k are different questions and are both reported.**
+A case whose commit changed 4 files scores 0.25 recall on one hit and 1.0 hit
+rate. "Finds the correct file in the top 10 N% of the time" is the hit rate;
+"R@10" in the tables is recall. They diverge most on exactly the multi-file
+commits that matter, so reporting one alone invites the reader to hear the
+other.
+
+Limits, stated so the numbers are not over-read.
+
+The population is filtered, and every filter biases the same way -- UPWARD.
+Cases must have a subject of 20+ characters that is not a merge, revert, WIP
+or version bump; 1 to 5 changed source files; and those files must still exist
+at HEAD. That keeps small, well-described, surviving implementation changes and
+discards broad refactors, test-only work, deleted and renamed-away files, and
+every commit whose author wrote a poor message. Read the result as a proxy for
+focused maintenance prompts, not as a fair sample of what a developer asks.
+
+Then the metric's own validity: a commit subject is terser and better-formed
+than a real prompt, and ground truth is what the commit CHANGED, which is
+neither all the files needed to understand the task nor necessarily the only
+relevant ones. These are change-set retrieval figures, not a measure of
+developer-context quality.
+
+It is a better instrument than a hand-labelled dozen, not a good one.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+# Ground truth is source the commit changed. Tests are excluded because the
+# scorer deliberately demotes them (a test file is a lexical superset of its
+# subject), so counting them as answers would score the demotion as a defect.
+_TEST_RE = re.compile(r"(^|/)(tests?|spec|__tests__)/|(^|/)test_|_test\.|\.spec\.|\.test\.")
+_SOURCE_EXTS = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".cs", ".go", ".rs", ".java",
+    ".rb", ".swift", ".kt", ".c", ".h", ".cc", ".cpp", ".hpp", ".m", ".mm",
+}
+# A subject that names no work ("bump version to 1.2.3") is not a query. The
+# conventional-commit prefix is stripped FIRST: anchoring at `^` alone let
+# "chore: bump version to 0.39.0" through, and it was mined as a real case.
+_CONVENTIONAL_PREFIX_RE = re.compile(r"^\w+(\([^)]*\))?!?:\s*")
+_SKIP_SUBJECT_RE = re.compile(
+    r"^(merge|revert|bump|release|v?\d+\.\d+\.\d+|wip\b|fixup!|squash!)", re.I
+)
+
+# One selected-file line of `--dry-run` output:
+#   "  src/neo/memory/store.py (lines 1-140) - 6183 bytes (score: 4.23)"
+_DRY_RUN_LINE = re.compile(r"^\s{2}(\S.*?)(?:\s+\(lines\s[\d-]+\))?\s+-\s+[\d,]+\s+bytes")
+
+
+def _git(repo: str, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+
+
+def mine_cases(repo: str, want: int, skip_recent: int, max_files: int) -> list[dict]:
+    """Walk back from HEAD~skip_recent collecting (subject, changed source) pairs.
+
+    Deterministic: the same repo at the same HEAD yields the same cases, which
+    is what lets an A/B compare two trees rather than two samples.
+    """
+    head_files = set(_git(repo, "ls-files").splitlines())
+    log = _git(repo, "log", "--no-merges", "--format=%H\x1f%s",
+               f"--skip={skip_recent}", "-n", str(want * 12))
+
+    cases = []
+    for line in log.splitlines():
+        if "\x1f" not in line:
+            continue
+        sha, subject = line.split("\x1f", 1)
+        subject = subject.strip()
+        if len(subject) < 20 or _SKIP_SUBJECT_RE.match(
+            _CONVENTIONAL_PREFIX_RE.sub("", subject)
+        ):
+            continue
+
+        changed = _git(repo, "show", "--name-only", "--format=", sha).splitlines()
+        truth = {
+            f for f in changed
+            if f in head_files                       # still exists to be found
+            and os.path.splitext(f)[1] in _SOURCE_EXTS
+            and not _TEST_RE.search(f)
+        }
+        # A 40-file sweep commit is one case with 40 equal answers -- noise, not
+        # a query anyone would type. A 0-file case has nothing to find.
+        if not 1 <= len(truth) <= max_files:
+            continue
+
+        cases.append({"sha": sha, "query": subject, "truth": sorted(truth)})
+        if len(cases) >= want:
+            break
+    return cases
+
+
+def recent_files(repo: str, window: int = 50) -> set[str]:
+    """The recency set the scorer actually reads -- history AND working tree.
+
+    Mirrors `context_gatherer.get_git_recent_files` so a run can report how much
+    of its own ground truth the scorer was handed for free.
+    """
+    recent = set()
+    for line in _git(repo, "status", "--porcelain").splitlines():
+        if len(line) > 3:
+            recent.add(line[3:].strip())
+    recent.update(
+        _git(repo, "log", f"-{window}", "--name-only", "--format=").splitlines()
+    )
+    return {f for f in recent if f}
+
+
+def rank_files(repo: str, tree: str, query: str, timeout: int) -> Optional[list[str]]:
+    """The ranked, de-duplicated file list the model would have been sent.
+
+    Returns None for a run that FAILED and [] for one that completed and chose
+    nothing. Collapsing those was the earlier behaviour and it is the failure
+    mode this whole branch exists to stop: a timeout, a crash or a renamed
+    heading would have scored as perfect-zero retrieval and averaged into the
+    table as evidence about ranking quality.
+    """
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.path.join(tree, "src"),   # trap 1; not optional
+        "NEO_OBSERVER_AUTOSTART": "0",             # don't spawn a daemon per case
+        "NEO_PROFILE": "off",                      # don't write metrics per case
+    }
+    try:
+        # stderr is MERGED, not discarded: the CLI writes its progress notices
+        # AND the dry-run listing to stderr, so reading stdout alone returns an
+        # empty ranking for every case and scores a working pipeline at zero.
+        proc = subprocess.run(
+            [sys.executable, "-m", "neo.cli", "--dry-run", query],
+            cwd=repo, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+    # Fail closed on both counts: a non-zero exit is not an empty ranking, and
+    # a missing marker means the format moved under us, not that nothing matched.
+    if proc.returncode != 0 or "=== DRY RUN" not in proc.stdout:
+        return None
+    out = proc.stdout
+    ranked: list[str] = []
+    for line in out.split("=== DRY RUN", 1)[1].splitlines():
+        m = _DRY_RUN_LINE.match(line)
+        if m:
+            path = m.group(1).strip()
+            if path not in ranked:      # a file chunked twice is one file
+                ranked.append(path)
+    return ranked
+
+
+def score(cases: list[dict], ranked_per_case: list[list[str]], ks: list[int]) -> dict:
+    recall = {k: 0.0 for k in ks}
+    hit = {k: 0.0 for k in ks}
+    rr = 0.0
+    for case, ranked in zip(cases, ranked_per_case):
+        truth = set(case["truth"])
+        for k in ks:
+            found = truth & set(ranked[:k])
+            recall[k] += len(found) / len(truth)
+            hit[k] += 1.0 if found else 0.0
+        for i, path in enumerate(ranked, start=1):
+            if path in truth:
+                rr += 1.0 / i
+                break
+    n = len(cases) or 1
+    return {
+        "cases": len(cases),
+        "recall": {f"R@{k}": round(recall[k] / n, 3) for k in ks},
+        "hit_rate": {f"H@{k}": round(hit[k] / n, 3) for k in ks},
+        "MRR": round(rr / n, 3),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--repo", required=True, help="repository to mine and rank in")
+    ap.add_argument("--tree", required=True,
+                    help="neo source tree to execute (exported as PYTHONPATH; "
+                         "an editable venv install will otherwise run THIS tree)")
+    ap.add_argument("--cases", type=int, default=50)
+    ap.add_argument("--skip-recent", type=int, default=50,
+                    help="commits to skip so ground truth stays outside the "
+                         "git-recency window the scorer reads (default 50)")
+    ap.add_argument("--max-truth-files", type=int, default=5)
+    ap.add_argument("--drop-contaminated", action="store_true",
+                    help="score only cases whose ground truth is OUTSIDE the "
+                         "scorer's recent-file set. Shrinks the sample -- often "
+                         "sharply, because central files are edited often and are "
+                         "also the likeliest ground truth -- in exchange for "
+                         "absolute figures that mean what they say")
+    ap.add_argument("--timeout", type=int, default=180)
+    ap.add_argument("--k", type=int, nargs="+", default=[1, 3, 10])
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    # Mined BEFORE the contamination filter, so --drop-contaminated still gets
+    # a full-sized sample to select from rather than a filtered remnant.
+    over_mine = args.cases * 4 if args.drop_contaminated else args.cases
+    cases = mine_cases(args.repo, over_mine, args.skip_recent, args.max_truth_files)
+    if args.drop_contaminated:
+        recent_now = recent_files(args.repo, args.skip_recent)
+        cases = [c for c in cases if not (set(c["truth"]) & recent_now)][: args.cases]
+    if not cases:
+        # Naming the wrong knob is its own defect: these two emptinesses have
+        # nothing to do with each other, and only one of them is a settings problem.
+        if args.drop_contaminated:
+            print("every mined case was dropped as contaminated: all of their "
+                  "ground truth sits in the scorer's recent-file set. On a repo "
+                  "whose churn concentrates in a few central files this is the "
+                  "expected outcome, and it means absolute figures here cannot "
+                  "be decontaminated by sampling -- raise --skip-recent to widen "
+                  "the gap, or drop the flag and read the figures as bounds.",
+                  file=sys.stderr)
+        else:
+            print("no eligible cases mined -- widen --max-truth-files or lower "
+                  "--skip-recent", file=sys.stderr)
+        return 1
+
+    raw = []
+    for i, case in enumerate(cases, start=1):
+        raw.append(rank_files(args.repo, args.tree, case["query"], args.timeout))
+        print(f"  {i}/{len(cases)}", end="\r", file=sys.stderr, flush=True)
+
+    # A failed case is DROPPED, not scored as a zero. Scoring it would let a
+    # broken subprocess masquerade as a ranking result.
+    failed = sum(1 for r in raw if r is None)
+    scored_cases = [c for c, r in zip(cases, raw) if r is not None]
+    scored_ranks = [r for r in raw if r is not None]
+    if not scored_cases:
+        print("every case failed to produce a ranking -- check --tree and the "
+              "CLI invocation", file=sys.stderr)
+        return 1
+
+    recent = recent_files(args.repo, args.skip_recent)
+    contaminated = sum(1 for c in scored_cases if set(c["truth"]) & recent)
+    dirty = bool(_git(args.repo, "status", "--porcelain").strip())
+
+    result = score(scored_cases, scored_ranks, sorted(args.k))
+    result["failed_cases"] = failed
+    result["contaminated_cases"] = contaminated
+    result["repo_dirty"] = dirty
+    result["repo"] = args.repo
+    result["tree"] = args.tree
+    result["skip_recent"] = args.skip_recent
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"\nrepo={args.repo}  tree={args.tree}  "
+              f"cases={result['cases']}  skip_recent={args.skip_recent}")
+        if failed:
+            print(f"  WARNING: {failed} case(s) failed (timeout or non-zero exit) "
+                  f"and were DROPPED, not scored")
+        if contaminated:
+            print(f"  WARNING: {contaminated}/{result['cases']} case(s) have ground "
+                  f"truth inside the scorer's recent-file set; absolute figures "
+                  f"are an upper bound")
+        if dirty:
+            print("  WARNING: working tree is dirty -- every modified path is in "
+                  "the recency signal. Re-run on a clean checkout before quoting.")
+        print(f"  recall   {result['recall']}")
+        print(f"  hit rate {result['hit_rate']}")
+        print(f"  MRR      {result['MRR']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -23,8 +23,11 @@ confident wrong numbers:
 1. **The venv installs neo EDITABLE against `src/`.** Running the CLI from a
    worktree of another commit executes THIS tree's code against THAT tree's
    files. A "baseline" run that is not the baseline: it made main look like
-   MRR 0.613 when its real figure is 0.082. `--tree` is therefore mandatory
-   and is exported as `PYTHONPATH`; there is no default.
+   MRR 0.613 against a real figure of 0.082 -- both SUPERSEDED-generation
+   numbers, quoted for the size of the error and not as measurements, since
+   this harness puts main's neo MRR at 0.304. `--tree` is therefore mandatory,
+   is made absolute before use, is checked against what `import neo` actually
+   resolves to, and is exported as `PYTHONPATH`; there is no default.
 2. **`score_candidate` is not the pipeline.** `gather_context` re-ranks with
    `pi_boost + hist_boost + _symbol_score`, then applies an adaptive limit and
    a byte budget -- exactly the stages that decide the tight cutoffs. An
@@ -212,7 +215,15 @@ def assert_tree_is_effective(tree: str) -> None:
     worktree or one directory too high does not fail -- `import neo` quietly
     falls through to the working tree, BOTH arms run the same code, and the run
     completes with a full ranking and `failed_cases: 0`. That is the 0.613
-    against 0.082 error, unguarded, inside the tool written to prevent it.
+    against 0.082 error (superseded generation, see the module docstring),
+    unguarded, inside the tool written to prevent it.
+
+    Caller MUST pass an absolute path. This resolves from the HARNESS's cwd
+    while `rank_files` hands the same string to a child running with
+    `cwd=repo`, so a relative `--tree` checks one directory and measures
+    another -- and Python drops a nonexistent `PYTHONPATH` entry without a
+    word, which leaves this guard green while the run uses the installed copy.
+    `main` absolutizes both paths before calling here.
     """
     src = os.path.join(tree, "src")
     if not os.path.isdir(os.path.join(src, "neo")):
@@ -341,6 +352,13 @@ def main() -> int:
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
 
+    # Absolute BEFORE anything reads them. Both are handed to children running
+    # with `cwd=repo`, while the guard below resolves them from the HARNESS's
+    # cwd -- so `--repo ~/git/car --tree .` checked one directory and measured
+    # another, and Python drops a nonexistent PYTHONPATH entry silently, which
+    # put the guard green while both arms ran the installed copy.
+    args.tree = os.path.abspath(args.tree)
+    args.repo = os.path.abspath(args.repo)
     assert_tree_is_effective(args.tree)
     cases = mine_cases(args.repo, args.cases, args.skip_recent, args.max_truth_files)
     if not cases:
@@ -398,11 +416,18 @@ def main() -> int:
     # cannot be attributed to the change under test rather than to the window
     # having moved -- which has already happened once on this branch.
     result["repo_head"] = _git(args.repo, "rev-parse", "HEAD").strip()[:12]
+    # And the TREE's revision, which is the object the two arms actually differ
+    # by. `result["tree"]` is a mutable path, not a generation: it says where
+    # the ranker was read from, never which ranker it was.
+    result["tree_head"] = _git(args.tree, "rev-parse", "HEAD").strip()[:12]
 
     if args.json:
         print(json.dumps(result, indent=2))
     else:
-        print(f"\nrepo={args.repo}  tree={args.tree}  cases={result['cases']}  "
+        # The generation stamp belongs in the header people copy tables out of,
+        # not only in --json.
+        print(f"\nrepo={args.repo}@{result['repo_head']}  "
+              f"tree={args.tree}@{result['tree_head']}  cases={result['cases']}  "
               f"skip_recent={args.skip_recent}  "
               f"git_recency={'ON' if args.with_git else 'off (--no-git)'}")
         if failed:

--- a/tools/rank_mine_eval.py
+++ b/tools/rank_mine_eval.py
@@ -216,8 +216,16 @@ def _git_head(path: str) -> str:
     effectiveness guard, ranks all 50 cases, and only then discovers it cannot
     be stamped -- ~100 seconds of subprocess work thrown away with a traceback
     pointing at a string format instead of at the real problem.
+
+    `rev-parse` searches ANCESTORS, so a non-git tree sitting inside a checkout
+    would stamp that enclosing checkout's sha -- a confidently wrong label on
+    the field whose whole point is saying which ranker ran. Compared against
+    `--show-toplevel` so only the path itself counts.
     """
     try:
+        top = _git(path, "rev-parse", "--show-toplevel").strip()
+        if os.path.realpath(top) != os.path.realpath(path):
+            return "not-a-git-checkout"
         return _git(path, "rev-parse", "HEAD").strip()[:12]
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
         return "not-a-git-checkout"


### PR DESCRIPTION
## Description

**File selection ranked files without reading them.** `score_candidate` took `(rel_path, size, prompt_tokens, git_recent, entry_points)` — no content parameter. The file was first opened inside `gather_context`, *after* selection, only to chunk what had already been chosen.

Every other defect followed from that. With no content signal, relevance had to come from a filename and a byte count, and the dominant term was `score -= 0.01 * size_kb` — once over 10 KB, **uncapped**, against a realistic positive signal of +0.6 to +2.1. So a file with one keyword hit was unrankable above 60 KB.

Measured, for *"fix the fact store supersession threshold"*:

```
src/neo/memory/store.py   keyword +0.60  depth -0.15  size -1.62  =  0.000
                                                      rank 200 of 284
```

The most relevant file in the repository, unrankable, because it is 162 KB. Ground truth ran 31–177 KB against a corpus median of 10 KB — central files are large *because* they are central.

This had been diagnosed once already. The comment above the penalty read *"they're large because they're central, and the old 0.002 multiplier was pushing THE relevant file (93KB engine.py) below threshold"* — and the fix was a seven-name stem whitelist that rescued `engine.py` (−0.13) and left `store.py` (−1.62). A **12× disparity** between two files of near-identical size, decided by whether someone had thought of the name.

**The literature says the sign was wrong, not the magnitude.** This task is IR-based bug localization; BugLocator's rVSM (Zhou et al., ICSE 2012) adds a logistic length function that ranks *larger* files *higher*, because larger files are empirically more likely to contain the defect. BM25's `b` handles the same concern with bounded, corpus-derived length normalization.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Code cleanup/refactoring

## Related Issue

Fixes #193.

## Motivation and Context

Neo already shipped the BM25 (`neo.memory.bm25`, Lucene-style with IDF smoothing) and already ran hybrid dense+sparse fusion for **fact** retrieval. File selection used none of it.

Now: BM25 over file content with code-aware tokenization — identifiers split on camelCase and separators, emitting both the whole identifier and its parts, so a prompt saying "user by id" reaches `getUserById`. Score max-normalized per query and applied as the dominant term, at a named `CONTENT_WEIGHT = 3.0`. The size penalty and the `main_impl_stems` whitelist are deleted; filename overlap drops from 0.6 to 0.15 per hit and becomes a tie-breaker; `EXPLICIT_PATH_BOOST` is untouched.

### Measured, end-to-end through the real CLI

Cases mined from git history — commit subject as query, changed non-test files as ground truth. `PYTHONPATH` pinned per tree, at the shipped `CONTENT_WEIGHT = 3.0`, 50 cases per repo, zero failed cases:

| repo | R@1 | R@10 | MRR | top-10 hit rate |
|---|---|---|---|---|
| neo | 0.081 → **0.351** | 0.301 → **0.742** | 0.304 → **0.771** | 0.58 → **0.98** |
| car | 0.047 → **0.185** | 0.180 → **0.472** | 0.162 → **0.425** | 0.24 → **0.62** |
| quip | 0.057 → **0.321** | 0.174 → **0.696** | 0.158 → **0.643** | 0.30 → **0.86** |

Reproduce with `tools/rank_mine_eval.py --repo <repo> --tree <tree>`, which ships in this PR.

**Measured with the recency signal off, which is the harness default.** `get_git_recent_files` reads `git status --porcelain` plus the last 50 commits and stores *paths*, so a case mined below the window whose truth file was touched again inside it is handed its own answer key — as is every file dirty in the tree you measure from. `neo --dry-run --no-git` gates that signal and nothing else, leaving `_history_boost` and the rest of the re-rank live, which is what `tools/rank_eval.py` had been doing all along. Running `--with-git` instead reports **48 of 50 neo cases contaminated** and moves every figure by ≤0.03: the leak is real, and it was never what carried the result.

> **These supersede the table this description carried until now** (neo 0.078 → 0.603 / 0.082 → 0.655, and so on). Not a correction of arithmetic — a different instrument. The original numbers came from a harness that was never committed and no longer exists to re-run, which is the defect this revision fixes; see *Corrections after review*. Same direction, different magnitudes, and only these are reproducible.

### Two measurement bugs, both of which produced confident wrong numbers

Worth more than the result, because both are easy to hit again and both are now documented in CLAUDE.md.

1. **The venv installs neo EDITABLE against `src/`.** Running `.venv/bin/python -m neo.cli` from a git worktree of another commit executes *this* tree's code against *that* tree's files. My "main baseline" was branch code. It made main look like MRR 0.613 against a real figure of 0.082 — a 7× error, flattering to the change under test. (Both are superseded-generation figures, quoted for the size of the error, not as measurements; this harness puts main's neo MRR at 0.304.) Fixed with `PYTHONPATH=<tree>/src`.
2. **Calling `score_candidate` directly measures only the first-pass ranking.** `gather_context` then re-ranks with `pi_boost + hist_boost + _symbol_score` and applies an adaptive limit and byte budget. A first-pass harness overstated R@10 by 0.14 against the real CLI.

Both are now written into `tools/rank_mine_eval.py`'s docstring, and the tool closes them structurally: it shells out to `neo --dry-run` rather than replicating the pipeline, and it absolutizes `--tree` and then **refuses to run unless that tree is the one `import neo` actually resolves to**. Mandatory is not the same as effective — review demonstrated that a typo'd `--tree` falls through the editable install's `.pth` to the working checkout, so both arms measure the same code and the run still reports `failed_cases: 0`. That is trap 1 returning inside the tool written to prevent it. The guard then had to be fixed twice for the same reason it exists — checking one directory while the run measured another. First, a relative `--tree` resolved against the harness's directory while the child ran with `cwd=repo`, so `--repo ../car --tree .` passed and Python discarded the nonexistent `PYTHONPATH` entry in silence. Second, the probe itself ran from the wrong place: cwd lands at `sys.path[0]` *ahead of* `PYTHONPATH`, so a repo with a top-level `neo/` would shadow the named tree in the measurement while a probe run from elsewhere saw nothing wrong. The probe now runs from `cwd=repo`, exactly as the measurement does. No repo involved here has such a directory, so no published number was affected — but a guard is the one place "nobody has hit it yet" is not an argument. I reported wrong numbers in both directions before arriving at these. Any in-process replica must be validated against `--dry-run` before a sweep is run on it.

### Also in this branch

- **PR #188's test-file demotion**, cherry-picked and reconciled — it earns its place and is worth *more* under BM25, because a test file is a lexical superset of its subject (same identifiers plus scaffolding). The figures that established this came off a superseded harness generation and are deliberately not restated here, per `score_candidate`'s own docstring; the direction held on every repo and is carried by the table above. #188 is closed as subsumed.
- **Proportional chunk allocation** (`_cap_chunks`, reusing the existing `_allocate_slots`). Round-robin gave every file the same *count* regardless of size — `store.py` 6/82 symbols = 7% coverage, `text_budget.py` 4/4 = 100%. Now equal coverage *fraction*: store.py 6 → 19 chunks.

## Corrections after review

Two rounds of review. The first found a blocker that had been shipped **and measured** without being noticed, plus a conclusion already written into CLAUDE.md that was wrong — all fixed in `7d00723`, full write-up in [this comment](https://github.com/Parslee-ai/neo/pull/194#issuecomment-5250285666). The second found that the evidence for the whole change was unreproducible.

**The harness that produced the headline table was never committed**, and CLAUDE.md named `tools/rank_eval.py` as its source — a different instrument entirely: 12 hand-labelled prompts, this repo only, recall@k, no MRR, no repo argument. A false claim about a file in the same commit, and the same paragraph credited it with two docstring warnings it does not contain. Nobody, including me, could re-run the numbers this PR rests on.

`tools/rank_mine_eval.py` now ships as that harness, and re-measurement replaced the table above. Its own first draft then failed review twice over, which is worth recording because both failures are the exact defect this branch exists to remove:

- **It claimed `--skip-recent` removed recency contamination. It does not.** The scorer's recency set holds paths rather than commits, so a truth file touched again inside the window is back in it, and `get_git_recent_files` also reads `git status --porcelain` — so measuring a branch from the tree you are editing leaks regardless of history. My first sweep ran against a dirty tree. Worse, I answered this by inventing a `--drop-contaminated` sampling filter when **`neo --dry-run` has taken `--no-git` all along, and the sibling harness in the same directory was already passing it** — a bespoke workaround for a solved problem, sitting one file away. That flag gates `git_recent` and nothing else, so it removes the leak structurally instead of by discarding data. It is now the default; `--with-git` opts back in and reports contamination counts.
- **Its parser failed open.** A timeout, a non-zero exit or a renamed heading returned an empty ranking, which scored as perfect-zero retrieval and averaged into the table as if it were evidence about ranking quality. Failed cases are now dropped and counted, never scored. The published sweep had zero.
- **Fixing that at the header was not enough.** A per-*line* format change keeps the banner and parses to nothing, so every case returns empty and the run reports a confident `R@10 0.000` with no failures — the same defect back through a different door, and there is a live trigger today (the CLI's second dry-run printer emits absolute paths, which parse cleanly and match no repo-relative ground truth). Marker found but nothing parsed anywhere is now a hard failure.
- **Reverts were being mined as cases.** `revert:` and `wip:` are themselves conventional-commit types, so stripping the prefix consumed the very word that should have skipped them and the remainder read as ordinary work. A revert's changed files are a removal, which is not ground truth for its own subject. Caught by writing the test against the predicate rather than against a composition performed in the test body; the case sets turned out identical on all three repos, so the table above is unaffected — verified rather than assumed.

- **The content term was applied twice.** `score += 3.0 * content_relevance` sat at two adjacent lines, so the effective weight was **6.0** while every docstring, comment and table said 3.0 — introduced by the cherry-pick that merged #188's scorer with this one. Now a named `CONTENT_WEIGHT` applied once, with a structural test that it is applied exactly once. Re-measurement showed 3.0 beats 6.0 — but that is luck, not process. **The honest statement is that every number previously reported on this PR was produced at a weight nobody chose.**
- **"The re-rank is redundant" was wrong.** Disabling `pi_boost` + `_symbol_score` + `hist_boost` on the real CLI takes **R@1 from 0.344 to 0.044** and MRR from 0.646 to 0.261 — an ablation run on the superseded harness generation, so read it against itself, not against the table above. It is load-bearing. The opposite conclusion came from a sweep at k=10 — where every configuration on this repo is flat — through an in-process replica omitting the byte budget and adaptive limit, i.e. exactly the stages that make the re-rank matter. Both mistakes are now warned about in `tools/rank_mine_eval.py`'s docstring — an earlier revision of this description attributed those warnings to `rank_eval.py`, which carries neither. The surviving half is real and kept: `hist_boost` contributes nothing measurable.
- **Binary files were entering the BM25 corpus.** `errors="ignore"` turned PDFs into junk tokens, and they set `avgdl` — so length normalization depended on how many papers happened to sit in the repo. The same defect this change exists to remove, re-entering through corpus statistics. NUL-byte probe added. Re-measured through the real candidate path for this description: **8 of 289 candidates (2.8%) carrying 27.5% of tokens**, `avgdl` 2760 → 2059. The exact share is not stable — four of the eight are `.ruff_cache` blobs, so it depends on whether ruff has run since the last clean, and an earlier reading on a cleaner tree recorded 5 PDFs at 1.7%/32.9%. The stable shape is a low single-digit share of documents carrying roughly a third of corpus tokens.
- **`MAX_INDEXED_BYTES` → `MAX_INDEXED_CHARS`.** `TextIOWrapper.read(n)` counts code points; CLAUDE.md already records this exact lie in `_render_context_files`.
- **Four constants pinned by value** (`CONTENT_WEIGHT`, `MAX_INDEXED_CHARS`, `PATH_TOKEN_WEIGHT`, the normalize ceiling). The test that should have caught the doubling named 3.0 in its docstring and asserted an inequality satisfied by anything above 1.76 — naming a number in prose while asserting a direction is how a constant goes unpinned and looks pinned. To be exact about what the pins buy: none of them would have caught this bug, because the constant *was* 3.0 and the doubling was at the call site. Only `test_content_weight_is_applied_exactly_once` catches that. The pins close the adjacent hole.
- The chunk-cap console line no longer promises a floor that `_allocate_slots` does not always give, and three conflicting measurement tables were reconciled to one with the harness generation named (`car` had appeared as both 0.969 and 0.507 for the same quantity).

## Negative results — recorded so they are not blindly retried

| tried | result |
|---|---|
| RRF fusion with the dense channel | **Provisional — must be retried, not filed away.** Measured worse than BM25 alone (0.596 best-weighted vs 0.693 — superseded-generation figures, unstamped when first recorded, and **not** comparable with the headline table above), but the result is triply compromised: those two numbers come off a harness that no longer exists, it was taken at k=10 (the blind cutoff that produced the re-rank error above), and the mechanism it blamed — dense's narrow ~25-file recall against BM25's ~180, compounded by chunk starvation — **was fixed two commits later in this same branch**. Re-measure at k=3/k=5 against the current tree before relying on it either way. |
| Evidence/saturation term on the BM25 score | +0.010 MRR (superseded generation) — noise. Every eval prompt is an on-topic commit subject, so the harness cannot see the prompt class it serves. Documented, not shipped. |
| Four filename-tuning fixes (document frequency, `{3,}` length floor, whole-token matching, cutting the docs bonus) | All measured and rejected in earlier work. They tune the *filename*; the filename is not the evidence. |

The re-rank weight sweep is **not** in this table. It concluded the re-rank was redundant and was refuted — see *Corrections after review*.

## Deferred

**#195 — BM25 is O(N) in memory and query time** (~3 s and ~100 MB per 1,000 files; ~15 s and ~500 MB at 5,000). The fix is a precomputed per-doc `Counter` plus an inverted index in `src/neo/memory/bm25.py`, which has other callers (fact retrieval), so it is not this PR's job. `gather_context` is CLI-only, so the observer daemon's documented RSS behaviour is unaffected. Filed with measurements and blast radius stated.

## How Has This Been Tested?

- [x] `2162 passed, 8 skipped`; ruff clean
- [x] End-to-end on three repos via the real CLI with `PYTHONPATH` pinned per tree, zero failed cases
- [x] The harness itself is tested (`tests/test_rank_mine_eval.py`, 41 tests): the recall/hit-rate/MRR arithmetic, the fail-closed paths for non-zero exit, missing marker and timeout, chunk de-duplication, and that `--no-git` is passed unless asked otherwise. A defect here does not crash — it publishes a wrong number with a confident table around it, which is this branch's whole subject
- [x] Contamination audited after review: `_history_boost` returns 0 entries for dev-run prompts; the main worktree was given its own ProjectIndex and scores **identically** (0.082 — superseded generation, from the audit run at the time), so the comparison is fair; `iter_paths` returns a list, so `build_index` cannot exhaust the candidate iterable
- [x] Mutation-tested: 4 mutants on `file_retrieval`, 4 on the scorer, 2 on `_cap_chunks` — all caught, after two gaps were found and closed, and the set re-run after the weight correction
- [x] Cost measured on this repo at 279 indexed files: **0.48 s** to walk, read and build the index (0.07 s of it I/O), **68 ms** for one query. No cache; the gatherer already reads every file it selects. #195 is the authority on how this scales (~3 s and ~100 MB per 1,000 files) — earlier revisions of this description quoted 0.14–0.16 s build and 12–14 ms query, which do not reproduce and conflicted with #195 by roughly 8×
- [x] Ablation (superseded generation — quoted for relative scale, not as current measurements): git recency +0.021 R@10, filename overlap +0.009, docs bonus −0.002 on code prompts but **+1.0 docs-in-top-10 on doc-seeking prompts**, so it stays

**Test Configuration**: Python 3.13.9 · macOS 26.5.2 · neo 0.44.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Known limits, stated rather than fixed.** Max-normalization preserves order but discards evidence — the top file gets the full ceiling whether its raw BM25 score was 20 or 4. Total abstention works (a query matching nothing yields no boost), but a weak best match is promoted as confidently as a strong one; measured separation is ~2× (on-topic 14.8–20.2, off-topic 6.3–7.5). Ground truth is what a commit *changed*, a subset of what a developer needed to *read*, and commit subjects are terser and better-formed than real prompts.

**The docs bonus and the saturation term are mirror decisions.** An eval that cannot see doc-seeking prompts was not allowed to justify *deleting* a feature serving them; an eval that cannot see off-topic prompts was not allowed to justify *adding* one. Neither was decided on argument.
