### PR TITLE
test(release-gate): per-language LLM round trip gates the release; invariant battery gates every PR

### DIFF
--- a/.claude/commands/ship-release.md
+++ b/.claude/commands/ship-release.md
@@ -97,6 +97,19 @@ git push origin v{version}
 
 ### Phase 6: Create GitHub Release
 
+**The release gate runs here.** Creating the release triggers `publish.yml`,
+which will not build a wheel until `language-roundtrip` is green: one real LLM
+round trip each for C#, TypeScript and Python against generated fixture
+repositories, asserting that the language's files reach the prompt and that
+the model can name a symbol present in exactly one of them. A red language
+stops the chain at `build` and nothing reaches PyPI.
+
+The job **fails** rather than skips when `ANTHROPIC_API_KEY` is not configured
+as a repository secret — an absent credential is a red gate, not a green one.
+Configure it before the first gated release. Full details, including how to
+dry-run the gate without cutting a release, are in
+[`docs/release-gate.md`](../../docs/release-gate.md).
+
 ```bash
 gh release create v{version} \
   --title "v{version}" \
@@ -121,6 +134,7 @@ byte-identical artifacts, so a mismatch would not be visible on the release page
 ### Phase 7: Verify Publication
 
 Check that:
+- `language-roundtrip` passed — all three languages green
 - GitHub Actions workflow completed successfully
 - Package appears on PyPI: https://pypi.org/project/neo-reasoner/
 
@@ -157,6 +171,13 @@ above `publish-testpypi` in the workflow, and CONTRIBUTING.md.
 **If tag already exists**: Report conflict, suggest incrementing version
 
 **If GitHub Actions fails**: Check workflow logs at github.com/{repo}/actions
+
+**If `language-roundtrip` fails**: reproduce it for free first —
+`pytest -m invariants -v` runs the same fixtures with no model call and will
+usually name the broken invariant. If the battery is green and only the round
+trip is red, the model stopped seeing a file the gatherer still selects; run
+`NEO_RELEASE_ROUNDTRIP=1 pytest -m roundtrip -v` locally. Do not work around
+it by removing the job from `build`'s `needs`.
 
 **If PyPI publish fails**: Check Actions logs for authentication or build issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,47 @@ jobs:
 
     - name: Run tests
       run: pytest -v
+
+  # The free half of the release gate, as its own required-looking check.
+  #
+  # These assertions also run inside `test` above — this job exists so that a
+  # broken selection invariant is legible AS a broken selection invariant on
+  # the PR that caused it, rather than as one red line inside a 2,000-test
+  # matrix. That legibility is the whole point: C# was absent from Neo's index
+  # for 8.5 months (#158/#159) and the gatherer selected gitignored junk
+  # (#186), and in both cases something green was being read as evidence.
+  #
+  # No model call, no credentials, every PR. The paid per-language round trip
+  # is release-only and lives in publish.yml; see docs/release-gate.md.
+  invariants:
+    name: Guard-invariant battery
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: pip install -e ".[dev]"
+
+    - name: Guard invariants (G1-inv..G3-inv, per language, no LLM)
+      run: pytest -m invariants -v
+
+    # Proves the negative the constraint actually cares about: the paid half
+    # was collected and did NOT run. A gate that silently stopped being
+    # release-only would otherwise first show up on the bill.
+    - name: Confirm the LLM round trip stayed opted out
+      run: |
+        pytest -m roundtrip -v --no-header -rs > roundtrip-run.txt 2>&1
+        cat roundtrip-run.txt
+        if grep -qE '[0-9]+ (passed|failed)' roundtrip-run.txt; then
+          echo "::error::round-trip tests executed on a PR; they are release-only"
+          exit 1
+        fi
+        grep -qE '[0-9]+ skipped' roundtrip-run.txt || {
+          echo "::error::no round-trip tests were collected at all"; exit 1; }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,14 +23,80 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # Same three paths as ci.yml, the Makefile and .githooks/pre-commit.
+      # This job had been linting two of them, so the release path enforced
+      # LESS than a pull request did — a release could publish code that CI
+      # would have rejected.
       - name: Lint with ruff
-        run: ruff check src/ tests/
+        run: ruff check src/ tests/ tools/
 
       - name: Run tests
         run: pytest -v
 
+  # THE RELEASE GATE. One real LLM round trip per language (C#, TypeScript,
+  # Python) against the generated fixture repos, asserting that the language's
+  # files reach the prompt and that the model can name a symbol which exists
+  # in exactly one of them.
+  #
+  # Cost-bearing model calls are approved FOR RELEASES and only for releases
+  # (Matt Liotta, 2026-08-10): "if that's what we have to do as part of the
+  # release process, we want to do it because we obviously want to catch that
+  # shit." Every push and PR gets the free half instead — the guard-invariant
+  # battery in ci.yml.
+  #
+  # `build` needs this job, so a red language blocks the wheel. It is
+  # deliberately NOT `continue-on-error` and deliberately does NOT skip when
+  # the credential is absent: an absent credential is a red gate, not a green
+  # one. The scar tissue this replaces is a class of failure where every
+  # failure printed success and exited 0.
+  #
+  # Requires the `ANTHROPIC_API_KEY` repository secret. Optional repository
+  # variable `NEO_RELEASE_MODEL` overrides the model; the default matches
+  # `adapters.create_adapter`'s own Anthropic default so the gate and the
+  # library cannot drift apart silently.
+  language-roundtrip:
+    name: Per-language LLM round trip (release gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,anthropic]"
+
+      - name: Require release credentials
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY is not configured, so the"\
+                 "per-language round trip cannot run. A release does not"\
+                 "publish without it. Add the secret at"\
+                 "Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+      # `NEO_INFERENCE_MODE=static` because CAR is not present on a runner and
+      # 'auto' would spend the attempt discovering that. `NEO_MODEL` is set
+      # explicitly: NeoConfig's provider and model defaults are independent, so
+      # switching only the provider would hand an OpenAI model name to
+      # Anthropic.
+      - name: Per-language round trip (C#, TypeScript, Python)
+        env:
+          NEO_RELEASE_ROUNDTRIP: '1'
+          NEO_PROVIDER: anthropic
+          NEO_MODEL: ${{ vars.NEO_RELEASE_MODEL || 'claude-sonnet-4-5-20250929' }}
+          NEO_INFERENCE_MODE: static
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: pytest -m roundtrip -v
+
   build:
-    needs: ci-check
+    needs: [ci-check, language-roundtrip]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,19 @@ pytest tests/test_neo.py
 
 # Run with coverage
 pytest --cov=neo
+
+# The free half of the release gate on its own: per-language selection
+# invariants, no model call. This is what the `invariants` CI job runs.
+pytest -m invariants
+
+# The paid half. The marker alone does not spend money — the module skips
+# unless NEO_RELEASE_ROUNDTRIP=1, so a plain `pytest` reports these SKIPPED
+# rather than omitting them. One real LLM call per language.
+NEO_RELEASE_ROUNDTRIP=1 pytest -m roundtrip
 ```
+
+See [`docs/release-gate.md`](docs/release-gate.md) for what each half asserts
+and why it is split that way.
 
 ### Code Formatting
 
@@ -107,8 +119,13 @@ Publishing is automated: creating a GitHub **Release** triggers `publish.yml`,
 which builds and uploads to PyPI via Trusted Publishers (OIDC — no token lives
 in the repo). The sequence is push → tag → release; do not run `twine` locally.
 
-Two things to know before you rely on it:
+Three things to know before you rely on it:
 
+- **A release gate runs first.** `build` needs `language-roundtrip`, which
+  makes one real LLM call per language (C#, TypeScript, Python) against
+  generated fixture repositories. A red language blocks the wheel. The job
+  requires the `ANTHROPIC_API_KEY` repository secret and **fails rather than
+  skips** without it. See [`docs/release-gate.md`](docs/release-gate.md).
 - **TestPyPI is not configured.** `publish-testpypi` only runs on a manual
   `workflow_dispatch`, and it currently fails at the publish step because no
   Trusted Publisher exists for this repo on TestPyPI. The `build` job and the

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -102,6 +102,32 @@ Low confidence is **not** gated. A correct refusal is a legitimate answer and
 must not block a release. Absent confidence is a different matter and does
 fail — that is the serialization contract breaking.
 
+### Reading a red round trip
+
+A red per-language round trip reads as "that language broke", and for the
+failure this gate exists to catch, that is right. Several other things can
+turn it red, and the failure message names which, because sending someone to
+the gatherer for a parser problem is an expensive wrong turn.
+
+Measured during this gate's own bring-up: two consecutive local runs of the
+same commit, one 21/21 green, the next red on Python with
+`ValidationError: Failed to parse simulation traces: missing_start_sentinel`.
+The gatherer had selected the right four files both times. The model's reply
+simply did not carry neo's `<<<NEO:SCHEMA=v3:KIND=simulation>>>` sentinel.
+
+**That is not swallowed and is not retried.** A user issuing the same command
+gets the same error, so it is a genuine release blocker — and a gate that
+retries until green is the same defect as a failure that exits 0. But it is
+not a selection failure, so:
+
+- `pytest -m invariants` will be **green** when the parser is the cause. That
+  contrast is the fastest available diagnosis, and it costs nothing.
+- The assertion message names the layer (`structured_parser.py`, the
+  provider, the network, the credential) rather than leaving "neo failed".
+
+Expect this to bite occasionally. The right response is to fix the brittleness
+it exposes, not to loosen the gate.
+
 ## Running it
 
 ```bash

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -1,0 +1,166 @@
+# The release gate
+
+**Date:** 2026-08-12
+**Plan of record:** [`docs/unified-store-plan.md`](unified-store-plan.md), Goal 10 (G5-inv)
+
+A release cannot publish while any of C#, TypeScript or Python has a red LLM
+round trip. Every pull request gets the free half of the same battery, with no
+model call.
+
+## Why a language axis
+
+Three failures motivate this, and all three were invisible from the outside:
+
+- **C# was absent from Neo's index for 8.5 months** (#158/#159). Everything
+  that could have caught it was exercised against Python, and passed.
+- **The gatherer selected gitignored junk** — 14 of 16 selected files on one
+  measured prompt (#186).
+- **Every failure printed success and exited 0.**
+
+A single-language check would have stayed green through all of it. The
+language axis is the assertion, not decoration. Matt Liotta, on the
+2026-08-10 sync: real-LLM round-trip tests per language belong in the release
+process — *"if that's what we have to do as part of the release process, we
+want to do it because we obviously want to catch that shit."* Cost-bearing
+model calls are approved **for releases**, not for every push.
+
+## The two halves
+
+| | Free half | Paid half |
+|---|---|---|
+| What | Guard-invariant battery | Per-language LLM round trip |
+| File | `tests/test_selection_invariants.py` | `tests/test_release_roundtrip.py` |
+| Marker | `-m invariants` | `-m roundtrip` |
+| Model calls | none | one per language |
+| Runs on | every push and PR | the release flow, and manual dispatch |
+| Wired in | `invariants` job in `.github/workflows/ci.yml` | `language-roundtrip` job in `.github/workflows/publish.yml` |
+| Blocks | the PR | the wheel — `build` needs it |
+
+Both build the **same** three fixture repositories from
+`tests/fixtures/language_repos.py`. That sharing is deliberate: a red release
+gate has to be diagnosable from a free CI run, and it cannot be if the two
+halves disagree about what the repository under test looks like.
+
+## The fixtures
+
+`build_fixture_repo(language, root)` generates a real git repository per
+language — real, because the invariants are defined against `git
+check-ignore` and a fake cannot be differentially compared to git. Each holds,
+in its own language:
+
+- a **target** file the prompt names by path, carrying a **sentinel** symbol
+  that appears in no other file;
+- **gitignored junk** in the same language, sharing the target's filename stem
+  and containing its sentinel, so it competes for the same slots;
+- a **duplicate** of the target under an agent-worktree layout
+  (`.claude/worktrees/...`), which is *not* gitignored — the gatherer's own
+  default exclusions are what must catch it;
+- **bulk below the sentinel**, so the target exceeds the reasoning prompt's
+  per-file character cap and the truncation-marker assertions are non-vacuous
+  on the one file that matters. The sentinel sits at the top because the cut
+  keeps the head.
+
+Adding a language to `LANGUAGES` adds it to both halves at once. That is the
+only ordering that cannot leave a language gated in name only.
+
+## What the free half asserts
+
+Per language, against `docs/unified-store-plan.md`'s guard invariants:
+
+- **G1-inv** — no selected path is excluded by `git check-ignore` (asked of
+  git, never re-derived); the planted junk is specifically absent; no path is
+  selected twice; the worktree copy does not compete with the original; no two
+  selected files are byte-identical.
+- **G2-inv** — the prompt-named file is selected, and arrives whole rather
+  than windowed.
+- **G3-inv** — every cut file carries a marker and every uncut file carries
+  none; the banner counts what was **sent**, not what was offered; the
+  truncated-file count matches.
+
+Several assertions guard the guard, because a battery that passes on no
+evidence is worse than no battery: the planted junk is checked to be genuinely
+gitignored, the target is checked to be genuinely large enough to be cut, and
+the sentinel is checked to survive the cut.
+
+## What the paid half adds
+
+One `neo --json` subprocess per language — a subprocess, not an in-process
+engine, because the thing under test is the release artifact end to end:
+argument parsing, adapter resolution from the environment, gathering, the
+model call, serialization.
+
+The load-bearing assertion is that **the model names the sentinel**. The
+sentinel exists in exactly one file, so it cannot be named unless that file
+reached the prompt. That closes the gap the free half cannot: the battery
+proves the gatherer *selected* the file; this proves the model *saw* it — the
+gap C# sat inside for 8.5 months.
+
+It also re-asserts the selection invariants on the commit being published.
+"The battery passed on some other commit" is not evidence about this one.
+
+Low confidence is **not** gated. A correct refusal is a legitimate answer and
+must not block a release. Absent confidence is a different matter and does
+fail — that is the serialization contract breaking.
+
+## Running it
+
+```bash
+# Free half — every PR runs this; it costs nothing.
+pytest -m invariants -v
+
+# Paid half. The marker alone is not enough: the module skips unless the
+# environment variable is set, so an ordinary `pytest` reports the round trips
+# SKIPPED rather than silently omitting them.
+NEO_RELEASE_ROUNDTRIP=1 pytest -m roundtrip -v
+```
+
+Locally the round trip uses whatever provider your config resolves. With
+CarHost running and `inference_mode` left at `auto`, CAR routes it and no API
+key is needed:
+
+```bash
+NEO_INFERENCE_MODE=auto NEO_RELEASE_ROUNDTRIP=1 pytest -m roundtrip -v
+```
+
+## Configuring CI
+
+The `language-roundtrip` job needs one repository secret:
+
+| Name | Kind | Required | Purpose |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | secret | yes | the round trip's provider credential |
+| `NEO_RELEASE_MODEL` | variable | no | overrides the model; defaults to `adapters.create_adapter`'s own Anthropic default |
+
+**The job fails, loudly, when the secret is absent.** It does not skip. An
+absent credential is a red gate, not a green one — a gate that no-ops when
+unconfigured is the same class of defect as a failure that exits 0. Until the
+secret is added, releases are blocked; that is the gate working.
+
+## Dry-running the gate
+
+`publish.yml` still carries `workflow_dispatch`, so the whole release path
+including this gate can be exercised without cutting a release:
+
+```bash
+gh workflow run publish.yml --ref <branch>
+gh run watch
+```
+
+`ci-check` and `language-roundtrip` run; `build` waits on both; nothing
+publishes (`publish-pypi` is gated on `github.event_name == 'release'`). Note
+that `publish-testpypi`'s upload step fails for an unrelated, pre-existing
+reason — no Trusted Publisher is configured — which is documented in
+`.claude/commands/ship-release.md` and in the workflow itself.
+
+## Where this sits in the release flow
+
+`/ship-release` Phase 6 creates the GitHub Release, which triggers
+`publish.yml`. The gate runs there, before `build`, so the ordering is:
+
+```
+ci-check ─┐
+          ├─▶ build ─▶ publish-pypi
+roundtrip ─┘
+```
+
+A red language stops the chain at `build`. Nothing reaches PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,19 @@ exclude = [
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = ["--import-mode=importlib", "-v"]
+markers = [
+    # The free half of the release gate: per-language selection invariants
+    # (G1-inv..G3-inv), no model call. Runs in the ordinary suite AND as its
+    # own named CI job so a break is legible on the PR that caused it.
+    "invariants: guard-invariant battery, no LLM calls (runs on every PR)",
+    # The paid half. Selecting the marker is NOT enough to spend money: the
+    # module skips unless NEO_RELEASE_ROUNDTRIP=1, so an ordinary `pytest` run
+    # reports them SKIPPED rather than silently omitting them. A gate nobody
+    # can see is the failure mode this whole goal exists to prevent. The
+    # release workflow is the only thing that sets the variable.
+    # See docs/release-gate.md.
+    "roundtrip: per-language LLM round trip, costs money (release flow only)",
+]
 filterwarnings = [
     "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,9 @@
+"""Generated fixture repositories shared by the release gate.
+
+The selection-invariant battery (`tests/test_selection_invariants.py`, every
+PR, no LLM) and the per-language round trip
+(`tests/test_release_roundtrip.py`, release only, real LLM) build the SAME
+three repos from this package. That sharing is the point: a language whose
+round trip is red in the release gate must be diagnosable from a free CI run,
+and it cannot be if the two gates disagree about what the repo looks like.
+"""

--- a/tests/fixtures/language_repos.py
+++ b/tests/fixtures/language_repos.py
@@ -1,0 +1,389 @@
+"""Three small single-language repositories, built on demand.
+
+Each one is a real git repository with a real `.gitignore`, because the
+invariants under test are defined against `git check-ignore` and a fake
+cannot be differentially compared to git. Each carries, in its own language:
+
+- a **target** file the prompt names by path, holding a sentinel symbol that
+  appears nowhere else. Naming the path pins the file (G2-inv); the sentinel
+  is what lets the round trip prove the MODEL saw it rather than merely that
+  the gatherer selected it.
+- **gitignored junk** in the same language, which `git check-ignore` excludes
+  and the gatherer therefore must not select (G1-inv). C# was silently absent
+  from Neo's index for 8.5 months and the gatherer selected gitignored junk;
+  both failures were invisible because nothing asserted the negative.
+- a **duplicate copy** of the target under an agent worktree layout. Not
+  gitignored — this is the other half of G1-inv, and it is asserted on
+  identity (one copy of the basename) rather than on a count.
+- **bulk below the sentinel**, so the target exceeds the reasoning prompt's
+  per-file character cap. That makes the truncation-marker assertion
+  (G3-inv) non-vacuous on the one file that matters, and it is realistic:
+  real source files exceed 3000 characters constantly. The sentinel sits at
+  the top because `truncate_marked` keeps the head.
+
+`LANGUAGES` is the parametrization both gates iterate. Adding a language here
+adds it to the free CI battery and to the paid release gate at once, which is
+the only ordering that cannot leave a language gated in name only.
+"""
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Comfortably past `engine._CONTEXT_FILE_CHARS` (3000) so the target file is
+# always cut, and cut by enough that a marker claiming a plausible-but-wrong
+# amount would be visible. Not imported from `engine` on purpose: the fixture
+# must stay oversized if that constant is ever raised.
+_TARGET_MIN_CHARS = 12_000
+
+
+@dataclass(frozen=True)
+class FixtureRepo:
+    """A built fixture and everything the two gates need to assert against."""
+
+    language: str
+    root: Path
+    #: Repo-relative path of the file the prompt names.
+    target_rel: str
+    #: Symbol present only in `target_rel`. The round trip requires the model
+    #: to echo it, which it cannot do unless the file reached the prompt.
+    sentinel: str
+    #: The prompt handed to the gatherer and to the LLM.
+    prompt: str
+    #: Repo-relative paths `git check-ignore` excludes. Selecting any is G1-inv.
+    ignored_rels: tuple[str, ...] = field(default_factory=tuple)
+    #: Repo-relative path of the second copy of the target.
+    duplicate_rel: str = ""
+    #: Extension that identifies this language's source, without the dot.
+    ext: str = ""
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+def _pad(comment: str, unit: str, minimum: int = _TARGET_MIN_CHARS) -> str:
+    """Filler that reads as code, sized to push a file past `minimum`.
+
+    `unit` is one syntactically valid declaration for the language; it is
+    repeated with a running index so the result parses and so no two lines are
+    identical (identical lines would let a line-level deduplicator collapse
+    the bulk and quietly un-truncate the file).
+    """
+    body = [comment]
+    i = 0
+    while sum(len(line) + 1 for line in body) < minimum:
+        body.append(unit.format(i=i))
+        i += 1
+    return "\n".join(body) + "\n"
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _init_repo(root: Path) -> None:
+    """A real repository, so `git check-ignore` is answering about real state.
+
+    `git init` is run with `cwd=root` under conftest's ambient-git scrub; see
+    `tests/test_git_env_isolation.py` for why that scrub is load-bearing.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", ".")
+    _git(root, "config", "user.email", "fixtures@neo.test")
+    _git(root, "config", "user.name", "Neo Fixtures")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "fixture: initial import")
+
+
+# --------------------------------------------------------------------------
+# Python
+# --------------------------------------------------------------------------
+
+_PY_SENTINEL = "compute_zephyr_checksum"
+
+_PY_TARGET = f'''"""Rolling checksum over a stream of records."""
+
+CHECKSUM_MODULUS = 65521
+
+
+def {_PY_SENTINEL}(records: list[bytes]) -> int:
+    """Return the rolling checksum of `records`.
+
+    The accumulator is seeded at 1 rather than 0 so that a leading empty
+    record is distinguishable from no records at all.
+    """
+    low = 1
+    high = 0
+    for record in records:
+        for byte in record:
+            low = (low + byte) % CHECKSUM_MODULUS
+            high = (high + low) % CHECKSUM_MODULUS
+    return (high << 16) | low
+
+
+def verify_checksum(records: list[bytes], expected: int) -> bool:
+    return {_PY_SENTINEL}(records) == expected
+
+
+''' + _pad(
+    "# Supporting record codecs, kept in this module for locality.",
+    "\n\ndef decode_record_{i}(payload: bytes) -> bytes:\n"
+    "    \"\"\"Decode a version-{i} record payload.\"\"\"\n"
+    "    return payload[{i} % 4:] or payload\n",
+)
+
+_PY_OTHER = '''"""Reader that feeds the checksum routine."""
+
+from pathlib import Path
+
+
+def read_records(path: Path) -> list[bytes]:
+    return [line for line in path.read_bytes().splitlines() if line]
+'''
+
+_PY_IGNORED = '''"""Generated. Do not edit; do not read."""
+
+
+def compute_zephyr_checksum(records):  # noqa: F811 - stale generated copy
+    raise NotImplementedError("generated stub")
+'''
+
+
+# --------------------------------------------------------------------------
+# C#
+# --------------------------------------------------------------------------
+
+_CS_SENTINEL = "ComputeZephyrChecksum"
+
+_CS_TARGET = f'''using System;
+using System.Collections.Generic;
+
+namespace Fixture.Checksums;
+
+/// <summary>Rolling checksum over a stream of records.</summary>
+public sealed class ChecksumService : IChecksumService
+{{
+    private const int ChecksumModulus = 65521;
+
+    /// <summary>Returns the rolling checksum of <paramref name="records"/>.</summary>
+    /// <remarks>
+    /// The accumulator is seeded at 1 rather than 0 so a leading empty record
+    /// is distinguishable from no records at all.
+    /// </remarks>
+    public int {_CS_SENTINEL}(IReadOnlyList<byte[]> records)
+    {{
+        var low = 1;
+        var high = 0;
+        foreach (var record in records)
+        {{
+            foreach (var b in record)
+            {{
+                low = (low + b) % ChecksumModulus;
+                high = (high + low) % ChecksumModulus;
+            }}
+        }}
+
+        return (high << 16) | low;
+    }}
+
+    public bool VerifyChecksum(IReadOnlyList<byte[]> records, int expected)
+        => {_CS_SENTINEL}(records) == expected;
+}}
+
+''' + _pad(
+    "// Supporting record codecs, kept in this file for locality.",
+    "\npublic static class RecordCodec{i}\n{{\n"
+    "    /// <summary>Decodes a version-{i} record payload.</summary>\n"
+    "    public static byte[] Decode(byte[] payload) => payload;\n}}\n",
+)
+
+_CS_OTHER = '''using System.Collections.Generic;
+
+namespace Fixture.Checksums;
+
+public interface IChecksumService
+{
+    int ComputeZephyrChecksumContract(IReadOnlyList<byte[]> records);
+}
+'''
+
+_CS_IGNORED = '''// <auto-generated /> Build output. Do not edit; do not read.
+namespace Fixture.Checksums.Generated;
+
+public static class ChecksumServiceStub
+{
+    public static int ComputeZephyrChecksum() => throw new System.NotImplementedException();
+}
+'''
+
+
+# --------------------------------------------------------------------------
+# TypeScript
+# --------------------------------------------------------------------------
+
+_TS_SENTINEL = "computeZephyrChecksum"
+
+_TS_TARGET = f'''/** Rolling checksum over a stream of records. */
+
+export const CHECKSUM_MODULUS = 65521;
+
+/**
+ * Returns the rolling checksum of `records`.
+ *
+ * The accumulator is seeded at 1 rather than 0 so that a leading empty record
+ * is distinguishable from no records at all.
+ */
+export function {_TS_SENTINEL}(records: Uint8Array[]): number {{
+  let low = 1;
+  let high = 0;
+  for (const record of records) {{
+    for (const byte of record) {{
+      low = (low + byte) % CHECKSUM_MODULUS;
+      high = (high + low) % CHECKSUM_MODULUS;
+    }}
+  }}
+  return (high << 16) | low;
+}}
+
+export function verifyChecksum(records: Uint8Array[], expected: number): boolean {{
+  return {_TS_SENTINEL}(records) === expected;
+}}
+
+''' + _pad(
+    "// Supporting record codecs, kept in this module for locality.",
+    "\n/** Decodes a version-{i} record payload. */\n"
+    "export function decodeRecord{i}(payload: Uint8Array): Uint8Array {{\n"
+    "  return payload.subarray({i} % 4);\n}}\n",
+)
+
+_TS_OTHER = '''/** Reader that feeds the checksum routine. */
+
+export function readRecords(raw: string): Uint8Array[] {
+  return raw.split("\\n").filter(Boolean).map((line) => new TextEncoder().encode(line));
+}
+'''
+
+_TS_IGNORED = '''/* Generated. Do not edit; do not read. */
+export function computeZephyrChecksum(): number {
+  throw new Error("generated stub");
+}
+'''
+
+
+_SPECS: dict[str, dict] = {
+    "python": {
+        "ext": "py",
+        "sentinel": _PY_SENTINEL,
+        "target_rel": "src/checksum_service.py",
+        "target": _PY_TARGET,
+        "others": {"src/record_reader.py": _PY_OTHER},
+        "gitignore": "/generated/\n__pycache__/\n*.pyc\n",
+        "ignored": {"generated/checksum_service_stub.py": _PY_IGNORED},
+    },
+    "csharp": {
+        "ext": "cs",
+        "sentinel": _CS_SENTINEL,
+        "target_rel": "src/ChecksumService.cs",
+        "target": _CS_TARGET,
+        "others": {"src/IChecksumService.cs": _CS_OTHER},
+        "gitignore": "/generated/\nobj/\n",
+        "ignored": {"generated/ChecksumServiceStub.cs": _CS_IGNORED},
+    },
+    "typescript": {
+        "ext": "ts",
+        "sentinel": _TS_SENTINEL,
+        "target_rel": "src/checksumService.ts",
+        "target": _TS_TARGET,
+        "others": {"src/recordReader.ts": _TS_OTHER},
+        "gitignore": "/generated/\nnode_modules/\n",
+        "ignored": {
+            "generated/checksumServiceStub.ts": _TS_IGNORED,
+            "node_modules/left-pad/index.ts": _TS_IGNORED,
+        },
+    },
+}
+
+#: Iteration order for both gates. Sorted so a failure report reads the same
+#: on every runner.
+LANGUAGES: tuple[str, ...] = tuple(sorted(_SPECS))
+
+
+def build_fixture_repo(language: str, root: Path) -> FixtureRepo:
+    """Build the `language` fixture at `root` and describe it.
+
+    `root` need not exist. The returned `FixtureRepo` is what both gates
+    assert against; nothing else should re-derive these paths.
+    """
+    try:
+        spec = _SPECS[language]
+    except KeyError:  # pragma: no cover - a typo in a parametrize list
+        raise ValueError(
+            f"unknown fixture language {language!r}; known: {LANGUAGES}"
+        ) from None
+
+    target_rel = spec["target_rel"]
+    _write(root, target_rel, spec["target"])
+    for rel, content in spec["others"].items():
+        _write(root, rel, content)
+    for rel, content in spec["ignored"].items():
+        _write(root, rel, content)
+    _write(root, ".gitignore", spec["gitignore"])
+
+    # A second copy of the target under an agent worktree layout. Not
+    # gitignored: the gatherer's own default exclusions are what must catch
+    # it, and a worktree copy competes with the original for the same slots
+    # rather than merely adding noise.
+    duplicate_rel = f".claude/worktrees/scratch/{target_rel}"
+    _write(root, duplicate_rel, spec["target"])
+
+    _write(
+        root,
+        "README.md",
+        "# checksum fixture\n\nA single-language fixture repository.\n",
+    )
+    _init_repo(root)
+
+    return FixtureRepo(
+        language=language,
+        root=root,
+        target_rel=target_rel,
+        sentinel=spec["sentinel"],
+        prompt=(
+            f"Explain what {target_rel} does and identify the off-by-one risk "
+            f"in its accumulator seeding. Name the function you are describing."
+        ),
+        ignored_rels=tuple(spec["ignored"]),
+        duplicate_rel=duplicate_rel,
+        ext=spec["ext"],
+    )
+
+
+def check_ignored(root: Path, rel_paths: list[str]) -> list[str]:
+    """Return the subset of `rel_paths` that `git check-ignore` excludes.
+
+    The differential half of G1-inv. Asking git rather than re-implementing
+    its rules is the whole point — a second implementation of gitignore is
+    the defect this guards against, not the guard.
+
+    `check-ignore` exits 1 when nothing matches, which is not an error, so the
+    return code is read rather than `check=True`.
+    """
+    if not rel_paths:
+        return []
+    proc = subprocess.run(
+        ["git", "check-ignore", "--stdin"],
+        cwd=root,
+        input="\n".join(rel_paths) + "\n",
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git check-ignore failed ({proc.returncode}): {proc.stderr.strip()}"
+        )
+    return [line for line in proc.stdout.splitlines() if line]

--- a/tests/test_release_roundtrip.py
+++ b/tests/test_release_roundtrip.py
@@ -94,7 +94,9 @@ def _run_neo(fx: FixtureRepo) -> dict:
         f"\n--- stdout ---\n{proc.stdout[-4000:]}"
         f"\n--- stderr ---\n{proc.stderr[-4000:]}"
     )
-    assert proc.returncode == 0, f"neo failed for {fx.language}{detail}"
+    assert proc.returncode == 0, (
+        f"neo failed for {fx.language}: {_classify_failure(proc.stdout)}{detail}"
+    )
 
     try:
         payload = json.loads(proc.stdout)
@@ -108,6 +110,49 @@ def _run_neo(fx: FixtureRepo) -> dict:
     # zero exit carrying `error` would mean the contract itself broke.
     assert "error" not in payload, f"{fx.language}: {payload.get('error')}{detail}"
     return payload
+
+
+# Error envelopes the CLI emits that say nothing about file selection, mapped
+# to where to look instead. Naming the layer is the whole value: measured
+# live, a run failed on `ValidationError` (the model's reply missed neo's own
+# v3 start sentinel) and the default reading of a red LANGUAGE round trip
+# would have sent someone to the gatherer, which was working perfectly.
+_UNRELATED_TO_SELECTION = {
+    "ValidationError": (
+        "neo's structured parser rejected the model's reply. This is a real "
+        "release blocker — a user would get the same error — but it is NOT a "
+        "file-selection failure. Look at structured_parser.py, not the "
+        "gatherer. `pytest -m invariants` covers selection for free and will "
+        "be GREEN when this is the cause"
+    ),
+    "RequestTimeout": "the provider did not answer in time; not a selection failure",
+    "NetworkTimeout": "the network did not reach the provider; not a selection failure",
+    "ProcessingError": "an unexpected engine error; read the stderr events below",
+}
+
+
+def _classify_failure(stdout: str) -> str:
+    """Name the layer that broke, so a red gate points somewhere real.
+
+    A red per-language round trip reads as "the language broke", and for the
+    failure this gate exists to catch that is right. For the several ways an
+    invocation can fail that have nothing to do with which files were
+    selected, it is an expensive wrong turn.
+    """
+    try:
+        envelope = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return "no JSON envelope on stdout"
+
+    kind = envelope.get("error")
+    if not kind:
+        return "non-zero exit with no error envelope"
+    if kind.startswith("Failed to initialize LM adapter"):
+        return (
+            "no usable provider credential. The release job requires "
+            "ANTHROPIC_API_KEY and fails rather than skips without it"
+        )
+    return f"{kind} — {_UNRELATED_TO_SELECTION.get(kind, 'see the envelope below')}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_release_roundtrip.py
+++ b/tests/test_release_roundtrip.py
@@ -1,0 +1,215 @@
+"""Per-language LLM round trip — the paid half of the release gate.
+
+One real `neo --json` invocation per language, against the generated fixture
+repo, through whatever provider the environment is configured for. A red
+language here blocks the release; see `docs/release-gate.md` and the
+`language-roundtrip` job in `.github/workflows/publish.yml`.
+
+**These tests cost money and are release-only.** They skip unless
+`NEO_RELEASE_ROUNDTRIP=1` is set, and they SKIP rather than deselect on
+purpose: an ordinary `pytest` run should print three skipped round trips, so
+a reader can see the gate exists. A gate nobody can see is the failure this
+goal exists to prevent — C# was absent from the index for 8.5 months and
+every run printed success and exited 0.
+
+What each language asserts, end to end:
+
+1. the invocation exits 0 and stdout is exactly one JSON document;
+2. the result is non-empty and on topic — the model names the fixture's
+   sentinel symbol, which appears in exactly one file, so it cannot be named
+   unless that file actually reached the prompt. This is the assertion the
+   free battery cannot make: the battery proves the gatherer SELECTED the
+   file, this proves the model SAW it;
+3. the selection invariants the battery checks still hold for this run's
+   context — the language's files present, nothing gitignored, no duplicates.
+
+Point 3 is re-asserted here rather than assumed because the release gate is
+the last thing standing between a broken selection and a published wheel,
+and "the battery passed on some other commit" is not evidence about this one.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.language_repos import (
+    LANGUAGES,
+    FixtureRepo,
+    build_fixture_repo,
+    check_ignored,
+)
+from tests.test_selection_invariants import _gather
+
+pytestmark = [
+    pytest.mark.roundtrip,
+    pytest.mark.skipif(
+        os.environ.get("NEO_RELEASE_ROUNDTRIP") != "1",
+        reason=(
+            "release-only: costs a real LLM call per language. "
+            "Set NEO_RELEASE_ROUNDTRIP=1 to run (see docs/release-gate.md)."
+        ),
+    ),
+]
+
+# Generous: this is one call on a release, not a per-push cost, and a gate
+# that flakes on a slow provider teaches people to re-run it until it passes.
+_TIMEOUT_SECONDS = 600
+
+
+@pytest.fixture(scope="module")
+def roundtrip_repos(tmp_path_factory) -> dict[str, FixtureRepo]:
+    base = tmp_path_factory.mktemp("roundtrip_fixtures")
+    return {
+        language: build_fixture_repo(language, base / language)
+        for language in LANGUAGES
+    }
+
+
+def _run_neo(fx: FixtureRepo) -> dict:
+    """Invoke the installed CLI the way a user does, and parse its stdout.
+
+    A subprocess rather than an in-process `NeoEngine`, because the thing
+    under test is the release artifact's behaviour end to end: argument
+    parsing, adapter resolution from the environment, gathering, the model
+    call and serialization. An in-process call would skip the half of that
+    which a release can actually break.
+
+    stdout is exactly one JSON document by contract; stderr carries JSONL
+    events and is surfaced verbatim on failure, because a provider error
+    reported as "the assertion failed" costs an hour.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "neo", "--json", fx.prompt],
+        cwd=str(fx.root),
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+    )
+    detail = (
+        f"\n--- exit {proc.returncode} ---"
+        f"\n--- stdout ---\n{proc.stdout[-4000:]}"
+        f"\n--- stderr ---\n{proc.stderr[-4000:]}"
+    )
+    assert proc.returncode == 0, f"neo failed for {fx.language}{detail}"
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:  # pragma: no cover - failure path
+        raise AssertionError(
+            f"stdout was not a single JSON document for {fx.language}: "
+            f"{e}{detail}"
+        ) from None
+
+    # The CLI prints an error envelope and exits non-zero on failure, so a
+    # zero exit carrying `error` would mean the contract itself broke.
+    assert "error" not in payload, f"{fx.language}: {payload.get('error')}{detail}"
+    return payload
+
+
+@pytest.fixture(scope="module")
+def roundtrip_results(roundtrip_repos) -> dict[str, dict]:
+    """One invocation per language, shared by the assertions below.
+
+    Module-scoped so the gate costs three model calls, not three per
+    assertion. If a language's call fails, its assertions fail with the
+    provider's own output attached.
+    """
+    return {
+        language: _run_neo(fx) for language, fx in sorted(roundtrip_repos.items())
+    }
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+class TestLanguageRoundTrip:
+    def test_the_result_is_not_empty(self, language, roundtrip_results):
+        """A run that returns nothing is a red language, not a quiet one."""
+        payload = roundtrip_results[language]
+
+        substance = (
+            payload.get("plan")
+            or payload.get("code_suggestions")
+            or payload.get("hypotheses")
+            or (payload.get("notes") or "").strip()
+        )
+        assert substance, (
+            f"{language}: neo returned no plan, no suggestion, no hypothesis "
+            f"and no notes"
+        )
+
+    def test_the_model_names_the_symbol_only_that_file_contains(
+        self, language, roundtrip_repos, roundtrip_results
+    ):
+        """The end-to-end assertion the free battery cannot make.
+
+        The sentinel appears in exactly one file in the fixture. The model
+        can only name it if that file reached the prompt, so this closes the
+        gap between "the gatherer selected it" and "the model saw it" — the
+        gap C# sat inside for 8.5 months.
+        """
+        fx = roundtrip_repos[language]
+        blob = json.dumps(roundtrip_results[language])
+
+        assert fx.sentinel.lower() in blob.lower(), (
+            f"{language}: the response never mentions {fx.sentinel}, the only "
+            f"symbol in {fx.target_rel}. Either the file did not reach the "
+            f"prompt or it was truncated above the symbol."
+        )
+
+    def test_confidence_is_reported(self, language, roundtrip_results):
+        """`confidence` absent is a different failure from low confidence.
+
+        Low confidence is a legitimate answer and is NOT gated here — a
+        correct refusal must not block a release. Its absence means the
+        serialization contract broke.
+        """
+        payload = roundtrip_results[language]
+
+        assert isinstance(payload.get("confidence"), (int, float)), payload.keys()
+
+    def test_the_orchestrator_envelope_is_present(self, language, roundtrip_results):
+        """Both host adapters read this envelope; a release must not ship
+        without it. See `tests/test_host_adapter_parity.py`."""
+        orchestrator = roundtrip_results[language].get("orchestrator")
+
+        assert isinstance(orchestrator, dict), orchestrator
+        assert (orchestrator.get("summary") or "").strip()
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+class TestSelectionInvariantsHoldOnTheReleaseCommit:
+    """The battery's invariants, re-asserted at the gate.
+
+    Not redundant with `test_selection_invariants.py`: that runs on a PR,
+    this runs on the commit being published. The only claim a release can
+    make about its own selection behaviour is one it measured itself.
+    """
+
+    def test_the_named_file_is_selected_and_whole(self, language, roundtrip_repos):
+        fx = roundtrip_repos[language]
+        gathered = _gather(fx)
+
+        target = next(
+            (g for g in gathered if g.rel_path == fx.target_rel), None
+        )
+        assert target is not None, [g.rel_path for g in gathered]
+        assert (target.content or "") == (
+            (fx.root / fx.target_rel).read_text(encoding="utf-8")
+        )
+
+    def test_nothing_gitignored_is_selected(self, language, roundtrip_repos):
+        fx = roundtrip_repos[language]
+        rels = [g.rel_path for g in _gather(fx)]
+
+        assert check_ignored(fx.root, rels) == []
+
+    def test_no_duplicate_copies_are_selected(self, language, roundtrip_repos):
+        fx = roundtrip_repos[language]
+        rels = [g.rel_path for g in _gather(fx)]
+        basename = Path(fx.target_rel).name
+
+        assert len(rels) == len(set(rels)), rels
+        assert [r for r in rels if Path(r).name == basename] == [fx.target_rel]

--- a/tests/test_selection_invariants.py
+++ b/tests/test_selection_invariants.py
@@ -302,3 +302,39 @@ class TestTruncationIsAlwaysMarked:
         )
         noun = "file" if cut == 1 else "files"
         assert f"{cut} {noun} truncated, marked inline" in banner, banner
+
+
+class TestThePaidHalfStaysOptIn:
+    """The round trip must not become a per-PR cost by accident.
+
+    Deleting the env gate on `tests/test_release_roundtrip.py` turns every
+    push into three model calls, and nothing else in the suite would notice —
+    the tests would simply start passing. The bill is a slow signal; this is
+    a fast one.
+    """
+
+    def test_the_round_trip_is_gated_on_an_environment_variable(self):
+        import tests.test_release_roundtrip as roundtrip
+
+        skipifs = [
+            m for m in roundtrip.pytestmark if getattr(m, "name", "") == "skipif"
+        ]
+        assert skipifs, "the round trip module lost its opt-in gate"
+        assert "NEO_RELEASE_ROUNDTRIP" in skipifs[0].kwargs.get("reason", "")
+
+    def test_the_round_trip_carries_the_marker_the_release_job_selects(self):
+        """`pytest -m roundtrip` is what publish.yml runs. An unmarked test
+        in that module is a language silently dropped from the gate."""
+        import tests.test_release_roundtrip as roundtrip
+
+        names = [getattr(m, "name", "") for m in roundtrip.pytestmark]
+        assert "roundtrip" in names
+
+    def test_every_language_is_in_the_gate(self):
+        """Both halves iterate `LANGUAGES`, so this pins the set itself.
+
+        The plan names C#, TypeScript and Python (G5-inv). A language quietly
+        dropped from the tuple would take its round trip with it and every
+        remaining test would stay green.
+        """
+        assert set(LANGUAGES) == {"csharp", "typescript", "python"}

--- a/tests/test_selection_invariants.py
+++ b/tests/test_selection_invariants.py
@@ -1,0 +1,304 @@
+"""The guard-invariant battery — the free half of the release gate.
+
+Runs on every PR (`pytest -m invariants`, and inside the ordinary suite). It
+makes NO model call: everything here is answered by the gatherer, by the
+prompt renderer, and by `git check-ignore`.
+
+The invariants are G1-inv..G3-inv from `docs/unified-store-plan.md`, asserted
+per language against the generated fixture repos in `tests/fixtures/`:
+
+- **G1-inv** zero selected files that `git check-ignore` excludes; zero
+  duplicate copies.
+- **G2-inv** a prompt-named file is present, whole or explicitly marked.
+- **G3-inv** no silent caps — every truncation is marked and the reported
+  counts match what was actually sent.
+
+Why per language rather than once: C# was absent from Neo's index for 8.5
+months (#158/#159) precisely because every check that existed was run against
+Python and passed. A single-language battery would have stayed green through
+that entire window. The language axis is the point, not decoration.
+
+The paid half — an actual LLM round trip per language — lives in
+`tests/test_release_roundtrip.py` and runs only in the release flow. Both
+halves build the same fixtures from the same module so that a red release
+gate is diagnosable from a free CI run.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from neo.context_gatherer import GatherConfig, gather_context
+from neo.engine import _CONTEXT_FILE_CHARS, _IMPORTANT_FILE_CHARS, NeoEngine
+from neo.models import ContextFile
+from tests.fixtures.language_repos import (
+    LANGUAGES,
+    FixtureRepo,
+    build_fixture_repo,
+    check_ignored,
+)
+
+pytestmark = pytest.mark.invariants
+
+
+@pytest.fixture(scope="session")
+def fixture_repos(tmp_path_factory) -> dict[str, FixtureRepo]:
+    """Build each language fixture once for the whole session.
+
+    Session-scoped because building them is three `git init`s and nothing
+    here mutates them; the gathering that tests actually assert on happens
+    per test, under conftest's per-test home isolation.
+    """
+    base = tmp_path_factory.mktemp("release_gate_fixtures")
+    return {
+        language: build_fixture_repo(language, base / language)
+        for language in LANGUAGES
+    }
+
+
+@pytest.fixture
+def repo(request, fixture_repos) -> FixtureRepo:
+    return fixture_repos[request.param]
+
+
+def _gather(fx: FixtureRepo):
+    """Gather with the same config `cli.main` builds for a plain invocation.
+
+    Deliberately not a reduced or tuned config: an invariant asserted under
+    settings no user runs is an invariant about nothing.
+    """
+    return gather_context(
+        GatherConfig(
+            root=str(fx.root),
+            prompt=fx.prompt,
+            exts=None,
+            includes=[],
+            excludes=[],
+            max_files=30,
+            use_git=True,
+        )
+    )
+
+
+def _as_engine_files(gathered) -> list[ContextFile]:
+    """The conversion `cli.main` performs before the engine sees them."""
+    return [
+        ContextFile(
+            path=g.path,
+            content=g.content,
+            line_range=(g.start, g.end) if g.start else None,
+        )
+        for g in gathered
+    ]
+
+
+def _limit_for(path: str) -> int:
+    from neo.engine import _IMPORTANT_FILE_PATTERNS
+
+    lowered = path.lower()
+    return (
+        _IMPORTANT_FILE_CHARS
+        if any(pat in lowered for pat in _IMPORTANT_FILE_PATTERNS)
+        else _CONTEXT_FILE_CHARS
+    )
+
+
+_PARAM = pytest.mark.parametrize("repo", LANGUAGES, indirect=True)
+
+
+@_PARAM
+class TestLanguageReachesContext:
+    """The 8.5-month failure, asserted as a positive per language."""
+
+    def test_the_languages_own_source_is_selected(self, repo):
+        gathered = _gather(repo)
+        rels = [g.rel_path for g in gathered]
+
+        of_language = [r for r in rels if r.endswith(f".{repo.ext}")]
+        assert of_language, (
+            f"no .{repo.ext} file reached context for {repo.language}; "
+            f"selected {rels}"
+        )
+
+    def test_the_selected_source_carries_real_content(self, repo):
+        """Selected-but-empty is the same absence with a better disguise."""
+        gathered = _gather(repo)
+        target = next(g for g in gathered if g.rel_path == repo.target_rel)
+
+        assert (target.content or "").strip(), f"{repo.target_rel} arrived empty"
+        assert repo.sentinel in (target.content or ""), (
+            f"{repo.sentinel} missing from the selected copy of "
+            f"{repo.target_rel}"
+        )
+
+
+@_PARAM
+class TestNamedFileGuarantee:
+    """G2-inv: a file the prompt names by path is present."""
+
+    def test_the_prompt_named_file_is_selected(self, repo):
+        gathered = _gather(repo)
+        rels = [g.rel_path for g in gathered]
+
+        assert repo.target_rel in rels, (
+            f"prompt named {repo.target_rel} and it was not selected; "
+            f"got {rels}"
+        )
+
+    def test_the_named_file_arrives_whole(self, repo):
+        """Whole, not a window.
+
+        `--include`/named-path semantics are "the named file, whole, or with
+        an explicit marker" (standing ruling 1). At the gatherer layer that
+        means no line range: the truncation that DOES happen to this file
+        happens later, at the prompt renderer, and is marked there — which is
+        what `TestTruncationIsAlwaysMarked` pins.
+        """
+        gathered = _gather(repo)
+        target = next(g for g in gathered if g.rel_path == repo.target_rel)
+
+        assert target.start is None and target.end is None, (
+            f"{repo.target_rel} was windowed to lines "
+            f"{target.start}-{target.end} despite being named"
+        )
+        on_disk = (repo.root / repo.target_rel).read_text(encoding="utf-8")
+        assert (target.content or "") == on_disk
+
+
+@_PARAM
+class TestNothingGitIgnoredIsSelected:
+    """G1-inv, differential half: git decides, not a second implementation."""
+
+    def test_no_selected_path_is_excluded_by_git(self, repo):
+        gathered = _gather(repo)
+        rels = [g.rel_path for g in gathered]
+
+        offenders = check_ignored(repo.root, rels)
+        assert offenders == [], (
+            f"{repo.language}: selected {len(offenders)} path(s) that "
+            f"git check-ignore excludes: {offenders}"
+        )
+
+    def test_the_planted_junk_is_specifically_absent(self, repo):
+        """A repo with nothing ignorable in it passes the test above trivially.
+
+        These files are the same language as the target, share its filename
+        stem and contain its sentinel, so they compete for the same slots.
+        """
+        gathered = _gather(repo)
+        rels = set(g.rel_path for g in gathered)
+
+        planted = sorted(rels & set(repo.ignored_rels))
+        assert planted == [], f"{repo.language}: selected ignored junk {planted}"
+
+    def test_the_planted_junk_is_ignored_by_git(self, repo):
+        """Guards the guard: junk git does not ignore proves nothing above."""
+        assert sorted(check_ignored(repo.root, list(repo.ignored_rels))) == sorted(
+            repo.ignored_rels
+        )
+
+
+@_PARAM
+class TestNoDuplicateSelections:
+    """G1-inv, dedup half. Asserted on identity, not on a count."""
+
+    def test_no_path_is_selected_twice(self, repo):
+        gathered = _gather(repo)
+        rels = [g.rel_path for g in gathered]
+
+        assert len(rels) == len(set(rels)), f"duplicate paths in {rels}"
+
+    def test_the_worktree_copy_does_not_compete_with_the_original(self, repo):
+        """The measured failure was one file selected six times, once per
+        agent worktree, at identical scores — 12 of 16 slots on 2 files."""
+        gathered = _gather(repo)
+        rels = [g.rel_path for g in gathered]
+
+        assert repo.duplicate_rel not in rels
+        basename = os.path.basename(repo.target_rel)
+        copies = [r for r in rels if os.path.basename(r) == basename]
+        assert copies == [repo.target_rel], f"{basename} selected as {copies}"
+
+    def test_no_two_selected_files_have_identical_content(self, repo):
+        """Path-level dedup misses a copy that landed under a different name."""
+        gathered = _gather(repo)
+        seen: dict[str, str] = {}
+        for g in gathered:
+            content = g.content or ""
+            if not content.strip():
+                continue
+            assert content not in seen, (
+                f"{g.rel_path} is a byte-identical copy of {seen[content]}"
+            )
+            seen[content] = g.rel_path
+
+
+@_PARAM
+class TestTruncationIsAlwaysMarked:
+    """G3-inv: no silent caps, and reported counts match reality."""
+
+    def test_every_cut_file_says_it_was_cut(self, repo):
+        gathered = _gather(repo)
+        files = _as_engine_files(gathered)
+        sections, _banner, _visible = NeoEngine._render_context_files(files)
+
+        for f, section in zip(files, sections):
+            was_cut = len(f.content or "") > _limit_for(f.path)
+            marked = "[truncated:" in section
+            assert marked is was_cut, (
+                f"{f.path}: cut={was_cut} but marker={marked}"
+            )
+
+    def test_the_target_is_actually_large_enough_to_be_cut(self, repo):
+        """Guards the guard: with nothing oversized the test above is vacuous.
+
+        The fixture keeps the target well past the cap for exactly this
+        reason, and this assertion is what fails if that ever stops being
+        true — rather than the marker test quietly passing on no evidence.
+        """
+        gathered = _gather(repo)
+        target = next(g for g in gathered if g.rel_path == repo.target_rel)
+
+        assert len(target.content or "") > _limit_for(target.path)
+
+    def test_the_sentinel_survives_the_cut(self, repo):
+        """The cut keeps the HEAD, and the fixture puts the sentinel there.
+
+        Without this the round trip could fail for a reason that has nothing
+        to do with the model: the symbol it is asked to name would have been
+        truncated away before the prompt was built.
+        """
+        gathered = _gather(repo)
+        _sections, _banner, visible = NeoEngine._render_context_files(
+            _as_engine_files(gathered)
+        )
+        target_visible = next(
+            v for v in visible if Path(v.path).name == Path(repo.target_rel).name
+        )
+
+        assert repo.sentinel in (target_visible.content or "")
+
+    def test_the_banner_counts_what_was_sent_not_what_was_offered(self, repo):
+        gathered = _gather(repo)
+        files = _as_engine_files(gathered)
+        _sections, banner, visible = NeoEngine._render_context_files(files)
+
+        sent = sum(len(v.content or "") for v in visible)
+        offered = sum(len(f.content or "") for f in files)
+
+        assert f"{sent} of {offered} chars" in banner, banner
+        assert sent < offered, (
+            "fixture stopped exercising the truncating banner form"
+        )
+
+    def test_the_banner_counts_the_truncated_files(self, repo):
+        gathered = _gather(repo)
+        files = _as_engine_files(gathered)
+        _sections, banner, _visible = NeoEngine._render_context_files(files)
+
+        cut = sum(
+            1 for f in files if len(f.content or "") > _limit_for(f.path)
+        )
+        noun = "file" if cut == 1 else "files"
+        assert f"{cut} {noun} truncated, marked inline" in banner, banner


### PR DESCRIPTION
## Description

Wires Neo's release process to a per-language LLM round trip, and every pull request to the free half of the same battery.

`build` in `publish.yml` now needs a new `language-roundtrip` job: one real `neo --json` call each for **C#, TypeScript and Python** against generated fixture repositories. A red language stops the chain at `build` and nothing reaches PyPI. `ci.yml` gains an `invariants` job that runs the same fixtures with **no model call** on every push and PR.

This is Goal 10 (G5-inv) of [`docs/unified-store-plan.md`](https://github.com/Parslee-ai/neo/blob/main/docs/unified-store-plan.md). It touches tests, CI and docs only — no gatherer or index runtime code (Goals 5–8 own those files).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

Guards the class of failure behind #158 / #159 (C# absent from the index for 8.5 months) and #186 (gatherer selected gitignored junk). Does not close them.

## Motivation and Context

Matt Liotta, on the 2026-08-10 sync: real-LLM round-trip tests per language belong in the release process — *"if that's what we have to do as part of the release process, we want to do it because we obviously want to catch that shit."* Cost-bearing model calls are approved **for releases**, not for every push.

Three failures motivate the language axis specifically, and all three were invisible from the outside:

- **C# was absent from Neo's index for 8.5 months.** Everything that could have caught it was exercised against Python, and passed.
- **The gatherer selected gitignored junk** — 14 of 16 selected files on one measured prompt.
- **Every failure printed success and exited 0.**

A single-language check would have stayed green through all of it.

### The two halves

| | Free half | Paid half |
|---|---|---|
| File | `tests/test_selection_invariants.py` | `tests/test_release_roundtrip.py` |
| Marker | `-m invariants` | `-m roundtrip` |
| Model calls | none | one per language |
| Runs on | every push and PR | the release flow, and manual dispatch |
| Wired in | `invariants` job, `ci.yml` | `language-roundtrip` job, `publish.yml` |
| Blocks | the PR | the wheel — `build` needs it |

Both build the **same** three fixture repos from `tests/fixtures/language_repos.py`. That sharing is deliberate: a red release gate has to be diagnosable from a free CI run, and it cannot be if the two halves disagree about the repository under test.

Each generated fixture is a real git repository (the invariants are defined against `git check-ignore`, and a fake cannot be differentially compared to git) holding, in its own language: a **target** file the prompt names, carrying a **sentinel** symbol present in no other file; **gitignored junk** in the same language sharing the target's filename stem and sentinel, so it competes for the same slots; a **duplicate** of the target under `.claude/worktrees/…` which is *not* gitignored, so the gatherer's own defaults must catch it; and **bulk below the sentinel** so the target exceeds the prompt's per-file cap and the truncation assertions are non-vacuous on the file that matters.

The load-bearing round-trip assertion is that **the model names the sentinel**. It exists in exactly one file, so it cannot be named unless that file reached the prompt — closing the gap between "the gatherer selected it" and "the model saw it", which is the gap C# sat inside.

## How Has This Been Tested?

### 1. Full round-trip suite, all three languages green (local, real LLM)

`NEO_INFERENCE_MODE=auto NEO_RELEASE_ROUNDTRIP=1 pytest -m roundtrip -v`

```
test_the_result_is_not_empty[csharp] PASSED
test_the_result_is_not_empty[python] PASSED
test_the_result_is_not_empty[typescript] PASSED
test_the_model_names_the_symbol_only_that_file_contains[csharp] PASSED
test_the_model_names_the_symbol_only_that_file_contains[python] PASSED
test_the_model_names_the_symbol_only_that_file_contains[typescript] PASSED
test_confidence_is_reported[csharp] PASSED
test_confidence_is_reported[python] PASSED
test_confidence_is_reported[typescript] PASSED
test_the_orchestrator_envelope_is_present[csharp] PASSED
test_the_orchestrator_envelope_is_present[python] PASSED
test_the_orchestrator_envelope_is_present[typescript] PASSED
test_the_named_file_is_selected_and_whole[csharp] PASSED
test_the_named_file_is_selected_and_whole[python] PASSED
test_the_named_file_is_selected_and_whole[typescript] PASSED
test_nothing_gitignored_is_selected[csharp] PASSED
test_nothing_gitignored_is_selected[python] PASSED
test_nothing_gitignored_is_selected[typescript] PASSED
test_no_duplicate_copies_are_selected[csharp] PASSED
test_no_duplicate_copies_are_selected[python] PASSED
test_no_duplicate_copies_are_selected[typescript] PASSED

21 passed, 2195 deselected in 123.33s (0:02:03)
```

### 2. Invariant battery (free, no model call)

`pytest -m invariants` → **48 passed, 2168 deselected in 29.71s**. The `invariants` CI job on this PR is the run the DoD asks for.

### 3. Mutation check — the battery actually fails when the product breaks

Each mutation applied to `src/`, battery run, then reverted (`git checkout --`; working tree confirmed clean after).

| Mutation | Result |
|---|---|
| Gatherer stops reading the repo's `.gitignore` | **6 failed**, 42 passed |
| Agent-worktree layout exclusions removed | **6 failed**, 42 passed |
| Prompt renderer cuts without a marker | **3 failed**, 45 passed |

### 4. The paid half stays opted out

`pytest -m roundtrip` with no env var → **21 skipped**, each with the reason printed. They skip rather than deselect on purpose: an ordinary run should *show* that the gate exists. The `invariants` CI job asserts this negative directly — it fails if any round trip executes on a PR, and fails if none were collected at all. Three tests in the battery pin the gate itself (env-gated, marker present, all three languages in `LANGUAGES`), so deleting it turns every PR red rather than expensive.

### 5. Credential-absent behaviour

Reproduced locally: with no provider configured, the round trip fails with `Failed to initialize LM adapter`. The CI job asserts the secret up front and **fails rather than skips**. An absent credential is a red gate, not a green one.

**Test Configuration**: Python 3.13.7 · macOS (darwin 25.5.0) · neo @ this branch · provider routed via CAR locally, Anthropic in CI.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes — see the two caveats below
- [x] Any dependent changes have been merged and published

## Additional Notes

Three things a reviewer should decide on rather than discover.

**1. `ANTHROPIC_API_KEY` is not configured on this repo, so the gate blocks releases until it is added.** That is the gate working, and it is deliberate — a job that skips when unconfigured is the same defect as a failure that exits 0. It needs adding at Settings → Secrets and variables → Actions before the next release. Optional variable `NEO_RELEASE_MODEL` overrides the model; the default matches `adapters.create_adapter`'s own Anthropic default so the gate and the library cannot drift.

**2. The round trip can go red for reasons that are not about file selection, and it is not retried.** Measured during bring-up: two consecutive local runs of the same commit, one 21/21 green, the next red on Python with `ValidationError: Failed to parse simulation traces: missing_start_sentinel`. The gatherer had selected the right four files both times; the model's reply simply lacked neo's v3 sentinel. A user issuing that command gets the same error, so it is a genuine release blocker — and a gate that retries until green is the defect this goal exists to prevent. What the PR does instead is make the failure *name its layer*, and record that `pytest -m invariants` will be **green** when the parser is the cause. That contrast is the fastest diagnosis available and it costs nothing. Expect it to bite occasionally; the right response is to fix the brittleness, not loosen the gate.

**3. One pre-existing test failure on `main`, untouched by this branch.** `tests/test_integration.py::TestPerformanceIntegration::test_consolidation_performance_with_all_boosts` asserts a wall-clock `<100ms` bound and measures **198.2ms on this machine**. Reproduced on `origin/main` @ `5bbee46` with an identical `src/`; this branch changes no file under `src/` and does not touch `test_integration.py`. Left alone as out of scope. Worth noting it is the same defect class `CLAUDE.md` already documents for the learning-loop benchmark — a hardware-dependent latency threshold gating a correctness verdict — and it will flap on shared runners.

**Also included, one line:** `publish.yml`'s `ci-check` was linting `src/ tests/` while `ci.yml`, the Makefile and the pre-commit hook lint `src/ tests/ tools/`. The release path enforced less than a pull request did. Now aligned.

Full reference: [`docs/release-gate.md`](https://github.com/Parslee-ai/neo/blob/goalpool/g_mspyjqfj_ddd931-unified-store-goal-10/docs/release-gate.md).
