### PR TITLE
fix(trust): language-aware constraint markers (#196) and a confidence scale without a sentinel (#199)

### DIFF
--- a/.claude-plugin/agents/neo.md
+++ b/.claude-plugin/agents/neo.md
@@ -100,6 +100,15 @@ Then:
    plainly: "Neo found…" versus "Looking at this myself…". Never present your
    own reasoning as Neo's, or the reverse.
 6. Report Neo's confidence as the number it is. Do not round it up in prose.
+7. **`confidence` may be `null`, and that is an answer, not a gap.** It means
+   the run produced nothing a confidence number could describe — read
+   `confidence_basis` and say which: `analysis_only` (Neo answered and proposed
+   no change) or `no_verifiable_change` (Neo named files but shipped no diff,
+   so those suggestions were excluded from the score). Never substitute a
+   number, never call a `null` run low-confidence, and never rank it below a
+   scored run on the strength of the missing number — an empty patch
+   self-reporting `0.96` is the exact inversion this contract exists to stop.
+   `orchestrator.summary` already states the case in Neo's voice; lead with it.
 
 ### Voice
 
@@ -161,7 +170,7 @@ Events on stderr are `{"type": ..., "phase": ..., "message": ..., "data": {...}}
 | `hypothesis_rejected` | An approach was discarded. Worth surfacing. |
 | `risk_found` | A simulation issue or failed static check. Worth surfacing. |
 | `personality_beat` | Same line as `orchestrator.personality`. |
-| `completed` | Run finished. `data.confidence`, `data.elapsed_seconds`. |
+| `completed` | Run finished. `data.confidence` (may be `null`), `data.elapsed_seconds`. |
 | `failed` | Run raised. `data.error_type`. **No final JSON result follows.** |
 
 Exactly one of `completed` or `failed` terminates every run. If you see
@@ -203,6 +212,7 @@ Use the Neo agent to debug this race condition in the task processor.
 ## Important Notes
 
 - Neo queries take 5-30 seconds (uses LLM API calls)
-- Always verify low-confidence suggestions (<0.7)
+- Always verify low-confidence suggestions (<0.7). A `null` confidence is not a
+  low one — check `confidence_basis` before saying anything about certainty.
 - Provide rich context for better results
 - Ordinary analysis is explicit `advise` and does not mutate durable memory. Use `learn` only when the user intends to record evidence; never request `agent` without explicit workspace authority and a host executor.

--- a/plugins/neo/skills/neo/SKILL.md
+++ b/plugins/neo/skills/neo/SKILL.md
@@ -62,6 +62,16 @@ purpose:
 | `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
 | `recommended_narration` | Advisory progress lines. Reword freely. |
 
+`confidence` may be `null`, which is an answer rather than a gap: the run
+produced nothing a confidence number could describe. Read `confidence_basis`
+and report which case it is — `analysis_only` (Neo answered and proposed no
+change) or `no_verifiable_change` (Neo named files but shipped no diff, so
+those suggestions were excluded from the score). Do not substitute a number,
+do not call a `null` run low-confidence, and do not rank it beneath a scored
+run: an empty patch self-reporting `0.96` outranking a correct analysis is the
+inversion this contract exists to stop. Neo's result is an input to your work,
+not the deliverable — so state which case it is rather than papering over it.
+
 Useful event types on stderr: `memory_found` (prior facts recalled),
 `hypothesis_formed`, `hypothesis_rejected` (an approach was discarded — usually
 worth surfacing), `risk_found`, and exactly one of `completed` or `failed`
@@ -114,4 +124,5 @@ is no fallback line.
 
 - This skill uses explicit `advise` mode: it may retrieve established memory but does not create candidates or update durable memory. Use `neo --mode learn` only when the user intends to contribute outcome evidence.
 - For code review, optimization, architectural decisions, debugging, or pattern extraction, prefer the more specific Neo skills (`$neo-review`, `$neo-optimize`, `$neo-architect`, `$neo-debug`, `$neo-pattern`).
-- Always verify low-confidence suggestions (< 0.7) before applying them.
+- Always verify low-confidence suggestions (< 0.7) before applying them. A
+  `null` confidence is not a low one — read `confidence_basis` first.

--- a/src/neo/car_tool_schema.py
+++ b/src/neo/car_tool_schema.py
@@ -432,6 +432,7 @@ def neo_output_to_dict(output: NeoOutput) -> dict[str, Any]:
         "static_checks": [_static_check_to_dict(c) for c in output.static_checks],
         "next_questions": list(output.next_questions),
         "confidence": output.confidence,
+        "confidence_basis": output.confidence_basis,
         "notes": output.notes,
         "metadata": dict(output.metadata),
         "goal_assessment": (

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -1420,6 +1420,7 @@ def main():
             ],
             "next_questions": output.next_questions,
             "confidence": output.confidence,
+            "confidence_basis": output.confidence_basis,
             "notes": output.notes,
             "metadata": output.metadata,
             "goal_assessment": (
@@ -1443,7 +1444,8 @@ def main():
             output.confidence,
             output.next_questions,
             output.plan,
-            output.code_suggestions
+            output.code_suggestions,
+            output.confidence_basis,
         )
         output_dict["confidence_interpretation"] = confidence_interpretation
 
@@ -1454,7 +1456,15 @@ def main():
         else:
             # Human-readable text mode
             print("\n" + "="*80)
-            print(f"CONFIDENCE: {output.confidence:.2f}")
+            if output.confidence is None:
+                # Printing "0.50" here is what made a correct analysis look
+                # like a hedged one. The interpretation carries the reason.
+                print(
+                    f"CONFIDENCE: n/a "
+                    f"({confidence_interpretation['message']})"
+                )
+            else:
+                print(f"CONFIDENCE: {output.confidence:.2f}")
             print("="*80)
 
             # The same summary a host would relay, so the terminal reader and

--- a/src/neo/config/beats/neo_matrix.yaml
+++ b/src/neo/config/beats/neo_matrix.yaml
@@ -111,6 +111,7 @@ orchestrator_voice:
     phase_checks_clean: "All {count} checker(s) clean."
     phase_checks_failed: "{failed} of {count} checker(s) pushed back."
     phase_checks_none: "No checkers here. Nothing verified this."
+    phase_checks_inconclusive: "The checkers ran and could evaluate none of it. Treat this as unverified."
     phase_checks_considering: "Considering the checkers."
     phase_checks_skipped: "Out of time before I could run them. This is unchecked."
 

--- a/src/neo/config/beats/neo_matrix.yaml
+++ b/src/neo/config/beats/neo_matrix.yaml
@@ -72,12 +72,23 @@ orchestrator_voice:
     verify_clean: "nothing pushed back"
     verify_none: "no checkers could run"
 
+    # Said instead of a number when there is no code change to score. Stage
+    # -neutral like the cautions: "I have no score for this" is a fact about
+    # the run, and a terse stage must not shorten it into looking like one.
+    confidence_analysis_only: "No confidence score — I proposed no code change."
+    confidence_no_verifiable_change: >-
+      No confidence score — I named a file and produced no change to go
+      with it.
+
     # Cautions — stage-neutral by design (see the note above).
     caution_low_confidence: "I'm at {confidence} on this. Don't take it on trust — check it."
     caution_check_failed: "{tool} isn't happy: {summary}"
     caution_sim_issues: "I ran this through and hit {count} problem(s) with my own approach."
     caution_unverified_skipped: "I ran out of time before the checkers. This code is unverified."
     caution_unverified_no_tools: "No checkers on this machine. This code is unverified."
+    caution_no_verifiable_change: >-
+      {count} suggestion(s) named a file but carried no diff and no code.
+      Nothing here is verifiable — treat this as no answer, not a safe one.
     caution_open_question: "Still open: {question}"
     caution_validation_blocked: "Proof still missing for required gate {gate_id}."
     caution_hypothesis_provisional: "Causal claim {hypothesis_id} is still {status}; do not publish it as fact."

--- a/src/neo/constraint_verification.py
+++ b/src/neo/constraint_verification.py
@@ -100,7 +100,10 @@ _PYTHON_MARKERS: Dict[ConstraintType, tuple] = {
     ConstraintType.SORTED: ("sorted(", ".sort(", "heappush", "heappop", "bisect"),
     ConstraintType.INCREASING: ("sorted(", ".sort(", "bisect"),
     ConstraintType.DECREASING: ("sorted(", ".sort(", "reverse=True"),
-    ConstraintType.UNIQUE_ELEMENTS: ("set(", "dict.fromkeys"),
+    # `frozenset(` is listed in its own right: markers are matched on left
+    # identifier boundaries, so it is no longer reached as a substring of
+    # `set(` — which is the same rule that stops `offset(` reaching it.
+    ConstraintType.UNIQUE_ELEMENTS: ("set(", "frozenset(", "dict.fromkeys"),
     ConstraintType.NON_NEGATIVE: ("abs(", "max(0"),
     ConstraintType.DIVISIBILITY: ("%",),
 }
@@ -126,7 +129,9 @@ _TYPESCRIPT_MARKERS: Dict[ConstraintType, tuple] = {
     ConstraintType.SORTED: (".sort(", "sortBy(", "orderBy(", "toSorted("),
     ConstraintType.INCREASING: (".sort(", "sortBy(", "toSorted("),
     ConstraintType.DECREASING: (".sort(", ".reverse(", "toReversed(", "orderBy("),
-    ConstraintType.UNIQUE_ELEMENTS: ("new Set", "uniq(", "uniqBy(", "Set<"),
+    # `new Set(` carries its trailing paren so it cannot be found inside
+    # `new Settings()`; `Set<` covers the annotated form.
+    ConstraintType.UNIQUE_ELEMENTS: ("new Set(", "uniq(", "uniqBy(", "Set<"),
     ConstraintType.NON_NEGATIVE: ("Math.abs(", "Math.max(0"),
     ConstraintType.DIVISIBILITY: ("%",),
 }

--- a/src/neo/constraint_verification.py
+++ b/src/neo/constraint_verification.py
@@ -84,9 +84,19 @@ class Constraint:
 
 # Code-level markers that suggest a given constraint type is handled in the
 # generated code. Used by the static (no-exec) checker in engine.py.
+#
 # Absence of a marker is a warning, not an error — the LM may satisfy the
-# constraint through other means.
-CONSTRAINT_CODE_MARKERS: Dict[ConstraintType, tuple] = {
+# constraint through other means. That reasoning covers a different *approach*;
+# it never covered a different *language*. These tables were Python-only, so on
+# every C#/TypeScript/markdown target the expectation was unsatisfiable by
+# construction and the warning fired permanently (#196). Markers are therefore
+# keyed by language, and a language with no table produces an honest "not
+# checked" note instead of a false alarm.
+#
+# Markers are compared case-insensitively against the (comment- and
+# string-stripped) code, so they are written here in their natural casing —
+# `HashSet<` reads better in the operator-facing message than `hashset<`.
+_PYTHON_MARKERS: Dict[ConstraintType, tuple] = {
     ConstraintType.SORTED: ("sorted(", ".sort(", "heappush", "heappop", "bisect"),
     ConstraintType.INCREASING: ("sorted(", ".sort(", "bisect"),
     ConstraintType.DECREASING: ("sorted(", ".sort(", "reverse=True"),
@@ -94,6 +104,91 @@ CONSTRAINT_CODE_MARKERS: Dict[ConstraintType, tuple] = {
     ConstraintType.NON_NEGATIVE: ("abs(", "max(0"),
     ConstraintType.DIVISIBILITY: ("%",),
 }
+
+_CSHARP_MARKERS: Dict[ConstraintType, tuple] = {
+    ConstraintType.SORTED: (
+        "OrderBy", ".Sort(", "Array.Sort", "SortedSet<", "SortedList<",
+        "SortedDictionary<", "PriorityQueue<", "BinarySearch",
+    ),
+    ConstraintType.INCREASING: ("OrderBy", ".Sort(", "SortedSet<", "BinarySearch"),
+    ConstraintType.DECREASING: ("OrderByDescending", ".Sort(", ".Reverse("),
+    ConstraintType.UNIQUE_ELEMENTS: (
+        "HashSet<", "ToHashSet(", ".Distinct(", ".GroupBy(", "ISet<",
+    ),
+    ConstraintType.NON_NEGATIVE: ("Math.Abs", "Math.Max(0", "Math.Clamp("),
+    ConstraintType.DIVISIBILITY: ("%",),
+}
+
+# TypeScript and JavaScript share a table: the constructs a constraint is
+# satisfied with (`Array.prototype.sort`, `new Set`) are the runtime's, not the
+# type layer's, so splitting them would duplicate every entry to no effect.
+_TYPESCRIPT_MARKERS: Dict[ConstraintType, tuple] = {
+    ConstraintType.SORTED: (".sort(", "sortBy(", "orderBy(", "toSorted("),
+    ConstraintType.INCREASING: (".sort(", "sortBy(", "toSorted("),
+    ConstraintType.DECREASING: (".sort(", ".reverse(", "toReversed(", "orderBy("),
+    ConstraintType.UNIQUE_ELEMENTS: ("new Set", "uniq(", "uniqBy(", "Set<"),
+    ConstraintType.NON_NEGATIVE: ("Math.abs(", "Math.max(0"),
+    ConstraintType.DIVISIBILITY: ("%",),
+}
+
+LANGUAGE_CONSTRAINT_MARKERS: Dict[str, Dict[ConstraintType, tuple]] = {
+    "python": _PYTHON_MARKERS,
+    "csharp": _CSHARP_MARKERS,
+    "typescript": _TYPESCRIPT_MARKERS,
+    "javascript": _TYPESCRIPT_MARKERS,
+}
+
+# Back-compat: this name has always meant "the Python markers", and now says so.
+CONSTRAINT_CODE_MARKERS: Dict[ConstraintType, tuple] = _PYTHON_MARKERS
+
+# Extension → language label. Entries whose label is a key of
+# LANGUAGE_CONSTRAINT_MARKERS are checkable; the rest exist so the "not
+# checked" note can name what the file actually is ("not checked for
+# markdown") rather than shrugging at it.
+_EXTENSION_LANGUAGES: Dict[str, str] = {
+    ".py": "python", ".pyi": "python",
+    ".cs": "csharp", ".csx": "csharp",
+    ".ts": "typescript", ".tsx": "typescript", ".mts": "typescript",
+    ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".md": "markdown", ".markdown": "markdown",
+    ".json": "json",
+    ".yaml": "yaml", ".yml": "yaml",
+    ".txt": "text",
+    ".rs": "rust", ".go": "go", ".java": "java", ".rb": "ruby",
+    ".php": "php", ".kt": "kotlin", ".swift": "swift",
+    ".c": "c", ".h": "c", ".cpp": "cpp", ".hpp": "cpp", ".cc": "cpp",
+    ".sql": "sql", ".sh": "shell", ".html": "html", ".css": "css",
+}
+
+# What a path with no usable extension is called in the message. A caution
+# saying "not checked for " reads as a bug in Neo, not as a limit of Neo.
+UNKNOWN_LANGUAGE = "unknown"
+
+
+def language_for_path(file_path: str) -> str:
+    """Name the language of a suggested file, for marker lookup and messaging.
+
+    Returns a canonical name when the extension is known (``python``,
+    ``csharp``, …), the bare extension when it is not (so a note can still say
+    which kind of file went unchecked), and ``UNKNOWN_LANGUAGE`` when there is
+    no extension to go on — including the ``/`` and ``N/A`` placeholders the
+    suggestion schema uses for analysis-only answers.
+    """
+    from pathlib import PurePosixPath
+
+    path = (file_path or "").strip()
+    if not path or path in ("/", "N/A", "n/a"):
+        return UNKNOWN_LANGUAGE
+    suffix = PurePosixPath(path).suffix.lower()
+    if not suffix:
+        return UNKNOWN_LANGUAGE
+    return _EXTENSION_LANGUAGES.get(suffix, suffix.lstrip("."))
+
+
+def markers_for_language(language: str) -> Dict[ConstraintType, tuple]:
+    """Marker table for a language, or an empty mapping when there is none."""
+    return LANGUAGE_CONSTRAINT_MARKERS.get(language, {})
 
 
 class ConstraintVerifier:

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -35,6 +35,9 @@ from neo.events import (
 )
 from neo.text_budget import apportion, elide_middle, shown_of, truncate_marked
 from neo.models import (
+    CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
+    CONFIDENCE_BASIS_SUGGESTIONS,
+    CONFIDENCE_BASIS_VERIFICATION,
     AppliedAction,
     CodeSuggestion,
     ContextFile,
@@ -104,6 +107,14 @@ _DELIBERATION_TOTAL_CHARS = 6000
 
 # Per-exemplar solution text in the "Similar Past Tasks" prompt section.
 _EXEMPLAR_SOLUTION_CHARS = 100
+
+# Prior written onto a legacy memory entry when the run itself produced no
+# scoreable code change. That number is a starting weight for a stored pattern,
+# on a scale the retrieval layer owns; it is NOT the run's operator-facing
+# confidence, which is `None` in exactly this case. Both used to be 0.5, which
+# is how one value came to mean two things (#199) — keeping them separate is
+# the fix, and naming this one is what keeps them separate.
+UNSCORED_MEMORY_PRIOR = 0.5
 
 # Community-cache fallback, used only when FactStore retrieval finds nothing
 # similar enough. That is precisely when the model has the least other
@@ -493,7 +504,11 @@ class NeoEngine:
             self._emit(
                 NeoEventType.COMPLETED,
                 message=output.orchestrator.summary or self._voice("completed_fallback"),
-                confidence=round(output.confidence, 3),
+                confidence=(
+                    round(output.confidence, 3)
+                    if output.confidence is not None else None
+                ),
+                confidence_basis=output.confidence_basis,
                 elapsed_seconds=round(time.time() - start_time, 2),
             )
             return output
@@ -976,6 +991,10 @@ class NeoEngine:
             static_checks=static_checks,
             next_questions=[],
             confidence=confidence,
+            # VERIFY's number is a pass/fail verdict over checks that ran, not
+            # a self-assessment of a patch — it belongs on its own basis so no
+            # consumer reads it as one.
+            confidence_basis=CONFIDENCE_BASIS_VERIFICATION,
             enriched_context={},
             start_time=start_time,
             difficulty="verification",
@@ -1254,8 +1273,17 @@ class NeoEngine:
         # error-severity diagnostics. An objective signal (static analysis
         # actually ran and is clean) is required — we do NOT early-exit when
         # static_checks is empty because no tools were available.
-        if code_suggestions and self._simulation_consensus(simulation_traces):
-            max_confidence = max((s.confidence for s in code_suggestions), default=0.0)
+        # Only suggestions that actually carry a change may gate the early
+        # exit. A self-reported 0.96 attached to an empty diff is an opinion
+        # about a patch that was never written, and EARLY_EXIT_CONFIDENCE is
+        # what decides whether the checkers run at all (#199).
+        from neo.models import suggestion_is_scoreable
+
+        scoreable_suggestions = [
+            s for s in code_suggestions if suggestion_is_scoreable(s)
+        ]
+        if scoreable_suggestions and self._simulation_consensus(simulation_traces):
+            max_confidence = max(s.confidence for s in scoreable_suggestions)
             check_statuses = [self._static_check_status(check) for check in static_checks]
             static_ran_clean = bool(check_statuses) and all(
                 status == "passed" for status in check_statuses
@@ -1291,7 +1319,7 @@ class NeoEngine:
         next_questions = self._generate_questions(
             plan, simulation_traces, code_suggestions, static_checks
         )
-        confidence = self._calculate_confidence(
+        confidence, confidence_basis = self._calculate_confidence(
             plan, simulation_traces, code_suggestions, static_checks
         )
 
@@ -1303,6 +1331,7 @@ class NeoEngine:
             static_checks=static_checks,
             next_questions=next_questions,
             confidence=confidence,
+            confidence_basis=confidence_basis,
             enriched_context=enriched_context,
             start_time=start_time,
             difficulty=difficulty,
@@ -1339,9 +1368,10 @@ class NeoEngine:
         code_suggestions: list[CodeSuggestion],
         static_checks: list[StaticCheckResult],
         next_questions: list[str],
-        confidence: float,
+        confidence: Optional[float],
         enriched_context: dict[str, Any],
         start_time: float,
+        confidence_basis: str = CONFIDENCE_BASIS_SUGGESTIONS,
         difficulty: str,
         time_budget: float,
         early_exit: bool,
@@ -1495,6 +1525,7 @@ class NeoEngine:
             static_checks=static_checks,
             next_questions=next_questions,
             confidence=confidence,
+            confidence_basis=confidence_basis,
             early_exit=early_exit,
         )
         if orchestrator.personality:
@@ -1512,6 +1543,7 @@ class NeoEngine:
             next_questions=next_questions,
             confidence=confidence,
             notes=self._generate_notes(plan, simulation_traces, static_checks),
+            confidence_basis=confidence_basis,
             metadata=metadata,
             goal_assessment=goal_assessment,
             strategy_assessment=strategy_assessment,
@@ -2570,7 +2602,15 @@ RULES:
 
     @staticmethod
     def _static_check_status(check: StaticCheckResult) -> str:
-        """Normalize legacy check results without treating absence as success."""
+        """Normalize legacy check results without treating absence as success.
+
+        A result carrying only informational diagnostics reports `skipped`, not
+        `passed`. The distinction is load-bearing: `passed` is what lets the run
+        exit early on the strength of clean static analysis, and a checker that
+        could not evaluate anything (no marker set for the target language) has
+        supplied no such evidence. Calling that clean is how a check that
+        verified nothing ends up vouching for the answer.
+        """
         if check.status:
             return check.status
         severities = {
@@ -2578,9 +2618,38 @@ RULES:
         }
         if "error" in severities:
             return "failed"
-        if check.diagnostics:
+        if NeoEngine._actionable_diagnostics(check.diagnostics):
             return "warning"
+        if check.diagnostics:
+            return "skipped"
         return "passed"
+
+    # Severities that report a fact about the run rather than a problem with
+    # it. Anything else — including a diagnostic with no severity at all —
+    # counts as actionable, so an unrecognized severity fails toward being
+    # surfaced rather than toward silence.
+    _INFORMATIONAL_SEVERITIES = frozenset({"info", "note", "skipped"})
+
+    @staticmethod
+    def _is_actionable_diagnostic(diagnostic: dict[str, Any]) -> bool:
+        """True when a diagnostic asserts a problem the operator can act on."""
+        severity = str(diagnostic.get("severity", "")).lower()
+        return severity not in NeoEngine._INFORMATIONAL_SEVERITIES
+
+    @staticmethod
+    def _actionable_diagnostics(
+        diagnostics: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """The subset of diagnostics that should count as issues.
+
+        Issue counts, confidence penalties and next-question prompts all read
+        this rather than `len(diagnostics)`: a note saying a constraint went
+        unchecked must not be relayed as a constraint that failed.
+        """
+        return [
+            item for item in diagnostics
+            if NeoEngine._is_actionable_diagnostic(item)
+        ]
 
     def _community_fallback_learnings(self, prompt_text: str) -> str:
         """Return formatted community facts when the primary store misses.
@@ -2695,39 +2764,78 @@ RULES:
 
         Pure textual checks with comment/string stripping. Does NOT execute
         code. Absence of a handler marker is a warning, not an error.
+
+        The markers are looked up per language. A caution may only claim "no
+        obvious handler" when a marker set for THAT language was actually
+        consulted; where none exists the constraint is reported as unchecked at
+        `info` severity, which the callers below deliberately exclude from
+        issue counts and confidence penalties. The Python-only table used to be
+        applied to every target, so a C# file satisfying uniqueness with
+        `HashSet<T>` — or a markdown file satisfying nothing at all — tripped a
+        warning that no code could ever clear (#196). A caution channel with a
+        permanent entry teaches operators to skip the channel.
         """
         if not constraints or not suggestions:
             return None
 
-        from neo.constraint_verification import CONSTRAINT_CODE_MARKERS
+        from neo.constraint_verification import (
+            language_for_path,
+            markers_for_language,
+        )
 
         diagnostics: list[dict[str, Any]] = []
         for sug in suggestions:
             raw = sug.code_block or sug.unified_diff or ""
             code = self._strip_comments_and_strings(raw).lower()
+            language = language_for_path(sug.file_path)
+            markers = markers_for_language(language)
             for c in constraints:
-                hints = CONSTRAINT_CODE_MARKERS.get(c.type)
+                hints = markers.get(c.type)
                 if not hints:
+                    diagnostics.append({
+                        "severity": "info",
+                        "message": (
+                            f"Constraint '{c.description}' was not checked: no "
+                            f"{language} marker set for constraint type "
+                            f"'{c.type.value}'"
+                        ),
+                        "constraint_type": c.type.value,
+                        "file_path": sug.file_path,
+                        "language": language,
+                    })
                     continue
                 if not any(h.lower() in code for h in hints):
                     diagnostics.append({
                         "severity": "warning",
                         "message": (
                             f"Prompt declares constraint '{c.description}' but "
-                            f"generated code shows no obvious handler "
+                            f"generated {language} code shows no obvious handler "
                             f"(expected one of: {', '.join(hints)})"
                         ),
                         "constraint_type": c.type.value,
                         "file_path": sug.file_path,
+                        "language": language,
                     })
 
         if not diagnostics:
             return None
 
+        unhandled = self._actionable_diagnostics(diagnostics)
+        unchecked = [
+            item for item in diagnostics
+            if not self._is_actionable_diagnostic(item)
+        ]
+        parts = []
+        if unhandled:
+            parts.append(f"{len(unhandled)} constraint(s) may not be handled")
+        if unchecked:
+            languages = ", ".join(sorted({item["language"] for item in unchecked}))
+            parts.append(f"{len(unchecked)} not checked ({languages})")
+
         return StaticCheckResult(
             tool_name="constraint_verifier",
             diagnostics=diagnostics,
-            summary=f"{len(diagnostics)} constraint(s) may not be handled",
+            summary="; ".join(parts),
         )
 
     def _generate_questions(
@@ -2747,11 +2855,14 @@ RULES:
                     f"Simulation found: {issue}" for issue in sim.issues_found[:2]
                 ])
 
-        # Questions from static checks
+        # Questions from static checks. Counts the actionable diagnostics only:
+        # "constraint_verifier found 1 issues" for a note saying the constraint
+        # could not be checked is the false alarm this channel must not carry.
         for check in checks:
-            if check.diagnostics:
+            actionable = self._actionable_diagnostics(check.diagnostics)
+            if actionable:
                 questions.append(
-                    f"{check.tool_name} found {len(check.diagnostics)} issues"
+                    f"{check.tool_name} found {len(actionable)} issues"
                 )
 
         # Questions from low-confidence suggestions
@@ -2770,23 +2881,67 @@ RULES:
         simulations: list[SimulationTrace],
         suggestions: list[CodeSuggestion],
         checks: list[StaticCheckResult],
-    ) -> float:
-        """Calculate overall confidence score."""
-        if not suggestions:
-            return 0.5
+    ) -> tuple[Optional[float], str]:
+        """Score the run's code suggestions, or say why there is no score.
+
+        Returns `(confidence, basis)`. `confidence` is None whenever this run
+        produced nothing a code-change score can describe, and `basis` names
+        which of those cases it was.
+
+        `0.5` used to be returned for "no suggestions" — a sentinel sitting on
+        the same scale the number is read against everywhere else, so an
+        analysis run that answered three sub-questions correctly landed on
+        "Proceed with caution - some uncertainties remain" while a run that
+        emitted an empty patch and declined to name findings scored its own
+        self-reported 0.96 and read as READY_TO_IMPLEMENT (#199). Both halves
+        of that inversion are fixed here: the sentinel comes off the scale, and
+        a suggestion naming a real file with no diff and no code block is
+        excluded from the average rather than allowed to grade a patch that
+        does not exist.
+        """
+        from neo.models import (
+            CONFIDENCE_BASIS_ANALYSIS_ONLY,
+            CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
+            CONFIDENCE_BASIS_SUGGESTIONS,
+            suggestion_is_review_marker,
+            suggestion_is_scoreable,
+        )
+
+        scoreable = [s for s in suggestions if suggestion_is_scoreable(s)]
+        if not scoreable:
+            # Two very different runs land here, and the operator needs to be
+            # able to tell them apart: one answered without proposing a change,
+            # the other claimed a file and delivered nothing.
+            empty_changes = [
+                s for s in suggestions if not suggestion_is_review_marker(s)
+            ]
+            basis = (
+                CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE if empty_changes
+                else CONFIDENCE_BASIS_ANALYSIS_ONLY
+            )
+            return None, basis
 
         # Average suggestion confidence
-        avg_confidence = sum(s.confidence for s in suggestions) / len(suggestions)
+        avg_confidence = sum(s.confidence for s in scoreable) / len(scoreable)
 
         # Penalty for simulation issues (reduced from 0.05 to 0.02)
         total_issues = sum(len(s.issues_found) for s in simulations)
         issue_penalty = min(0.15, total_issues * 0.02)  # Cap reduced from 0.3 to 0.15
 
-        # Penalty for static check failures (reduced from 0.02 to 0.01)
-        total_diagnostics = sum(len(c.diagnostics) for c in checks)
+        # Penalty for static check failures (reduced from 0.02 to 0.01).
+        # Informational diagnostics are excluded: a checker reporting that it
+        # had no marker set for the target language has found no fault to
+        # penalize, and docking confidence for it would be the same false alarm
+        # in a different currency.
+        total_diagnostics = sum(
+            len(self._actionable_diagnostics(c.diagnostics)) for c in checks
+        )
         check_penalty = min(0.1, total_diagnostics * 0.01)  # Cap reduced from 0.2 to 0.1
 
-        return max(0.0, min(1.0, avg_confidence - issue_penalty - check_penalty))
+        return (
+            max(0.0, min(1.0, avg_confidence - issue_penalty - check_penalty)),
+            CONFIDENCE_BASIS_SUGGESTIONS,
+        )
 
     # Used whenever the deck is missing, empty, or the wrong shape. Every
     # consumer (`_voice`, `_voice_stage`, `_generate_notes`) assumes a mapping,
@@ -2933,7 +3088,7 @@ RULES:
         self._beat_selected = True
         return self._selected_beat
 
-    def _orchestrator_beat(self, confidence: float) -> str:
+    def _orchestrator_beat(self, confidence: Optional[float]) -> str:
         """Return the host-facing personality line, or "" to stay silent.
 
         Silence is the default and the safe answer. A beat is relayed only when
@@ -2956,8 +3111,9 @@ RULES:
         code_suggestions: list[CodeSuggestion],
         static_checks: list[StaticCheckResult],
         next_questions: list[str],
-        confidence: float,
+        confidence: Optional[float],
         early_exit: bool,
+        confidence_basis: str = CONFIDENCE_BASIS_SUGGESTIONS,
     ) -> OrchestratorMessage:
         """State what this run did, so a host doesn't have to infer it.
 
@@ -3028,10 +3184,20 @@ RULES:
                 else "opener_solo", ""
             )
             confidence_lead = stage.get("confidence_lead", "")
-            confidence_text = (
-                f"{confidence_lead} {confidence:.2f}." if confidence_lead
-                else f"{confidence:.2f}."
-            )
+            if confidence is None:
+                # Saying a number here would be inventing one. Which kind of
+                # "no number" it is matters to the reader, so the two cases get
+                # two lines rather than one shrug.
+                confidence_text = self._voice(
+                    "confidence_no_verifiable_change"
+                    if confidence_basis == CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE
+                    else "confidence_analysis_only"
+                )
+            else:
+                confidence_text = (
+                    f"{confidence_lead} {confidence:.2f}." if confidence_lead
+                    else f"{confidence:.2f}."
+                )
             summary = " ".join(
                 part for part in (
                     opener,
@@ -3047,10 +3213,21 @@ RULES:
         # VERIFY reports confidence as a pass/fail verdict (0.0 on any failure),
         # not as self-assessed certainty, so the "verify this yourself" advice
         # would be both circular and wrong.
-        if not verification_only and confidence < self.LOW_CONFIDENCE:
+        if (
+            not verification_only
+            and confidence is not None
+            and confidence < self.LOW_CONFIDENCE
+        ):
             cautions.append(
                 self._voice("caution_low_confidence", confidence=f"{confidence:.2f}")
             )
+        # A run that named files and shipped no change is not a quiet outcome:
+        # its suggestions were dropped from the score precisely because they
+        # asserted an edit that is not there.
+        if confidence_basis == CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE:
+            cautions.append(self._voice(
+                "caution_no_verifiable_change", count=len(code_suggestions),
+            ))
         for check in failed_checks:
             cautions.append(self._voice(
                 "caution_check_failed", tool=check.tool_name, summary=check.summary,
@@ -3189,7 +3366,7 @@ RULES:
         neo_input: NeoInput,
         plan: list[PlanStep],
         suggestions: list[CodeSuggestion],
-        confidence: float,
+        confidence: Optional[float],
         context: dict[str, Any],
     ):
         """Store reasoning in persistent memory for future use."""
@@ -3314,7 +3491,15 @@ RULES:
                 context=context_str,
                 reasoning=reasoning,
                 suggestion=suggestion,
-                confidence=confidence,
+                # A memory entry's confidence is a prior on how much to trust
+                # this stored pattern later — a different scale from the run's
+                # operator-facing verdict, which is why a neutral value is
+                # legitimate here and was not there (#199). Named so the next
+                # reader doesn't mistake it for the sentinel that was removed.
+                confidence=(
+                    confidence if confidence is not None
+                    else UNSCORED_MEMORY_PRIOR
+                ),
                 source_context=context,
                 code_skeleton=code_skeleton,
                 common_pitfalls=pitfalls[:5],

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -2755,6 +2755,26 @@ RULES:
         except Exception:
             return code
 
+    @staticmethod
+    def _normalize_for_marker_match(text: str) -> str:
+        """Lowercase and drop all whitespace, for substring marker matching.
+
+        Not cosmetic. `_strip_comments_and_strings` rebuilds the source by
+        joining tokens with a space, so `sorted(x)` comes back as `sorted ( x )`
+        and the marker `sorted(` could never match — the Python half of the same
+        permanent caution #196 reported for C#: a *satisfied* constraint still
+        warned, on the one language the table was written for. Normalizing both
+        sides also makes the table indifferent to the target's formatting
+        (`max( 0`, `reverse = True`, `Math.Abs (`).
+
+        Whitespace removal can join two tokens into a marker that was not
+        written (`offset (` normalizes to text containing `set(`). That
+        direction is the safe one: a false match only *suppresses* a warning,
+        and absence of a marker was always a hint rather than a verdict —
+        whereas a false warning is the alarm-fatigue defect being fixed.
+        """
+        return "".join(text.split()).lower()
+
     def _check_constraints_static(
         self,
         suggestions: list[CodeSuggestion],
@@ -2786,7 +2806,9 @@ RULES:
         diagnostics: list[dict[str, Any]] = []
         for sug in suggestions:
             raw = sug.code_block or sug.unified_diff or ""
-            code = self._strip_comments_and_strings(raw).lower()
+            code = self._normalize_for_marker_match(
+                self._strip_comments_and_strings(raw)
+            )
             language = language_for_path(sug.file_path)
             markers = markers_for_language(language)
             for c in constraints:
@@ -2804,7 +2826,9 @@ RULES:
                         "language": language,
                     })
                     continue
-                if not any(h.lower() in code for h in hints):
+                if not any(
+                    self._normalize_for_marker_match(h) in code for h in hints
+                ):
                     diagnostics.append({
                         "severity": "warning",
                         "message": (

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -1239,6 +1239,7 @@ class NeoEngine:
                     tool=check.tool_name,
                 )
                 self._note_finding(f"{check.tool_name} reported errors")
+            evaluated = self._checks_that_evaluated(static_checks)
             if not static_checks:
                 summary = self._voice("phase_checks_none")
             elif failed:
@@ -1246,8 +1247,10 @@ class NeoEngine:
                     "phase_checks_failed",
                     failed=len(failed), count=len(static_checks),
                 )
+            elif not evaluated:
+                summary = self._voice("phase_checks_inconclusive")
             else:
-                summary = self._voice("phase_checks_clean", count=len(static_checks))
+                summary = self._voice("phase_checks_clean", count=len(evaluated))
             self._end_phase(
                 PHASE_STATIC_CHECKS,
                 summary,
@@ -1705,12 +1708,13 @@ class NeoEngine:
 
         if static_checks:
             for check in static_checks:
-                severities = {str(d.get("severity", "")).lower() for d in check.diagnostics}
-                status = check.status or (
-                    "failed" if "error" in severities
-                    else "warning" if check.diagnostics
-                    else "passed"
-                )
+                # Must go through _static_check_status, not a second copy of
+                # its logic: `aggregate_verification_status` ranks `warning`
+                # above `skipped`, so an inline `warning if check.diagnostics`
+                # promoted an info-only "not checked for <language>" note into
+                # the run's whole `verification_verdict` — #196's false alarm
+                # arriving through the episode ledger instead of the console.
+                status = self._static_check_status(check)
                 episode.verification.append(VerificationEvidence(
                     verification_id=uuid.uuid4().hex,
                     kind=check.kind or "neo_static",
@@ -2601,6 +2605,25 @@ RULES:
         return results
 
     @staticmethod
+    def _checks_that_evaluated(
+        checks: list[StaticCheckResult],
+    ) -> list[StaticCheckResult]:
+        """The checks that actually examined the code, `skipped` ones removed.
+
+        Every consumer that says a checker vouched for the answer — "all N
+        checker(s) clean", VERIFY's "nothing pushed back", and the caution that
+        fires when nothing checked the code at all — has to read this rather
+        than `static_checks`. A constraint check that found no marker set for
+        the target language still occupies a slot in that list, so counting
+        slots reports a run as verified by a checker that evaluated nothing,
+        and suppresses the "this code is unverified" caution that is true.
+        """
+        return [
+            check for check in checks
+            if NeoEngine._static_check_status(check) != "skipped"
+        ]
+
+    @staticmethod
     def _static_check_status(check: StaticCheckResult) -> str:
         """Normalize legacy check results without treating absence as success.
 
@@ -2628,7 +2651,12 @@ RULES:
     # it. Anything else — including a diagnostic with no severity at all —
     # counts as actionable, so an unrecognized severity fails toward being
     # surfaced rather than toward silence.
-    _INFORMATIONAL_SEVERITIES = frozenset({"info", "note", "skipped"})
+    # `information` is pyright's own spelling, passed through raw by
+    # static_analysis.py — omitting it made the one real tool that emits
+    # informational diagnostics the one tool this rule missed.
+    _INFORMATIONAL_SEVERITIES = frozenset(
+        {"info", "information", "note", "skipped"}
+    )
 
     @staticmethod
     def _is_actionable_diagnostic(diagnostic: dict[str, Any]) -> bool:
@@ -2732,15 +2760,49 @@ RULES:
             )
         return self._extract_prompt_constraints(text)
 
-    @staticmethod
-    def _strip_comments_and_strings(code: str) -> str:
-        """Best-effort strip of Python comments and string/bytes literals.
+    # Languages whose comments and literals are stripped by the C-family
+    # scanner below rather than by Python's tokenizer.
+    _C_FAMILY_LANGUAGES = frozenset({"csharp", "typescript", "javascript"})
 
-        Used before substring-matching constraint markers so the word
-        "sorted" inside a docstring or comment doesn't suppress a real
-        warning. Falls back to the original code if tokenization fails
-        (e.g. non-Python or syntactically broken input).
+    # One alternation, scanned left to right, so a construct that opens first
+    # wins: `"http://x"` is consumed as a string before `//` can be read as a
+    # comment. Best-effort by design — a C# verbatim string with a doubled
+    # quote (`@"a""b"`) ends early and leaves a fragment behind, which can only
+    # add non-marker noise to the matched text.
+    _C_FAMILY_TOKEN_RE = re.compile(
+        r"""
+          (?P<block>/\*.*?\*/)
+        | (?P<line>//[^\n]*)
+        | (?P<dquote>"(?:\\.|[^"\\\n])*")
+        | (?P<squote>'(?:\\.|[^'\\\n])*')
+        | (?P<template>`(?:\\.|[^`\\])*`)
+        """,
+        re.DOTALL | re.VERBOSE,
+    )
+
+    @staticmethod
+    def _strip_comments_and_strings(code: str, language: str = "python") -> str:
+        """Best-effort strip of comments and string literals, per language.
+
+        Used before substring-matching constraint markers so the word "sorted"
+        inside a docstring or comment doesn't suppress a real warning.
+
+        The stripper must follow the marker table's language or it defeats the
+        check it feeds. Python's `tokenize` does not fail on C#: `//` lexes as
+        floor-division, so line comments survived as code and a C# file
+        carrying `// TODO: use HashSet<int> here` matched the uniqueness marker
+        and reported a genuine miss as satisfied — the #196 fix silencing the
+        very warning it exists to make reachable, on the languages it added.
+
+        A language with no marker table never reaches the matcher, so its code
+        is returned untouched rather than run through a stripper written for
+        some other grammar.
         """
+        if language in NeoEngine._C_FAMILY_LANGUAGES:
+            return NeoEngine._C_FAMILY_TOKEN_RE.sub(" ", code)
+        if language != "python":
+            return code
+
         import io
         import tokenize
 
@@ -2755,9 +2817,15 @@ RULES:
         except Exception:
             return code
 
+    # Whitespace that touches a non-identifier character on either side; the
+    # two passes together delete exactly the spacing that is punctuation
+    # formatting and keep exactly the spacing that separates two identifiers.
+    _SPACE_BEFORE_SYMBOL_RE = re.compile(r"\s+(?![0-9A-Za-z_])")
+    _SPACE_AFTER_SYMBOL_RE = re.compile(r"(?<![0-9A-Za-z_])\s+")
+
     @staticmethod
     def _normalize_for_marker_match(text: str) -> str:
-        """Lowercase and drop all whitespace, for substring marker matching.
+        """Lowercase and normalize punctuation spacing, for marker matching.
 
         Not cosmetic. `_strip_comments_and_strings` rebuilds the source by
         joining tokens with a space, so `sorted(x)` comes back as `sorted ( x )`
@@ -2767,13 +2835,58 @@ RULES:
         sides also makes the table indifferent to the target's formatting
         (`max( 0`, `reverse = True`, `Math.Abs (`).
 
-        Whitespace removal can join two tokens into a marker that was not
-        written (`offset (` normalizes to text containing `set(`). That
-        direction is the safe one: a false match only *suppresses* a warning,
-        and absence of a marker was always a hint rather than a verdict —
-        whereas a false warning is the alarm-fatigue defect being fixed.
+        Only the spacing that is punctuation formatting is removed. Dropping
+        *all* whitespace instead looks simpler and destroys the boundaries the
+        matcher needs in both directions at once: it fuses `new HashSet<` into
+        `newhashset<`, so an identifier-boundary test rejects C#'s primary
+        uniqueness idiom, while simultaneously fusing `offset (` into text
+        containing `set(` so a plain substring test accepts a word nobody
+        wrote. Keeping the single space between two identifiers is what lets
+        `_marker_present` be strict without being wrong.
         """
-        return "".join(text.split()).lower()
+        collapsed = re.sub(r"\s+", " ", text.lower())
+        collapsed = NeoEngine._SPACE_BEFORE_SYMBOL_RE.sub("", collapsed)
+        return NeoEngine._SPACE_AFTER_SYMBOL_RE.sub("", collapsed)
+
+    @staticmethod
+    def _marker_present(marker: str, normalized_code: str) -> bool:
+        """True when `marker` occurs in normalized code, anchored on the left.
+
+        A plain substring test is too weak to be useful: `set(` matches
+        `offset(`, `reset(` and `dataset(`, and `Set<` matches `Subset<`, so
+        UNIQUE_ELEMENTS was close to inert on real Python and TypeScript —
+        every one of those suppressions silently dropping the warning the check
+        exists to raise. A marker that starts with an identifier character may
+        therefore not begin in the middle of a longer identifier.
+
+        The right edge is deliberately NOT anchored, and the asymmetry is the
+        whole design. Markers are written as prefixes of a family on purpose:
+        `OrderBy` is meant to cover `OrderByDescending`, `bisect` to cover
+        `bisect_left`, `heappush` to cover a call. Anchoring the right edge
+        rejects all three, and a rejected marker means a warning fired at code
+        that satisfies the constraint — the #196 false alarm, re-entering
+        through the matcher. Left-anchoring alone is what the observed
+        collisions actually needed; the one right-side case (`new Set` inside
+        `new Settings()`) is fixed where it belongs, by writing the marker as
+        `new Set(` in the table.
+
+        `frozenset(` is listed explicitly for the same reason: it satisfies
+        uniqueness and no longer matches `set(` now that the left edge is
+        anchored.
+        """
+        needle = NeoEngine._normalize_for_marker_match(marker)
+        if not needle:
+            return False
+        if not (needle[0].isalnum() or needle[0] == "_"):
+            return needle in normalized_code
+
+        start = normalized_code.find(needle)
+        while start != -1:
+            previous = normalized_code[start - 1] if start > 0 else ""
+            if not (previous.isalnum() or previous == "_"):
+                return True
+            start = normalized_code.find(needle, start + 1)
+        return False
 
     def _check_constraints_static(
         self,
@@ -2806,10 +2919,10 @@ RULES:
         diagnostics: list[dict[str, Any]] = []
         for sug in suggestions:
             raw = sug.code_block or sug.unified_diff or ""
-            code = self._normalize_for_marker_match(
-                self._strip_comments_and_strings(raw)
-            )
             language = language_for_path(sug.file_path)
+            code = self._normalize_for_marker_match(
+                self._strip_comments_and_strings(raw, language)
+            )
             markers = markers_for_language(language)
             for c in constraints:
                 hints = markers.get(c.type)
@@ -2826,9 +2939,7 @@ RULES:
                         "language": language,
                     })
                     continue
-                if not any(
-                    self._normalize_for_marker_match(h) in code for h in hints
-                ):
+                if not any(self._marker_present(h, code) for h in hints):
                     diagnostics.append({
                         "severity": "warning",
                         "message": (
@@ -3170,7 +3281,8 @@ RULES:
         if verification_only:
             verdict = (
                 self._voice("verify_failed", count=len(failed_checks)) if failed_checks
-                else self._voice("verify_clean") if static_checks
+                else self._voice("verify_clean")
+                if self._checks_that_evaluated(static_checks)
                 else self._voice("verify_none")
             )
             summary = self._voice(
@@ -3259,10 +3371,14 @@ RULES:
         issue_count = sum(len(t.issues_found) for t in simulation_traces or [])
         if issue_count:
             cautions.append(self._voice("caution_sim_issues", count=issue_count))
-        if code_suggestions and not static_checks:
+        if code_suggestions and not self._checks_that_evaluated(static_checks):
             # Two different facts with two different remedies: install a linter
             # versus give the run more time. The phase record already knows
             # which one happened — don't collapse them here.
+            # Reads evaluated checks, not the raw list: a constraint result
+            # that could only report "not checked for <language>" left the list
+            # non-empty and swallowed this caution, which is the one line
+            # telling the operator the code is unverified.
             skipped = any(
                 record["name"] == PHASE_STATIC_CHECKS and record["status"] == "skipped"
                 for record in self._phase_records

--- a/src/neo/models.py
+++ b/src/neo/models.py
@@ -286,6 +286,76 @@ class CodeSuggestion:
     suggestion_id: str = field(default_factory=lambda: uuid.uuid4().hex)
 
 
+# Paths a suggestion uses to say "this is analysis, not a change" — the schema
+# in engine.py permits an empty `unified_diff` only for these.
+REVIEW_ONLY_PATHS = frozenset({"", "/", "N/A"})
+
+
+def suggestion_is_review_marker(suggestion: "CodeSuggestion") -> bool:
+    """True when a suggestion is the schema's "no code change" placeholder.
+
+    A run that emits only these produced an *answer*, not a patch, so there is
+    nothing for a code-change confidence number to describe.
+    """
+    return (suggestion.file_path or "").strip().upper() in {
+        path.upper() for path in REVIEW_ONLY_PATHS
+    }
+
+
+def suggestion_is_scoreable(suggestion: "CodeSuggestion") -> bool:
+    """True when a suggestion proposes a change a confidence score can describe.
+
+    Deliberately narrower than "the model returned an object". A suggestion
+    naming a real file with an empty diff AND an empty code block violates the
+    schema (engine.py's prompt: an empty diff is permitted only when
+    ``file_path`` is ``/`` or ``N/A``), yet it still carries a self-reported
+    confidence — which is how a run that produced no content scored 0.96 and
+    outranked a correct analysis at 0.50 (#199). Such a suggestion is excluded
+    from the average rather than trusted to grade a patch it did not write.
+    """
+    if suggestion_is_review_marker(suggestion):
+        return False
+    return bool(
+        (suggestion.unified_diff or "").strip()
+        or (suggestion.code_block or "").strip()
+    )
+
+
+# Why a run's `confidence` is — or is not — a number on the 0..1 scale.
+# Separating these from the scale is the whole point of #199: `0.5` used to
+# mean both "moderately uncertain" and "there was nothing to score".
+CONFIDENCE_BASIS_SUGGESTIONS = "suggestions"
+CONFIDENCE_BASIS_ANALYSIS_ONLY = "analysis_only"
+CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE = "no_verifiable_change"
+CONFIDENCE_BASIS_VERIFICATION = "verification_verdict"
+
+# Operator-facing verdicts, ordered by how much usable output the run
+# delivered — lowest first. The one relation any code depends on is that
+# NO_VERIFIABLE_CHANGE is the floor: a run that named a file and produced no
+# change must never outrank a run that actually answered. ANALYSIS_ONLY sits
+# above PROCEED_WITH_CAUTION because it carries no unverified patch to act on,
+# not because it is more certain — there is no certainty claim in it at all.
+CONFIDENCE_ACTIONS: tuple[str, ...] = (
+    "NO_VERIFIABLE_CHANGE",
+    "GATHER_MORE_DATA",
+    "PROCEED_WITH_CAUTION",
+    "ANALYSIS_ONLY",
+    "READY_TO_IMPLEMENT",
+)
+
+
+def confidence_action_rank(action: str) -> int:
+    """Rank an interpretation action on the trust ladder above.
+
+    An unrecognized action ranks below every known one: a verdict this build
+    cannot place is not evidence that anything is safe to act on.
+    """
+    try:
+        return CONFIDENCE_ACTIONS.index(action)
+    except ValueError:
+        return -1
+
+
 @dataclass
 class StaticCheckResult:
     """Results from static analysis tools."""
@@ -330,8 +400,12 @@ class NeoOutput:
     code_suggestions: list[CodeSuggestion]
     static_checks: list[StaticCheckResult]
     next_questions: list[str]
-    confidence: float
+    # None when this run produced nothing a code-change score can describe.
+    # `confidence_basis` says which case it is; never read one without the
+    # other, and never substitute a number for the absence.
+    confidence: Optional[float]
     notes: str
+    confidence_basis: str = CONFIDENCE_BASIS_SUGGESTIONS
     metadata: dict[str, Any] = field(default_factory=dict)
     goal_assessment: Optional[GoalAssessment] = None
     strategy_assessment: Optional[StrategyAssessment] = None

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -16,9 +16,13 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from neo.models import RegenerateStats
+from neo.models import (
+    CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
+    CONFIDENCE_BASIS_SUGGESTIONS,
+    RegenerateStats,
+)
 
 if TYPE_CHECKING:
     from neo.config import NeoConfig
@@ -1464,18 +1468,65 @@ DOCUMENTATION:
 """
     print(help_text)
 
+# The numeric bands, and the fact that "no score" is not one of them. Shown on
+# every interpretation so a reader who sees `null` isn't left to guess where it
+# sits on the ladder — it doesn't sit on the ladder at all.
+_CONFIDENCE_SCALE = {
+    "0.0-0.4": "Gather more data - critical information missing",
+    "0.4-0.7": "Proceed with caution - some uncertainties remain",
+    "0.7-1.0": "Ready to implement - high confidence in approach",
+    "null": "Not applicable - this run proposed no code change to score",
+}
+
+
 def _interpret_confidence(
-    confidence: float,
+    confidence: Optional[float],
     next_questions: list[str],
     plan: list,
-    code_suggestions: list
+    code_suggestions: list,
+    confidence_basis: str = CONFIDENCE_BASIS_SUGGESTIONS,
 ) -> dict:
     """
     Interpret confidence score and provide actionable guidance.
 
     Helps users understand what the confidence score means and what to do next.
+
+    `confidence` is None when the run produced nothing a code-change score can
+    describe, and `confidence_basis` says which case that is. Those get their
+    own verdicts rather than being folded onto the numeric scale: an
+    analysis-only run used to arrive here as the sentinel 0.5 and render as
+    "Proceed with caution - some uncertainties remain", which read as a weaker
+    result than an empty patch carrying its own self-reported 0.96 (#199).
     """
-    interpretation = {}
+    interpretation: dict[str, Any] = {"confidence_basis": confidence_basis}
+
+    if confidence is None:
+        if confidence_basis == CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE:
+            interpretation["action"] = "NO_VERIFIABLE_CHANGE"
+            interpretation["message"] = (
+                "No verifiable output - suggestions named a file but carried "
+                "no diff and no code block"
+            )
+            interpretation["next_steps"] = [
+                "Treat this run as having produced nothing, not as a low-risk result",
+                "Re-run with the files the suggestion referenced actually in context",
+            ]
+        else:
+            interpretation["action"] = "ANALYSIS_ONLY"
+            interpretation["message"] = (
+                "No code change proposed - a confidence score for a patch does "
+                "not apply to this answer"
+            )
+            interpretation["next_steps"] = [
+                "Read the analysis on its own terms; there is no diff to review",
+                "Re-run with an implementation prompt if a change is what you wanted",
+            ]
+        interpretation["note"] = (
+            "Absence of a score is not a low score. Nothing here was measured "
+            "on the 0.0-1.0 code-change scale."
+        )
+        interpretation["confidence_scale"] = _CONFIDENCE_SCALE
+        return interpretation
 
     # Determine action guidance based on confidence level
     if confidence >= 0.7:
@@ -1531,11 +1582,7 @@ def _interpret_confidence(
         interpretation["note"] = "The plan itself may be valuable - low confidence indicates missing input data, not plan quality"
 
     # Add confidence scale reference
-    interpretation["confidence_scale"] = {
-        "0.0-0.4": "Gather more data - critical information missing",
-        "0.4-0.7": "Proceed with caution - some uncertainties remain",
-        "0.7-1.0": "Ready to implement - high confidence in approach"
-    }
+    interpretation["confidence_scale"] = _CONFIDENCE_SCALE
 
     return interpretation
 

--- a/tests/test_confidence_calibration.py
+++ b/tests/test_confidence_calibration.py
@@ -1,0 +1,309 @@
+"""#199: confidence 0.5 was a "no suggestions" sentinel sitting on the scale.
+
+The reported inversion, observed 2026-08-11 in one session on one subject:
+
+  * a planner-stage run with `unified_diff: ""` that explicitly declined to name
+    findings scored its own self-reported **0.96** and rendered as
+    READY_TO_IMPLEMENT;
+  * the run that actually answered three sub-questions produced no
+    `CodeSuggestion` at all, hit the `return 0.5` sentinel, and rendered as
+    "Proceed with caution - some uncertainties remain".
+
+The empty patch outranked the answer. The tests below reproduce that pair
+end-to-end and assert the ordering is now the right way round, plus the two
+mechanisms that get it there: the sentinel comes off the numeric scale, and a
+suggestion naming a real file with no diff and no code block is excluded from
+the average and from the early-exit gate.
+"""
+
+import json
+
+from neo.engine import NeoEngine
+from neo.models import (
+    CONFIDENCE_BASIS_ANALYSIS_ONLY,
+    CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
+    CONFIDENCE_BASIS_SUGGESTIONS,
+    CodeSuggestion,
+    NeoInput,
+    TaskType,
+    confidence_action_rank,
+    suggestion_is_scoreable,
+)
+from neo.schemas import SCHEMA_VERSION
+from neo.subcommands import _interpret_confidence
+
+
+class FakeLM:
+    """Returns one canned structured response regardless of the prompt."""
+
+    model = "fake"
+    provider = "fake"
+
+    def __init__(self, response):
+        self._response = response
+
+    def generate(self, messages, **kwargs):
+        return self._response
+
+    def name(self):
+        return "fake-lm"
+
+
+def _block(kind, payload):
+    return f"<<<NEO:SCHEMA=v3:KIND={kind}>>>\n{json.dumps(payload)}\n<<<END:{kind}>>>"
+
+
+def _response(code):
+    """A well-formed run whose only variable is what it proposes."""
+    plan = [{
+        "id": "ps_1",
+        "description": "Compare the refresh path against the equivalence rules",
+        "rationale": "the audit asks whether the two paths agree",
+        "dependencies": [],
+        "risk": "low",
+        "schema_version": SCHEMA_VERSION,
+    }]
+    sim = [{
+        "n": 1,
+        "input_data": "a stale entry",
+        "expected_output": "refreshed once",
+        "reasoning_steps": ["the refresh runs before the comparison"],
+        "issues_found": [],
+        "schema_version": SCHEMA_VERSION,
+    }]
+    return "\n".join([
+        _block("plan", plan), _block("simulation", sim), _block("code", code),
+    ])
+
+
+# The run that declined: a real file path, an empty diff, and a high
+# self-reported number attached to a patch it did not write.
+_EMPTY_PATCH = [{
+    "file_path": "src/Odi/RefreshService.cs",
+    "unified_diff": "",
+    "code_block": "",
+    "description": (
+        "No speculative patch is provided at planner stage because the supplied "
+        "source excerpts omit portions needed to answer the property audit."
+    ),
+    "confidence": 0.96,
+    "tradeoffs": [],
+    "schema_version": SCHEMA_VERSION,
+}]
+
+# The run that answered: an analysis, no code change proposed.
+_NO_SUGGESTIONS: list = []
+
+# A genuine mid-confidence code change, for the "these must be distinguishable"
+# assertion the issue asks for.
+_MID_CONFIDENCE_PATCH = [{
+    "file_path": "src/Odi/RefreshService.cs",
+    "unified_diff": "--- a\n+++ b\n@@\n+    if (entry is null) return;\n",
+    "code_block": "if (entry is null) return;",
+    "description": "guard the null entry",
+    "confidence": 0.55,
+    "tradeoffs": [],
+    "schema_version": SCHEMA_VERSION,
+}]
+
+
+def _run(code):
+    engine = NeoEngine(
+        lm_adapter=FakeLM(_response(code)), enable_persistent_memory=False
+    )
+    return engine.process(NeoInput(
+        prompt="audit the refresh path for equivalence with the cached path",
+        task_type=TaskType.EXPLANATION,
+    ))
+
+
+def _interpret(output):
+    return _interpret_confidence(
+        output.confidence,
+        output.next_questions,
+        output.plan,
+        output.code_suggestions,
+        output.confidence_basis,
+    )
+
+
+# ------------------------------------------------ the reported inversion
+
+
+def test_the_correct_analysis_now_outranks_the_empty_patch():
+    """The exact #199 scenario, both runs, ordered."""
+    empty_patch = _run(_EMPTY_PATCH)
+    analysis = _run(_NO_SUGGESTIONS)
+
+    empty_action = _interpret(empty_patch)["action"]
+    analysis_action = _interpret(analysis)["action"]
+
+    assert confidence_action_rank(analysis_action) > confidence_action_rank(
+        empty_action
+    ), (analysis_action, empty_action)
+    # And specifically: the empty patch no longer reads as ready to implement.
+    assert empty_action == "NO_VERIFIABLE_CHANGE"
+    assert analysis_action == "ANALYSIS_ONLY"
+
+
+def test_the_empty_patch_no_longer_carries_its_self_reported_number():
+    """0.96 was the model's opinion of a patch that does not exist."""
+    output = _run(_EMPTY_PATCH)
+
+    assert output.confidence is None
+    assert output.confidence_basis == CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE
+    assert output.metadata.get("early_exit") is not True
+
+
+def test_the_analysis_run_reports_no_score_rather_than_the_sentinel():
+    output = _run(_NO_SUGGESTIONS)
+
+    assert output.confidence is None
+    assert output.confidence_basis == CONFIDENCE_BASIS_ANALYSIS_ONLY
+
+
+def test_an_analysis_run_and_a_mid_confidence_run_are_distinguishable():
+    """The issue's third acceptance criterion.
+
+    Both used to land in the 0.4-0.7 band and read as "some uncertainties
+    remain" — one because it measured 0.55, the other because it measured
+    nothing.
+    """
+    analysis = _run(_NO_SUGGESTIONS)
+    mid = _run(_MID_CONFIDENCE_PATCH)
+
+    assert analysis.confidence is None
+    assert mid.confidence is not None
+    assert analysis.confidence_basis != mid.confidence_basis
+    assert mid.confidence_basis == CONFIDENCE_BASIS_SUGGESTIONS
+
+    assert _interpret(analysis)["action"] == "ANALYSIS_ONLY"
+    assert _interpret(mid)["action"] == "PROCEED_WITH_CAUTION"
+    assert "uncertainties remain" not in _interpret(analysis)["message"]
+
+
+def test_the_empty_patch_run_says_so_in_its_cautions():
+    """A host is told never to drop a caution; this is one it must not."""
+    output = _run(_EMPTY_PATCH)
+    joined = " ".join(output.orchestrator.cautions)
+    assert "no diff and no code" in joined
+
+
+def test_no_number_is_invented_in_the_orchestrator_summary():
+    for code in (_EMPTY_PATCH, _NO_SUGGESTIONS):
+        summary = _run(code).orchestrator.summary
+        assert "No confidence score" in summary
+        assert "0.96" not in summary
+        assert "0.50" not in summary
+
+
+# ------------------------------------------------------- the mechanisms
+
+
+def _suggestion(path, diff="", code="", confidence=0.9):
+    return CodeSuggestion(
+        file_path=path,
+        unified_diff=diff,
+        description="",
+        confidence=confidence,
+        code_block=code,
+    )
+
+
+def _engine():
+    return NeoEngine(lm_adapter=FakeLM(""), enable_persistent_memory=False)
+
+
+def test_a_real_path_with_no_change_is_not_scoreable():
+    assert suggestion_is_scoreable(_suggestion("src/a.py")) is False
+    assert suggestion_is_scoreable(_suggestion("src/a.py", diff="--- a\n+++ b\n"))
+    assert suggestion_is_scoreable(_suggestion("src/a.py", code="return 1"))
+
+
+def test_the_schema_review_markers_are_not_scoreable():
+    """`/` and `N/A` with an empty diff are the schema's analysis placeholder."""
+    for path in ("/", "N/A", "n/a", ""):
+        assert suggestion_is_scoreable(_suggestion(path)) is False
+
+
+def test_a_review_marker_run_reports_analysis_only_not_no_verifiable_change():
+    """Declining correctly is not the same failure as claiming a file."""
+    confidence, basis = _engine()._calculate_confidence(
+        [], [], [_suggestion("/", confidence=0.96)], []
+    )
+    assert confidence is None
+    assert basis == CONFIDENCE_BASIS_ANALYSIS_ONLY
+
+
+def test_an_empty_change_is_dropped_from_the_average_not_averaged_in():
+    """Mixed run: the real patch decides the number on its own."""
+    confidence, basis = _engine()._calculate_confidence(
+        [],
+        [],
+        [
+            _suggestion("src/a.py", diff="--- a\n+++ b\n", confidence=0.60),
+            _suggestion("src/b.py", confidence=0.96),
+        ],
+        [],
+    )
+    assert basis == CONFIDENCE_BASIS_SUGGESTIONS
+    assert confidence == 0.60
+
+
+def test_no_suggestions_at_all_no_longer_returns_the_sentinel():
+    confidence, basis = _engine()._calculate_confidence([], [], [], [])
+    assert confidence is None
+    assert basis == CONFIDENCE_BASIS_ANALYSIS_ONLY
+
+
+# ---------------------------------------------------- the reported ladder
+
+
+def test_no_verifiable_change_is_the_floor_of_the_trust_ladder():
+    """The one relation the fix depends on."""
+    floor = confidence_action_rank("NO_VERIFIABLE_CHANGE")
+    for action in (
+        "GATHER_MORE_DATA",
+        "PROCEED_WITH_CAUTION",
+        "ANALYSIS_ONLY",
+        "READY_TO_IMPLEMENT",
+    ):
+        assert confidence_action_rank(action) > floor
+
+
+def test_an_unrecognized_action_ranks_below_every_known_one():
+    """A verdict this build cannot place is not evidence anything is safe."""
+    assert confidence_action_rank("SHIP_IT") < confidence_action_rank(
+        "NO_VERIFIABLE_CHANGE"
+    )
+
+
+def test_the_interpretation_names_the_basis_and_the_null_band():
+    interpretation = _interpret_confidence(
+        None, [], [], [], CONFIDENCE_BASIS_ANALYSIS_ONLY
+    )
+    assert interpretation["confidence_basis"] == CONFIDENCE_BASIS_ANALYSIS_ONLY
+    assert "null" in interpretation["confidence_scale"]
+    assert "Absence of a score is not a low score" in interpretation["note"]
+
+
+def test_the_numeric_bands_are_unchanged_for_scored_runs():
+    """The fix takes the sentinel off the scale; it does not retune the scale."""
+    assert _interpret_confidence(0.85, [], [], [])["action"] == "READY_TO_IMPLEMENT"
+    assert _interpret_confidence(0.55, [], [], [])["action"] == "PROCEED_WITH_CAUTION"
+    assert _interpret_confidence(0.20, [], [], [])["action"] == "GATHER_MORE_DATA"
+
+
+# --------------------------------------------------------- wire contract
+
+
+def test_a_null_confidence_serializes_on_both_transports():
+    """`--json` consumers and the CAR artifact see the same absent value."""
+    from neo.car_tool_schema import neo_output_to_dict
+
+    output = _run(_NO_SUGGESTIONS)
+    payload = neo_output_to_dict(output)
+
+    assert payload["confidence"] is None
+    assert payload["confidence_basis"] == CONFIDENCE_BASIS_ANALYSIS_ONLY
+    assert json.loads(json.dumps(payload))["confidence"] is None

--- a/tests/test_constraint_language_markers.py
+++ b/tests/test_constraint_language_markers.py
@@ -1,0 +1,296 @@
+"""#196: the constraint marker check is language-aware, or it says it did not check.
+
+`CONSTRAINT_CODE_MARKERS` was a single Python-only table applied to every
+target, so on a C#, TypeScript or markdown file the expectation it printed
+("expected one of: set(, dict.fromkeys") could not be met by any code. The
+caution fired permanently on non-Python repos, which is alarm fatigue on the
+same channel that carries Neo's real warnings.
+
+Two things are pinned here: a language with a marker table gets a real check in
+its own vocabulary, and a language without one gets an honest "not checked"
+note that no downstream counter treats as a problem.
+"""
+
+from neo.constraint_verification import (
+    LANGUAGE_CONSTRAINT_MARKERS,
+    UNKNOWN_LANGUAGE,
+    Constraint,
+    ConstraintType,
+    language_for_path,
+)
+from neo.engine import NeoEngine
+from neo.models import CodeSuggestion, StaticCheckResult
+
+
+class FakeLM:
+    model = "fake"
+    provider = "fake"
+
+    def generate(self, messages, **kwargs):
+        return ""
+
+    def name(self):
+        return "fake-lm"
+
+
+def _engine() -> NeoEngine:
+    return NeoEngine(lm_adapter=FakeLM(), enable_persistent_memory=False)
+
+
+def _suggestion(file_path: str, code: str) -> CodeSuggestion:
+    return CodeSuggestion(
+        file_path=file_path,
+        unified_diff="",
+        description="",
+        confidence=0.9,
+        code_block=code,
+    )
+
+
+UNIQUE = Constraint(
+    type=ConstraintType.UNIQUE_ELEMENTS,
+    description="Elements must be unique",
+    parameters={"variable": "result"},
+)
+SORTED = Constraint(
+    type=ConstraintType.SORTED,
+    description="Output must be sorted",
+    parameters={"variable": "result"},
+)
+
+
+def _check(file_path: str, code: str, constraints=(UNIQUE,)):
+    return _engine()._check_constraints_static(
+        [_suggestion(file_path, code)], list(constraints)
+    )
+
+
+def _warnings(result):
+    if result is None:
+        return []
+    return [d for d in result.diagnostics if d["severity"] == "warning"]
+
+
+def _notes(result):
+    if result is None:
+        return []
+    return [d for d in result.diagnostics if d["severity"] == "info"]
+
+
+# ------------------------------------------------------- the reported case
+
+
+def test_a_markdown_target_never_reports_a_missing_python_handler():
+    """The exact run from #196: a uniqueness constraint against `/decision.md`.
+
+    Prose cannot contain `set(`, so the old check fired on every invocation.
+    """
+    result = _check("/decision.md", "# Decision\n\nWe will use the second option.")
+
+    assert _warnings(result) == []
+    notes = _notes(result)
+    assert len(notes) == 1
+    assert notes[0]["language"] == "markdown"
+    assert "not checked" in notes[0]["message"]
+    assert "set(" not in notes[0]["message"]
+
+
+def test_a_csharp_hashset_satisfies_uniqueness_without_a_caution():
+    result = _check(
+        "src/Odi/Ledger.cs",
+        "var unique = new HashSet<string>(names);\nreturn unique.ToList();",
+    )
+    assert result is None
+
+
+def test_a_csharp_distinct_satisfies_uniqueness_without_a_caution():
+    result = _check("src/Odi/Ledger.cs", "return names.Distinct().ToList();")
+    assert result is None
+
+
+def test_a_csharp_orderby_satisfies_sorting_without_a_caution():
+    result = _check(
+        "src/Odi/Ledger.cs", "return names.OrderBy(n => n).ToList();", (SORTED,)
+    )
+    assert result is None
+
+
+# ------------------------------------- real misses still warn, per language
+
+
+def test_a_csharp_file_with_no_handler_warns_in_csharp_vocabulary():
+    result = _check("src/Odi/Ledger.cs", "return names.ToList();")
+
+    warnings = _warnings(result)
+    assert len(warnings) == 1
+    message = warnings[0]["message"]
+    assert "no obvious handler" in message
+    assert "HashSet<" in message
+    # The Python spelling must not survive into a C# expectation — naming a
+    # marker the language does not have is what made the caution unclearable.
+    assert "dict.fromkeys" not in message
+    assert warnings[0]["language"] == "csharp"
+
+
+def test_a_python_file_with_no_handler_still_warns():
+    """The check the fix must not throw away while removing the false alarm."""
+    result = _check("src/neo/ledger.py", "return list(names)")
+
+    warnings = _warnings(result)
+    assert len(warnings) == 1
+    assert "dict.fromkeys" in warnings[0]["message"]
+    assert warnings[0]["language"] == "python"
+
+
+def test_a_python_set_satisfies_uniqueness():
+    result = _check("src/neo/ledger.py", "return list(set(names))")
+    assert result is None
+
+
+def test_a_satisfied_python_constraint_survives_the_token_rejoin():
+    """The Python half of the same permanent caution.
+
+    `_strip_comments_and_strings` rebuilds the source by joining tokens with a
+    space, so `sorted(x)` reached the matcher as `sorted ( x )` and the marker
+    `sorted(` could not match. Code that plainly satisfied the constraint still
+    warned — on the one language the table was written for.
+    """
+    assert _check("a.py", "result = sorted(values)", (SORTED,)) is None
+    assert _check("a.py", "result = sorted( values )", (SORTED,)) is None
+    assert _check("a.py", "values.sort( reverse = True )", (SORTED,)) is None
+
+
+def test_a_marker_word_in_a_comment_still_warns():
+    """Stripping comments is why the matcher is not run on raw source."""
+    result = _check("a.py", "# remember to use sorted() here\nreturn values", (SORTED,))
+    assert len(_warnings(result)) == 1
+
+
+def test_a_typescript_set_satisfies_uniqueness():
+    result = _check("src/app/ledger.ts", "return [...new Set(names)];")
+    assert result is None
+
+
+def test_a_typescript_file_with_no_handler_warns_in_typescript_vocabulary():
+    result = _check("src/app/ledger.ts", "return names.slice();")
+
+    warnings = _warnings(result)
+    assert len(warnings) == 1
+    assert "new Set" in warnings[0]["message"]
+    assert "dict.fromkeys" not in warnings[0]["message"]
+
+
+def test_javascript_shares_the_typescript_markers():
+    assert _check("src/app/ledger.js", "return [...new Set(names)];") is None
+
+
+# ------------------------------------------------------ honest degradation
+
+
+def test_an_unmapped_extension_is_named_rather_than_guessed_at():
+    """Rust has no marker table, and the note says so by name."""
+    result = _check("src/ledger.rs", "let unique: HashSet<_> = names.iter().collect();")
+
+    assert _warnings(result) == []
+    assert _notes(result)[0]["language"] == "rust"
+
+
+def test_a_path_with_no_extension_is_reported_as_unknown():
+    result = _check("Makefile", "all:\n\techo hi")
+
+    assert _warnings(result) == []
+    assert _notes(result)[0]["language"] == UNKNOWN_LANGUAGE
+
+
+def test_the_analysis_only_placeholder_paths_are_unknown_not_guessed():
+    """`/` and `N/A` are the schema's "no code change" markers, not files."""
+    for path in ("/", "N/A", ""):
+        assert language_for_path(path) == UNKNOWN_LANGUAGE
+
+
+def test_language_for_path_prefers_the_canonical_name():
+    assert language_for_path("a/b/c.py") == "python"
+    assert language_for_path("A/B/C.CS") == "csharp"
+    assert language_for_path("/abs/path/app.tsx") == "typescript"
+
+
+def test_the_summary_reports_unchecked_constraints_separately_from_failures():
+    result = _engine()._check_constraints_static(
+        [_suggestion("notes.md", "prose"), _suggestion("a.py", "return list(names)")],
+        [UNIQUE],
+    )
+    assert "1 constraint(s) may not be handled" in result.summary
+    assert "1 not checked (markdown)" in result.summary
+
+
+# ------------------------------- informational notes are not problem reports
+
+
+def test_a_check_that_only_said_not_checked_does_not_count_as_passed():
+    """`passed` is what lets a run exit early on clean static analysis.
+
+    A checker with no marker set for the target language evaluated nothing, so
+    it has no cleanliness to vouch for.
+    """
+    result = _check("/decision.md", "prose")
+    assert NeoEngine._static_check_status(result) == "skipped"
+
+
+def test_a_real_warning_still_maps_to_warning_status():
+    result = _check("src/neo/ledger.py", "return list(names)")
+    assert NeoEngine._static_check_status(result) == "warning"
+
+
+def test_an_error_still_maps_to_failed_and_an_empty_check_to_passed():
+    failed = StaticCheckResult(
+        tool_name="ruff", diagnostics=[{"severity": "error"}], summary=""
+    )
+    clean = StaticCheckResult(tool_name="ruff", diagnostics=[], summary="")
+    assert NeoEngine._static_check_status(failed) == "failed"
+    assert NeoEngine._static_check_status(clean) == "passed"
+
+
+def test_a_diagnostic_with_no_severity_counts_as_actionable():
+    """Unknown severities fail toward being surfaced, not toward silence."""
+    assert NeoEngine._is_actionable_diagnostic({}) is True
+    assert NeoEngine._is_actionable_diagnostic({"severity": "warning"}) is True
+    assert NeoEngine._is_actionable_diagnostic({"severity": "info"}) is False
+
+
+def test_unchecked_notes_raise_no_next_question():
+    """"constraint_verifier found 1 issues" is the line #196 reported."""
+    engine = _engine()
+    result = _check("/decision.md", "prose")
+    questions = engine._generate_questions([], [], [], [result])
+    assert questions == []
+
+
+def test_unchecked_notes_do_not_dock_confidence():
+    engine = _engine()
+    suggestion = _suggestion("src/app.ts", "return [...new Set(names)];")
+    unchecked = _check("/decision.md", "prose")
+
+    scored, _ = engine._calculate_confidence([], [], [suggestion], [unchecked])
+    unpenalized, _ = engine._calculate_confidence([], [], [suggestion], [])
+    assert scored == unpenalized
+
+
+# ---------------------------------------------------------- table hygiene
+
+
+def test_every_language_table_covers_the_same_constraint_types():
+    """Otherwise a constraint added to one language degrades to "not checked"
+    on the others — honest, but silently useless."""
+    covered = {
+        language: frozenset(markers)
+        for language, markers in LANGUAGE_CONSTRAINT_MARKERS.items()
+    }
+    assert len(set(covered.values())) == 1, covered
+
+
+def test_every_marker_is_a_non_empty_string():
+    for language, markers in LANGUAGE_CONSTRAINT_MARKERS.items():
+        for constraint_type, hints in markers.items():
+            assert hints, f"{language}/{constraint_type} has no markers"
+            for hint in hints:
+                assert isinstance(hint, str) and hint.strip(), (language, hint)

--- a/tests/test_constraint_marker_matching.py
+++ b/tests/test_constraint_marker_matching.py
@@ -1,0 +1,243 @@
+"""#196, second pass: the language-aware check must still catch a real miss.
+
+Making the markers language-aware fixed the permanent false alarm. Review of
+that fix found the other half of the same defect had been introduced with it:
+on the languages the fix *added*, a genuine missing handler now passed silently.
+
+Two independent causes, pinned separately below.
+
+1. The stripper followed the wrong grammar. `_strip_comments_and_strings` used
+   Python's `tokenize`, which does not fail on C# — `//` lexes as floor-division
+   — so line comments survived as code and `// TODO: use HashSet<int> here`
+   satisfied the uniqueness marker for a file that deduplicates nothing. C#
+   `///` and TS `/** */` doc comments name `HashSet`, `Distinct` and `OrderBy`
+   constantly, so this was the common case, not the corner.
+
+2. The matcher was a substring test over whitespace-stripped text, so `set(`
+   matched `offset(`, `reset(` and `dataset(`, and `Set<` matched `Subset<`.
+   UNIQUE_ELEMENTS was close to inert on real Python and TypeScript.
+
+Both directions are asserted here: satisfied code stays quiet, unsatisfied code
+still warns. A test that only pins the quiet half is what let this through.
+"""
+
+from neo.constraint_verification import (
+    Constraint,
+    ConstraintType,
+    language_for_path,
+    markers_for_language,
+)
+from neo.engine import NeoEngine
+from neo.models import CodeSuggestion
+
+
+class FakeLM:
+    model = "fake"
+    provider = "fake"
+
+    def generate(self, messages, **kwargs):
+        return ""
+
+    def name(self):
+        return "fake-lm"
+
+
+def _engine() -> NeoEngine:
+    return NeoEngine(lm_adapter=FakeLM(), enable_persistent_memory=False)
+
+
+UNIQUE = Constraint(
+    type=ConstraintType.UNIQUE_ELEMENTS,
+    description="Elements must be unique",
+    parameters={"variable": "result"},
+)
+SORTED = Constraint(
+    type=ConstraintType.SORTED,
+    description="Output must be sorted",
+    parameters={"variable": "result"},
+)
+
+
+def _warns(file_path: str, code: str, constraint=UNIQUE) -> bool:
+    """True when the check raises an actionable 'no obvious handler' warning."""
+    suggestion = CodeSuggestion(
+        file_path=file_path,
+        unified_diff="",
+        description="",
+        confidence=0.9,
+        code_block=code,
+    )
+    result = _engine()._check_constraints_static([suggestion], [constraint])
+    if result is None:
+        return False
+    return any(d["severity"] == "warning" for d in result.diagnostics)
+
+
+# --------------------------------------------- (1) comments, per language
+
+def test_a_csharp_line_comment_naming_the_marker_does_not_satisfy_it():
+    """The regression: Python's tokenizer left `//` comments in the code."""
+    code = (
+        "public List<int> F(List<int> xs)\n"
+        "{\n"
+        "    // TODO: use HashSet<int> here one day\n"
+        "    return xs;\n"
+        "}\n"
+    )
+    assert _warns("src/A.cs", code) is True
+
+
+def test_a_csharp_doc_comment_naming_the_marker_does_not_satisfy_it():
+    code = (
+        "/// <summary>Callers should use .Distinct() on the result.</summary>\n"
+        "public List<int> F(List<int> xs) { return xs; }\n"
+    )
+    assert _warns("src/A.cs", code) is True
+
+
+def test_a_csharp_block_comment_naming_a_sort_marker_does_not_satisfy_it():
+    code = (
+        "/* we could OrderBy(x => x) here, but we do not */\n"
+        "public List<int> F(List<int> xs) { return xs; }\n"
+    )
+    assert _warns("src/A.cs", code, SORTED) is True
+
+
+def test_a_typescript_jsdoc_naming_the_marker_does_not_satisfy_it():
+    code = (
+        "/** Consider new Set(xs) if duplicates ever matter. */\n"
+        "export function f(xs: string[]) { return xs; }\n"
+    )
+    assert _warns("src/a.ts", code) is True
+
+
+def test_a_string_literal_naming_the_marker_does_not_satisfy_it():
+    code = 'public string F() { return "call .Distinct() someday"; }'
+    assert _warns("src/A.cs", code) is True
+
+
+def test_a_python_comment_naming_the_marker_does_not_satisfy_it():
+    """The Python half already worked; it is pinned so it stays working."""
+    code = "# someday use set(xs)\ndef f(xs):\n    return xs\n"
+    assert _warns("src/a.py", code) is True
+
+
+def test_real_csharp_code_still_clears_the_constraint():
+    """The other direction: stripping comments must not eat the code."""
+    code = (
+        "public HashSet<int> F(List<int> xs)\n"
+        "{\n"
+        "    // dedupe below\n"
+        "    return new HashSet<int>(xs);\n"
+        "}\n"
+    )
+    assert _warns("src/A.cs", code) is False
+
+
+def test_a_url_inside_a_string_does_not_swallow_the_rest_of_the_file():
+    """`//` inside a literal must be consumed as a string, not as a comment.
+
+    If the scanner read `//x` in the URL as a line comment it would delete the
+    rest of that line only — but a naive comment-first alternation would run to
+    the newline from inside the string and could hide the real marker.
+    """
+    code = (
+        'var url = "http://example.com/x";\n'
+        "var seen = new HashSet<int>(xs);\n"
+    )
+    assert _warns("src/A.cs", code) is False
+
+
+# ------------------------------------- (2) identifier-boundary matching
+
+def test_offset_does_not_satisfy_the_unique_marker():
+    """`set(` inside `offset(` — the collision that made UNIQUE_ELEMENTS inert."""
+    assert _warns("src/a.py", "def f(rows, n):\n    return rows[offset(n):]\n") is True
+
+
+def test_reset_and_dataset_do_not_satisfy_the_unique_marker():
+    assert _warns("src/a.py", "def f(x):\n    x.reset(0)\n    return x\n") is True
+    assert _warns("src/a.py", "def f(x):\n    return load_dataset(x)\n") is True
+
+
+def test_subset_does_not_satisfy_the_typescript_unique_marker():
+    code = "export function f(x: Subset<string>) { return x; }"
+    assert _warns("src/a.ts", code) is True
+
+
+def test_new_settings_does_not_satisfy_the_typescript_unique_marker():
+    code = "export function f(xs: string[]) { const s = new Settings(); return xs; }"
+    assert _warns("src/a.ts", code) is True
+
+
+def test_a_real_set_call_still_clears_the_constraint():
+    assert _warns("src/a.py", "def f(xs):\n    return list(set(xs))\n") is False
+
+
+def test_frozenset_clears_the_constraint_on_its_own_entry():
+    """It used to ride in as a substring of `set(`; now it is listed."""
+    assert _warns("src/a.py", "def f(xs):\n    return frozenset(xs)\n") is False
+
+
+def test_both_typescript_set_spellings_clear_the_constraint():
+    assert _warns("src/a.ts", "const s = new Set(); return s;") is False
+    assert _warns("src/a.ts", "const s: Set<string> = new Set<string>(); return s;") is False
+
+
+def test_markers_are_prefixes_of_a_family_and_must_stay_unanchored_right():
+    """The right edge is deliberately not anchored.
+
+    `OrderBy` is written to cover `OrderByDescending`, `bisect` to cover
+    `bisect_left`. Anchoring both edges rejects them, and a rejected marker is
+    a warning fired at code that satisfies the constraint — #196 returning
+    through the matcher.
+    """
+    assert _warns("src/A.cs", "return xs.OrderByDescending(x => x).ToList();", SORTED) is False
+    assert _warns("src/a.py", "def f(a, x):\n    return bisect_left(a, x)\n", SORTED) is False
+    assert _warns("src/a.py", "import heapq\ndef f(h, x):\n    heapq.heappush(h, x)\n", SORTED) is False
+
+
+def test_the_token_rejoin_regression_stays_fixed():
+    """Python's tokenizer rejoins as `sorted ( x )`; the marker is `sorted(`."""
+    assert _warns("src/a.py", "def f(xs):\n    return sorted(xs)\n", SORTED) is False
+    assert _warns("src/a.py", "def f(xs):\n    return max( 0 , xs )\n",
+                  Constraint(
+                      type=ConstraintType.NON_NEGATIVE,
+                      description="Must be non-negative",
+                      parameters={},
+                  )) is False
+
+
+def test_a_genuine_miss_still_warns_in_every_mapped_language():
+    """The whole point of the check, asserted once per language table."""
+    assert _warns("src/a.py", "def f(xs):\n    return xs\n") is True
+    assert _warns("src/A.cs", "public List<int> F(List<int> xs) { return xs; }") is True
+    assert _warns("src/a.ts", "export function f(xs: string[]) { return xs; }") is True
+
+
+def test_every_marker_in_every_table_matches_itself():
+    """A marker no code can contain is unsatisfiable by construction — #196.
+
+    Each marker is checked against a minimal snippet that is the marker with an
+    identifier boundary in front of it, which is the weakest thing a real usage
+    can look like.
+    """
+    for language, table in [
+        ("python", markers_for_language("python")),
+        ("csharp", markers_for_language("csharp")),
+        ("typescript", markers_for_language("typescript")),
+    ]:
+        for constraint_type, hints in table.items():
+            for hint in hints:
+                normalized = NeoEngine._normalize_for_marker_match(f"x = {hint}")
+                assert NeoEngine._marker_present(hint, normalized), (
+                    f"{language}/{constraint_type.value} marker {hint!r} "
+                    "cannot match its own text"
+                )
+
+
+def test_unmapped_languages_are_left_untouched_by_the_stripper():
+    """No marker table is consulted, so no grammar is assumed either."""
+    source = "// go comment\nfunc F(xs []int) []int { return xs }"
+    assert language_for_path("src/a.go") not in ("python", "csharp", "typescript")
+    assert NeoEngine._strip_comments_and_strings(source, "go") == source

--- a/tests/test_host_adapter_parity.py
+++ b/tests/test_host_adapter_parity.py
@@ -181,6 +181,30 @@ def test_both_entry_points_document_the_error_shape():
         assert '"error"' in body
 
 
+def test_both_entry_points_teach_the_null_confidence_contract():
+    """`confidence` became `Optional[float]` with a `confidence_basis` (#199).
+
+    An LLM host handed `null` under a standing instruction to "report Neo's
+    confidence as the number it is" has no guidance, and the failure mode is
+    the exact one #199 fixed: treating a run with no number as less trustworthy
+    than an empty patch that self-reported 0.96. Both surfaces must name the
+    null case and both basis values, or one host relays a contract the other
+    does not.
+    """
+    from neo.models import (
+        CONFIDENCE_BASIS_ANALYSIS_ONLY,
+        CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
+    )
+
+    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
+    skill = _codex_skill("neo")
+    for body in (agent, skill):
+        assert "confidence_basis" in body
+        assert "null" in body
+        assert CONFIDENCE_BASIS_ANALYSIS_ONLY in body
+        assert CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE in body
+
+
 def test_both_entry_points_require_attribution():
     """Neo's conclusions and the host's own analysis must stay separable."""
     agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()

--- a/tests/test_static_check_honesty.py
+++ b/tests/test_static_check_honesty.py
@@ -1,0 +1,164 @@
+"""A checker that evaluated nothing may not be reported as a checker that passed.
+
+`_static_check_status` returns `skipped` for a result carrying only
+informational diagnostics, which is what stops an unevaluable constraint check
+from vouching for an early exit. Review found four consumers that never asked
+it, each re-deriving "the check said something / the check ran" from the raw
+list, and each turning #196's info note back into either a false alarm or false
+assurance one layer down:
+
+- the episode ledger recomputed the status inline as `warning if diagnostics`,
+  and `aggregate_verification_status` ranks `warning` above `skipped`, so an
+  unchecked-language note became the run's whole `verification_verdict`;
+- the static-checks phase summary said "All 1 checker(s) clean";
+- VERIFY's verdict said "nothing pushed back";
+- and the "No checkers on this machine. This code is unverified." caution was
+  suppressed, because the list was not empty.
+
+The last is the worst of the four: a true caution dropped, not a false one added.
+"""
+
+from neo.engine import NeoEngine
+from neo.models import CodeSuggestion, StaticCheckResult
+
+
+class FakeLM:
+    model = "fake"
+    provider = "fake"
+
+    def generate(self, messages, **kwargs):
+        return ""
+
+    def name(self):
+        return "fake-lm"
+
+
+def _engine() -> NeoEngine:
+    return NeoEngine(lm_adapter=FakeLM(), enable_persistent_memory=False)
+
+
+def _info_only() -> StaticCheckResult:
+    """What the constraint checker returns for an unmapped language."""
+    return StaticCheckResult(
+        tool_name="constraint_verifier",
+        diagnostics=[{
+            "severity": "info",
+            "message": (
+                "Constraint 'Elements must be unique' was not checked: no go "
+                "marker set for constraint type 'unique_elements'"
+            ),
+            "constraint_type": "unique_elements",
+            "file_path": "src/a.go",
+            "language": "go",
+        }],
+        summary="1 not checked (go)",
+    )
+
+
+def _real_warning() -> StaticCheckResult:
+    return StaticCheckResult(
+        tool_name="constraint_verifier",
+        diagnostics=[{
+            "severity": "warning",
+            "message": "no obvious handler",
+            "constraint_type": "unique_elements",
+            "file_path": "src/a.py",
+            "language": "python",
+        }],
+        summary="1 constraint(s) may not be handled",
+    )
+
+
+def _clean() -> StaticCheckResult:
+    return StaticCheckResult(tool_name="ruff", diagnostics=[], summary="clean")
+
+
+def test_an_info_only_check_reports_skipped():
+    assert NeoEngine._static_check_status(_info_only()) == "skipped"
+    assert NeoEngine._static_check_status(_real_warning()) == "warning"
+    assert NeoEngine._static_check_status(_clean()) == "passed"
+
+
+def test_checks_that_evaluated_drops_only_the_skipped_ones():
+    checks = [_info_only(), _clean(), _real_warning()]
+    evaluated = NeoEngine._checks_that_evaluated(checks)
+    assert [c.tool_name for c in evaluated] == ["ruff", "constraint_verifier"]
+    assert NeoEngine._checks_that_evaluated([_info_only()]) == []
+
+
+def test_pyright_informational_severity_is_not_actionable():
+    """`information` is pyright's spelling; `info` alone missed it."""
+    assert NeoEngine._is_actionable_diagnostic({"severity": "information"}) is False
+    assert NeoEngine._is_actionable_diagnostic({"severity": "info"}) is False
+    assert NeoEngine._is_actionable_diagnostic({"severity": "warning"}) is True
+    # An unrecognized severity still fails toward being surfaced.
+    assert NeoEngine._is_actionable_diagnostic({"severity": "weird"}) is True
+    assert NeoEngine._is_actionable_diagnostic({}) is True
+
+
+def test_the_episode_ledger_records_skipped_not_warning(tmp_path):
+    """The #196 false alarm arriving through the episode ledger."""
+    from neo.memory.episodes import aggregate_verification_status
+
+    from neo.memory.episodes import LearningEpisode
+
+    engine = _engine()
+    engine.dry_run = False
+    engine.current_learning_episode = LearningEpisode(
+        objective="dedupe the ids",
+        repository_root=str(tmp_path),
+    )
+    metadata: dict = {}
+    engine._complete_learning_episode(
+        code_suggestions=[CodeSuggestion(
+            file_path="src/a.go",
+            unified_diff="",
+            description="",
+            confidence=0.9,
+            code_block="func F(xs []int) []int { return xs }",
+        )],
+        static_checks=[_info_only()],
+        reasoning_fact=None,
+        simulation_facts=[],
+        metadata=metadata,
+    )
+    statuses = [v.status for v in engine.current_learning_episode.verification]
+    assert "warning" not in statuses, (
+        "an info-only 'not checked for <language>' note was recorded as a "
+        "warning; aggregate_verification_status ranks warning above skipped, "
+        "so it becomes the run's whole verdict"
+    )
+    assert "skipped" in statuses
+    assert metadata["verification_verdict"] != "warning"
+    assert aggregate_verification_status(
+        engine.current_learning_episode.verification
+    ) != "warning"
+
+
+def test_a_real_warning_still_reaches_the_episode_ledger(tmp_path):
+    """The other direction: the fix must not mute genuine findings."""
+    from neo.memory.episodes import LearningEpisode
+
+    engine = _engine()
+    engine.dry_run = False
+    engine.current_learning_episode = LearningEpisode(
+        objective="dedupe the ids",
+        repository_root=str(tmp_path),
+    )
+    metadata: dict = {}
+    engine._complete_learning_episode(
+        code_suggestions=[CodeSuggestion(
+            file_path="src/a.py",
+            unified_diff="",
+            description="",
+            confidence=0.9,
+            code_block="def f(xs):\n    return xs\n",
+        )],
+        static_checks=[_real_warning()],
+        reasoning_fact=None,
+        simulation_facts=[],
+        metadata=metadata,
+    )
+    statuses = [v.status for v in engine.current_learning_episode.verification]
+    assert "warning" in statuses
+    assert metadata["verification_verdict"] == "warning"


### PR DESCRIPTION
## Description

Two trust-calibration defects, both of which made a Neo channel say the same thing
regardless of the run.

**#196** — `CONSTRAINT_CODE_MARKERS` was a single Python-only table applied to every
target, so the "no obvious handler (expected one of: `set(`, `dict.fromkeys`)" caution
could not be cleared by any C#, TypeScript or markdown code. Markers are now keyed by
language; a language with no table produces an honest `info` note naming the language
instead of a warning, and every downstream counter reads actionable diagnostics only.

**#199** — `confidence = 0.5` was a "no suggestions" sentinel sitting on the very scale
the number is read against, so a run that emitted an empty patch with a self-reported
`0.96` outranked a run that answered correctly at `0.50`. The sentinel comes off the
scale, and a suggestion naming a real file with no diff and no code block is excluded
from the average and from the early-exit gate.

While writing the #196 tests, a **second, larger half of the same defect** surfaced:
`_strip_comments_and_strings` rebuilds the source by joining tokens with a space, so
`sorted(x)` reached the matcher as `sorted ( x )` and the marker `sorted(` could never
match. The caution therefore fired on satisfied **Python** code too — see the BEFORE
block below, where all five cases warn. Both sides are now whitespace-normalized
before matching, in the fail-safe direction (a false match only suppresses a warning;
absence of a marker was always a hint, not a verdict).

Plan of record: `docs/unified-store-plan.md`, "Goal 4. Trust calibration". Opened as a
**DRAFT** per the 2026-08-12 Review & merge governance ruling — the shepherd flips it
ready after evidence verification.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Fixes #196
Fixes #199

## Motivation and Context

A caution channel with a permanent entry teaches operators to skip the channel — the
same channel that carries "I ran out of time before the checkers. This code is
unverified" and Neo's correct refusals. And a confidence number that is a constant for
analysis runs, and the model's opinion of a patch it did not write for empty-patch
runs, is consumed as if it were calibrated: `EARLY_EXIT_CONFIDENCE = 0.8` decides
whether the checkers run at all, and `confidence_interpretation` renders operator-facing
actions off it.

### BEFORE — `origin/main` @ `4a48b80`

```
#196 — constraint_verifier
  C# satisfying uniqueness via HashSet<T>    -> [warning] ... no obvious handler (expected one of: set(, dict.fromkeys)
  C# with no handler                         -> [warning] ... no obvious handler (expected one of: set(, dict.fromkeys)
  markdown target (the reported run)         -> [warning] ... no obvious handler (expected one of: set(, dict.fromkeys)
  Python satisfying uniqueness               -> [warning] ... no obvious handler (expected one of: set(, dict.fromkeys)
  Python with no handler                     -> [warning] ... no obvious handler (expected one of: set(, dict.fromkeys)

#199 — confidence
  empty patch, real path, self-reported 0.96   -> confidence=0.96   action=READY_TO_IMPLEMENT
  correct analysis, no suggestions             -> confidence=0.50   action=PROCEED_WITH_CAUTION
  genuine mid-confidence change                -> confidence=0.55   action=PROCEED_WITH_CAUTION
```

Five out of five constraint cases warn — the check is a constant. And the empty patch
outranks the correct analysis by 46 points and two action tiers.

### AFTER — this branch

```
#196 — constraint_verifier
  C# satisfying uniqueness via HashSet<T>    -> no caution
  C# with no handler                         -> [warning] Prompt declares constraint 'Elements must be unique' but generated csharp code shows no obvious handler (expected one of: HashSet<, ToHashSet(, .Distinct(, .GroupBy(, ISet<)
  markdown target (the reported run)         -> [info] Constraint 'Elements must be unique' was not checked: no markdown marker set for constraint type 'unique_elements'
  Python satisfying uniqueness               -> no caution
  Python with no handler                     -> [warning] Prompt declares constraint 'Elements must be unique' but generated python code shows no obvious handler (expected one of: set(, dict.fromkeys)

#199 — confidence
  empty patch, real path, self-reported 0.96   -> confidence=None   basis=no_verifiable_change   action=NO_VERIFIABLE_CHANGE
  correct analysis, no suggestions             -> confidence=None   basis=analysis_only          action=ANALYSIS_ONLY
  genuine mid-confidence change                -> confidence=0.55   basis=suggestions            action=PROCEED_WITH_CAUTION
```

The #196 permanent false alarm is gone on the C# fixture while the real missing-handler
case still warns on Python. The #199 inversion is corrected: the correct analysis now
ranks **above** the empty patch, and the mid-confidence run stays distinguishable from
both.

Stated precisely, because the first draft of this line overclaimed: the inversion is
fixed by the values themselves — neither run reports a number any more, and the two
report *different* bases and different operator-facing actions, so there is no longer a
scale on which the empty patch can outrank the analysis. `models.CONFIDENCE_ACTIONS` /
`confidence_action_rank` **declare** that ordering for hosts and tests; they are not
read by any internal control flow, and calling them "the ladder the fix runs on" would
describe a table nobody executes.

Both blocks were produced by the same script against the two source trees; reproduce by
pointing `PYTHONPATH` at each `src/` and calling `_check_constraints_static` /
`_calculate_confidence` with the fixtures pinned in the two new test modules.

## What changed

- **`constraint_verification.py`** — `LANGUAGE_CONSTRAINT_MARKERS` keyed by language
  (Python, C#, TypeScript/JavaScript), `language_for_path`, `markers_for_language`.
  `CONSTRAINT_CODE_MARKERS` stays as an alias for the Python table, which is what the
  name always meant.
- **`engine.py`** — `_check_constraints_static` resolves markers per language and emits
  `info` "not checked for `<language>`" where none exists; `_normalize_for_marker_match`
  fixes the token-rejoin miss; `_is_actionable_diagnostic` / `_actionable_diagnostics`
  are read by issue counts, next-questions and the confidence penalty;
  `_static_check_status` returns `skipped` (not `passed`) for an info-only result, so a
  check that evaluated nothing cannot vouch for an early exit.
  `_calculate_confidence` returns `(Optional[float], basis)`; the early-exit gate and
  the average both filter to scoreable suggestions.
- **`models.py`** — `suggestion_is_scoreable` / `suggestion_is_review_marker`, the four
  `CONFIDENCE_BASIS_*` constants, `NeoOutput.confidence: Optional[float]` plus
  `confidence_basis`, and the `CONFIDENCE_ACTIONS` trust ladder with
  `confidence_action_rank`.
- **`subcommands.py`** — `_interpret_confidence` renders `ANALYSIS_ONLY` and
  `NO_VERIFIABLE_CHANGE` distinctly instead of folding them onto the numeric bands; the
  scale reference now names the `null` case. Numeric bands are unchanged.
- **`cli.py` / `car_tool_schema.py`** — `confidence_basis` on both wire shapes;
  `CONFIDENCE: n/a (<reason>)` instead of printing `0.50`.
- **`config/beats/neo_matrix.yaml`** — the three new user-facing lines, per the
  no-prose-in-engine rule.

## How Has This Been Tested?

- [x] `tests/test_constraint_language_markers.py` — 25 tests: the reported markdown run,
      C#/TypeScript satisfaction and misses in each language's own vocabulary, the
      Python regression guard, the token-rejoin regression, honest degradation for
      unmapped extensions, and that info notes raise no next-question, dock no
      confidence and do not read as `passed`.
- [x] `tests/test_confidence_calibration.py` — 16 tests: the #199 pair reproduced
      end-to-end through `engine.process`, plus the mechanisms and the wire contract.
- [x] Guard-invariant battery: `pytest -m invariants` — **48 passed, 1 skipped**.
- [x] `ruff check src/ tests/ tools/` — clean.
- [x] Affected-surface sweep (orchestrator events, CAR tool schema, JSON serialization,
      operating modes, subcommands, engine, multi-agent, static analysis, schemas,
      structured parser, host-adapter parity, import health, home isolation):
      **315 passed, 1 failed**.

**The one local failure is pre-existing and environmental**, verified by running the
same test against `origin/main` @ `4a48b80` in the same shell:
`test_operating_modes.py::test_verify_cli_needs_no_provider_and_agent_cli_fails_before_provider`
gives the CLI subprocess 30 s, and the subprocess spends ~20 s of it fetching the
fastembed model into the test's fresh `HOME` on a machine under load 35. It fails
identically on `origin/main`. Running the same VERIFY payload by hand on this branch
returns `rc=0` with `confidence_basis: "verification_verdict"`. CI is the authoritative
full-suite verdict.

**Test Configuration**:
- Python version: 3.13.7 (CI matrix: 3.10 / 3.11 / 3.12 / 3.13)
- OS: macOS (darwin 25.5.0)
- Neo version: 0.45.0

## M1 — branch vs main, three flagships

No selection code is touched. The diff is 7 source files
(`car_tool_schema.py`, `cli.py`, `neo_matrix.yaml`, `constraint_verification.py`,
`engine.py`, `models.py`, `subcommands.py`) and 2 new test modules; nothing under
`context_gatherer`, `index/` or the walker. `--dry-run` returns before any `NeoOutput`
is built, so it never reaches the changed `cli.py` block or `_calculate_confidence` at
all.

M1 is computed from what `neo --dry-run` selects, so identical selection means identical
R@k / MRR for any ground truth. Measured directly — same prompts, same repos, same venv,
only `PYTHONPATH` differing between this branch's `src/` and `origin/main` @ `4a48b80`:

```
neo         q1: IDENTICAL  (25 selected entries, branch == main)
neo         q2: IDENTICAL  (25 selected entries, branch == main)
aieweb      q1: IDENTICAL  (25 selected entries, branch == main)
aieweb      q2: IDENTICAL  (25 selected entries, branch == main)
m365dotnet  q1: IDENTICAL  (25 selected entries, branch == main)
m365dotnet  q2: IDENTICAL  (25 selected entries, branch == main)
```

q1 = "How does authentication work in this codebase?" (concept-only),
q2 = "Fix the retry logic when a request is throttled." (mixed), both with `--no-git` so
the recency signal cannot vary between arms. Byte-identical ranked selection lists on all
six pairs.

**Stated plainly so nobody reads more into it than is there:** this is a
selection-identity check on two prompts per repo, **not** a re-run of the 50-case
`tools/rank_mine_eval.py` MRR harness. That harness shells out to `neo --dry-run` once
per case; at ~12 s per invocation on this machine (load average 22–37 from concurrent
goalpool sessions) a single 50-case arm on `neo` exceeded 10 minutes, and six arms across
the three flagships was not achievable in this run. The identity check is the stronger
claim per unit of evidence — an identical selection list makes the MRR identical by
construction — but it samples two queries per repo rather than fifty. If the shepherd
wants the full M1 tables re-measured, say so and I will run them on a quiet machine.

## Review round: a fresh non-author pass, and what it found

A fresh non-author Claude verified the branch against both issues before the shepherd
sees it. It found the #196 fix had introduced **the other half of its own defect**, plus
three quieter leaks. All five are fixed in `be2427b`; the two `--- BEFORE / AFTER ---`
blocks above still hold.

**The one that mattered: on the languages this PR added, a genuine missing handler
passed silently.** `_strip_comments_and_strings` used Python's `tokenize`, which does
*not* fail on C# — `//` lexes as floor-division — so line comments survived as code and
a file carrying `// TODO: use HashSet<int> here one day` matched the uniqueness marker
while deduplicating nothing. C# `///` and TS `/** */` doc comments name `HashSet`,
`Distinct` and `OrderBy` constantly, so this was the common case. The PR had converted
"always warns, uselessly" into "silently passes whenever a doc comment mentions the
API", which is the worse failure of the two. Stripping is now per language.

**The matcher was also too weak to be useful.** A substring test over whitespace-stripped
text let `set(` match `offset(`, `reset(` and `dataset(`, and `Set<` match `Subset<` —
UNIQUE_ELEMENTS was close to inert on real Python and TypeScript, each collision
silently dropping a real warning. Markers are now anchored on the left identifier
boundary. Two things had to change together for that to be correct: normalization keeps
the single space between two identifiers (dropping *all* whitespace fuses `new HashSet<`
into `newhashset<`, so the anchor would reject C#'s primary idiom), and the right edge
stays deliberately **unanchored**, because markers are family prefixes — `OrderBy` is
written to cover `OrderByDescending`, `bisect` to cover `bisect_left`, and anchoring
both edges fires a warning at code that satisfies the constraint, which is #196
re-entering through the matcher. `frozenset(` and `new Set(` move into the tables in
their own right.

**Three honest-degradation leaks, one of which dropped a true caution.** The episode
ledger recomputed check status inline as `warning if diagnostics`, and
`aggregate_verification_status` ranks `warning` above `skipped` — so an info-only "not
checked for `<language>`" note became the run's whole `verification_verdict`, which is
#196's false alarm arriving through the ledger instead of the console. Separately, the
phase summary said "All 1 checker(s) clean", VERIFY's verdict said "nothing pushed
back", and the caution reading "No checkers on this machine. This code is unverified."
was **suppressed** — because the list was not empty. That last one is the worst shape:
a true caution dropped, not a false one added. All four now read
`_static_check_status` / the new `_checks_that_evaluated`.

Also `information` is pyright's own severity spelling, so the one real tool that emits
informational diagnostics was the one the new non-actionable rule missed.

The verifier additionally confirmed **(c)**: every read of `NeoOutput.confidence` across
`src/`, both host adapters and the CAR tool schema is either `None`-guarded or
JSON-serializes cleanly — no crash path from the `Optional[float]` change. And **(e)**:
nothing under `context_gatherer`, `index/` or the walker is touched, which Goals 3 and 5
own.

### Host adapters, which the first round missed

`--json` can now emit `"confidence": null` plus a new `"confidence_basis"`, and neither
integration surface documented it — a violation of this repo's own rule that both
adapters change when the contract does. An LLM host handed `null` under a standing
instruction to "report Neo's confidence as the number it is" has no guidance, and the
failure mode is precisely #199's: treating a run with no number as less trustworthy than
an empty patch self-reporting `0.96`. Both `.claude-plugin/agents/neo.md` and
`plugins/neo/skills/neo/SKILL.md` now name the null case and both basis values, and
`test_both_entry_points_teach_the_null_confidence_contract` pins it against the
constants so it cannot drift again.

### Verification of the review round

- [x] `tests/test_constraint_marker_matching.py` — 20 new tests: comments and doc
      comments per language, the string-literal and URL-inside-a-string cases, all five
      boundary collisions, both TypeScript `Set` spellings, the family-prefix markers
      that must stay unanchored, and one test asserting **every marker in every table
      can match its own text** — a marker no code can contain is #196 by construction.
- [x] `tests/test_static_check_honesty.py` — 5 new tests, including the episode-ledger
      verdict in both directions.
- [x] `tests/test_host_adapter_parity.py` — the null-confidence parity test.
- [x] Re-run after the fixes: the two original modules (41) + the two new ones (25) +
      host-adapter parity (54) = **120 passed**; Guard-invariant battery **48 passed,
      1 skipped**; engine/static-analysis/orchestrator-events/CAR-schema/learning-
      episodes/schemas/subcommands = **150 passed**; `ruff check src/ tests/ tools/`
      clean.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (one pre-existing
      environmental failure, evidenced above)
- [x] Any dependent changes have been merged and published

## Additional Notes

Three judgement calls worth a reviewer's attention:

1. **`NO_VERIFIABLE_CHANGE` is the floor of the trust ladder, and that is the only
   relation any code depends on.** `ANALYSIS_ONLY` is placed above
   `PROCEED_WITH_CAUTION` because it carries no unverified patch to act on — not
   because it is more certain; there is no certainty claim in it at all. An
   unrecognized action ranks below every known one.
2. **An info-only static check reports `skipped`, not `passed`.** That is a deliberate
   behaviour change beyond the reported bug: it means a constraint check that could not
   evaluate the target language no longer contributes to `static_ran_clean`, so a run
   whose only checker was unable to check anything will not early-exit.
3. **`UNSCORED_MEMORY_PRIOR = 0.5`** in `engine.py` keeps the legacy memory-entry prior
   at its old value on purpose. It is a starting weight on the retrieval layer's scale,
   not the operator-facing verdict — naming it is what keeps the two apart now that the
   run-level sentinel is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

