### PR TITLE
perf(index): persist the BM25 content index instead of rebuilding it per call (#195)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,6 +719,70 @@
   `test_every_chunk_query_compiles` /
   `test_every_edge_query_compiles` prove compilation ONLY, so a new query still
   needs its own behavioural assertion.
+- Persistent content index (`index/content_index.py`, `index/freshness.py`). The
+  BM25 corpus above is **built once and kept on disk**, in the repository's own
+  `.neo/` beside the semantic catalog, not re-derived per call. Rebuilding it per
+  invocation was the entire cost of a Neo call on a large repo: the canonical M2
+  battery on m365dotnet (9,348 eligible files) measured a **53.47 s** median wall
+  and 1.95 GB peak RSS, against 18.50 s / 1.45 GB with the store (#195). Selection
+  is UNCHANGED — byte-identical selected files and rank order on all six battery
+  prompts, and byte-identical `rank_mine_eval` MRR / R@k on all three flagships
+  (neo 0.712, aieweb 0.728, m365dotnet 0.669, 50 cases each).
+  - **SQLite, not the catalog's JSON, and the access shape is the reason.** The
+    catalog is read whole (every embedding participates in every query); a keyword
+    query touches ten terms out of a few hundred thousand, so a parse-whole format
+    would spend the warm budget deserializing postings nothing asked for. Index
+    artifacts only — postings, doc lengths, hashes, a tokenizer/schema signature —
+    never a file body; delivery still reads whole files fresh from disk. Cost is
+    disk: 109 MB for m365dotnet, 5 MB for neo.
+  - **The cheap stamp decides what to HASH, never that a file changed.** size +
+    mtime come free from the walk's existing `stat` (`EligiblePath.mtime_ns`);
+    only a content-hash mismatch counts as a change, so `touch` re-stamps and
+    re-tokenizes nothing and is reported as `touched`, separately from `changed`.
+    `UNRECORDED = -1` disables the cheap path for a store that persists hashes
+    alone — and it is checked EXPLICITLY, because the first cut stamped both the
+    store and the candidate with the sentinel and `-1 == -1` reported every
+    changed file as unchanged.
+  - **Eligibility arrives from the #208 walker and is never recomputed here** —
+    `test_the_module_does_not_walk_the_filesystem` fails on an `os.walk`/`glob` in
+    the module. A file the walker stops admitting (newly gitignored, deleted) has
+    its postings dropped on the same pass, so a stale index cannot answer with an
+    excluded file. Correspondingly the gatherer now walks ONCE, unfiltered, and
+    applies `--exts`/`--include`/`--exclude` to the result: the index is a
+    property of the REPOSITORY, and letting one `--exts py` call prune it would
+    force the next call to rebuild. `--exclude` no longer prunes a directory
+    subtree (it excludes every file under it via `should_ignore`, which matches a
+    non-final component); the names that make pruning matter are in the walker's
+    shared default list.
+  - **Parity is enforced, not asserted.** `K1`/`B`/IDF are imported from
+    `neo.memory.bm25` and the document is the same expression `FileIndex` used, so
+    `TestParity` can score one corpus both ways and compare to floating point.
+    Query-term MULTIPLICITY is preserved — deduping the query before hitting the
+    postings table is a silent ranking change, since the scorer this replaces
+    iterated the token LIST. One stated difference: N/df/avgdl are global to the
+    indexed repository rather than recomputed over each call's filtered subset;
+    with no filters (every eval, every default call) the sets are identical.
+  - Degradations are loud and none is fatal: a **corrupt** store is deleted and
+    rebuilt — detected while OPENING, which matters, because the fallback is
+    permanent and a store that merely failed to open would pin that repository to
+    the full per-call rebuild forever; a **tokenizer/schema** bump wipes and
+    rebuilds (no per-file hash can see it — the files did not change, the
+    tokenizer did); an **unwritable** store still ranks correctly from memory via
+    `FileIndex` and says so. `cold`/`rebuilt` are reported separately though both
+    read everything: only one means something went wrong.
+  - Cold build is bounded and ANNOUNCED before it starts, with progress every 250
+    files — 122 s for m365dotnet's 9,348, 2.3 s for neo's 307. `--dry-run` names
+    which of cold / rebuilt / incremental (N files) / warm / memory happened, in
+    the selected-files block and in the `--json` payload's `content_index` key
+    (`--json` implies `--quiet`, so the stderr note is suppressed on exactly the
+    path a machine consumer reads).
+  - **M2's 500 MB target is NOT reachable from file selection and never was.**
+    Warm profile on m365dotnet: imports 1.2 s, eligibility walk 4.6 s, content
+    index refresh 0.4 s + scores 0.1 s, `_history_boost` 2.9 s **and +1.26 GB**.
+    The RSS is the FactStore (152 MB of JSON with 768-dim embeddings inflating to
+    ~1.3 GB of Python objects) — Goal 1's 1.43 GB baseline was never the
+    gatherer's. What remains of the warm wall-clock is the walker and the memory
+    system, in that order.
 - Context selection (`context_gatherer`): **files are ranked by BM25 over their
   CONTENT** (`neo.file_retrieval`), not by their path. Until 2026-08 they were: the
   scorer took `(rel_path, size, prompt_tokens, git_recent, entry_points)` and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -759,17 +759,43 @@
     `TestParity` can score one corpus both ways and compare to floating point.
     Query-term MULTIPLICITY is preserved — deduping the query before hitting the
     postings table is a silent ranking change, since the scorer this replaces
-    iterated the token LIST. One stated difference: N/df/avgdl are global to the
-    indexed repository rather than recomputed over each call's filtered subset;
-    with no filters (every eval, every default call) the sets are identical.
-  - Degradations are loud and none is fatal: a **corrupt** store is deleted and
-    rebuilt — detected while OPENING, which matters, because the fallback is
-    permanent and a store that merely failed to open would pin that repository to
-    the full per-call rebuild forever; a **tokenizer/schema** bump wipes and
-    rebuilds (no per-file hash can see it — the files did not change, the
-    tokenizer did); an **unwritable** store still ranks correctly from memory via
-    `FileIndex` and says so. `cold`/`rebuilt` are reported separately though both
-    read everything: only one means something went wrong.
+    iterated the token LIST. **A filtered call gets filtered statistics**:
+    `scores(prompt, candidates)` takes N, df and avgdl from `candidates`, not
+    from the whole repository. Repo-global stats were the first cut and are the
+    better IR design in the abstract; they are also a re-rank, and a
+    fresh-verifier pass caught it — unflagged runs matched main exactly while
+    `--exts py` changed all 25 selected lines. Now byte-identical under
+    `--exts`, `--exclude` and `--include` as well.
+  - Degradations are loud and none is fatal, and the **except-clause ORDER is the
+    whole mechanism**: `sqlite3.OperationalError` is a SUBCLASS of
+    `DatabaseError`, so `except DatabaseError` written first catches "database is
+    locked" and runs the corruption handler — which `os.unlink`s a perfectly good
+    store. Reproduced: the index was deleted AND the peer's committed transaction
+    went into an unlinked inode and vanished with no error anywhere. Two Neo
+    invocations in one repo is ordinary (an editor plugin and a shell), not
+    exotic. So: **locked / read-only / full** → serve this call from memory via
+    `FileIndex` and say so; **corrupt** (a `DatabaseError` that is NOT an
+    `OperationalError`) → delete and rebuild, detected while OPENING because the
+    memory fallback is permanent and a store that merely failed to open would pin
+    that repo to the full per-call rebuild forever; **tokenizer/schema** bump →
+    wipe and rebuild (no per-file hash can see it — the files did not change, the
+    tokenizer did). `cold`/`rebuilt` are reported separately though both read
+    everything: only one means something went wrong, and the corruption flag is
+    CONSUMED, or a reused instance rebuilds on every refresh forever.
+  - **A warm call opens no write transaction.** Rewriting the unchanged signature
+    unconditionally made every invocation a writer, so two ordinary overlapping
+    calls contended on the steady-state path rather than only during a rebuild —
+    which is what made the clause-order bug reachable in normal use.
+  - **A file that cannot be hashed keeps its path tokens.** `chmod 000` used to
+    delete it from the corpus permanently, while the per-call index still ranked
+    it on its name (its content simply read as empty). Permission was withdrawn
+    from the CONTENT; the name is still a real name in the repository. The empty
+    hash is safe as a comparison value because stamps are keyed by path —
+    `"" == ""` is only ever asked of one file against its own previous state.
+  - **The vocabulary is not preloaded to answer a query.** Reading every `terms`
+    row to resolve ten of them cost a few hundred thousand rows on the warm path
+    this module exists to make cheap; term ids resolve per query, and the full
+    map is loaded only when writing.
   - Cold build is bounded and ANNOUNCED before it starts, with progress every 250
     files — 122 s for m365dotnet's 9,348, 2.3 s for neo's 307. `--dry-run` names
     which of cold / rebuilt / incremental (N files) / warm / memory happened, in

--- a/docs/goal6-content-index-measurements-2026-08-12.md
+++ b/docs/goal6-content-index-measurements-2026-08-12.md
@@ -80,6 +80,31 @@ for p in P1 P2 P3 P4 P5 P6; do
 done   # no output: identical selection AND order, all six
 ```
 
+**Parity holds under per-call flags too, which it did not at first.** A
+fresh-verifier pass found that repo-global corpus statistics re-ranked any call
+carrying `--exts` / `--exclude` / `--include`: unflagged runs matched `main`
+exactly while `--exts py` changed all 25 selected lines. `scores()` now takes N,
+document frequency and average document length from the candidate subset, which
+is what the per-call index did. Re-measured end-to-end on the neo repo, same
+prompt, comparing the full `--dry-run` selected-file lines (path, byte count,
+line range and score):
+
+| flags | result |
+|---|---|
+| *(none)* | IDENTICAL — 25 lines |
+| `--exts py` | IDENTICAL — 25 lines |
+| `--exts py,md` | IDENTICAL — 25 lines |
+| `--exclude docs` | IDENTICAL — 25 lines |
+| `--exclude src/neo/memory` | IDENTICAL — 25 lines |
+| `--include 'src/neo/*.py'` | IDENTICAL — 25 lines |
+
+A note on how that table was nearly wrong: a first run of this comparison
+reported "IDENTICAL (0 lines)" for every flagged row. Zsh does not word-split an
+unquoted `$flags`, so `--exts py` arrived as one argument, neo rejected it, and
+both arms selected nothing — two empty files compare equal. A vacuous PASS reads
+exactly like a real one; the row count is in the table so it cannot happen
+silently again.
+
 **Staleness, the check the plan asks for.** Ten `.cs` files in m365dotnet were each
 given a unique marker, the index was refreshed, and the marker was searched for:
 
@@ -219,4 +244,4 @@ verdict and cannot widen it.
 | A `dense` / RRF lane comparison | Unbaselined on the flagships since Goal 1 and unchanged by this goal; see that document's own note. |
 | M2 on neo or aieweb | The battery's six prompts are m365dotnet-specific by construction (they name m365dotnet paths). The plan measures M2 there. |
 | A distinct count for main's cold build | main has no persistent store; its per-call rebuild IS the 53.47 s median, and quoting it as a separate "cold" number would double-count. |
-| Concurrency measurements | Two Neo processes in one repository are handled (WAL, busy timeout, memory fallback) and unit-tested, but the contended path is not timed here. |
+| Concurrency measurements | The contended path is correct and unit-tested (`TestConcurrency` holds a real `BEGIN EXCLUSIVE` from a peer connection and asserts the store survives, the peer's commit survives, and the loser degrades to memory), but it is not TIMED here. |

--- a/docs/goal6-content-index-measurements-2026-08-12.md
+++ b/docs/goal6-content-index-measurements-2026-08-12.md
@@ -1,0 +1,212 @@
+# Goal 6 — persistent content index: measurements
+
+**Measured:** 2026-08-12
+**Goal:** Unified Store Plan, Goal 6 (Persistent content index) — see `docs/unified-store-plan.md`
+**Closes:** #195
+**Arms:** `main` = `9b0c16d63cfc` (post-#208) · `branch` = `df8f670ebded`
+**Companion:** `docs/eval-baselines-2026-08.md` (Goal 1), whose M2 battery and mining
+parameters are canonical and unchanged here.
+
+Every number below was produced by running the command printed beside it. Nothing is
+estimated, projected, or interpolated. Two placeholders, as in the baselines doc:
+`<platform-root>` is the checkout holding the child repos, `<branch>` / `<main>` are
+the two neo worktrees.
+
+---
+
+## Headline
+
+| Metric | main | branch | Target | Verdict |
+|---|---|---|---|---|
+| **M2** warm median wall, m365dotnet | 53.47 s | **18.50 s** | ≤ 5 s | **not met** (2.9× better, 3.7× over) |
+| **M2** peak RSS, m365dotnet | 1.95 GB | **1.45 GB** | ≤ 500 MB | **not met** — see *Where M2 actually goes* |
+| **M2** cold build, m365dotnet | n/a | 122.1 s / 1.47 GB | bounded + reported | **met** |
+| **M3** re-index after 10 edited files | n/a (full rebuild) | **0.79 s** index work | ≤ 5 s | **met** |
+| **M1** MRR, three flagships | 0.712 / 0.728 / 0.669 | **identical** | no regression | **met** |
+| **G1-inv** ignored / duplicate selections | 0 / 0 | 0 / 0 | 0 | **met** |
+
+Read the two M2 rows together with the profile below before treating them as a Goal 6
+shortfall. The cost this goal owns — re-reading and re-tokenizing the corpus on every
+call — is gone: it is **0.5 s of an 18.5 s** warm call. What remains belongs to two
+other components, and one of them makes the 500 MB target unreachable from file
+selection at all.
+
+---
+
+## M1 — retrieval quality: identical, on all three flagships
+
+Persistence must not re-rank, and it does not. Same harness, same repos, same mined
+cases, 50 per repo, zero failed cases, `--no-git` (the default).
+
+| repo | arm | cases | MRR | R@1 | R@3 | R@10 | H@10 |
+|---|---|---|---|---|---|---|---|
+| neo | main | 50 | 0.712 | 0.307 | 0.502 | 0.708 | 0.980 |
+| neo | **branch** | 50 | **0.712** | **0.307** | **0.502** | **0.708** | **0.980** |
+| aieweb | main | 50 | 0.728 | 0.487 | 0.654 | 0.778 | 0.880 |
+| aieweb | **branch** | 50 | **0.728** | **0.487** | **0.654** | **0.778** | **0.880** |
+| m365dotnet | main | 50 | 0.669 | 0.312 | 0.497 | 0.771 | 0.860 |
+| m365dotnet | **branch** | 50 | **0.669** | **0.312** | **0.497** | **0.771** | **0.860** |
+
+Byte-identical in every cell. Repo HEADs at measurement: neo `5bbee46747c8`,
+aieweb `26fff07e0f4a`, m365dotnet `61dc4a171bdf`.
+
+```bash
+for repo in neo aieweb m365dotnet; do
+  for arm in main branch; do
+    tree=<main>; [ "$arm" = branch ] && tree=<branch>
+    <branch>/.venv/bin/python <branch>/tools/rank_mine_eval.py \
+      --repo <platform-root>/$repo --tree "$tree" --json
+  done
+done
+```
+
+A stronger statement is available on the M2 battery, and it is the one to quote: the
+six canonical prompts on m365dotnet selected **the same files in the same rank order**
+on both arms, compared as text.
+
+```bash
+for p in P1 P2 P3 P4 P5 P6; do
+  diff /tmp/g6_m2_main/${p}_run1.files /tmp/g6_m2_branch/${p}_run1.files
+done   # no output: identical selection AND order, all six
+```
+
+**Staleness, the check the plan asks for.** Ten `.cs` files in m365dotnet were each
+given a unique marker, the index was refreshed, and the marker was searched for:
+
+```
+S3 files matching the unique edit token: 1 -> ['src/Ink.Core/Editing/ApplyEditPlanResult.cs']
+```
+
+New content is findable and attributed to exactly the file that now holds it. The
+converse — old content ceasing to be findable — is pinned by
+`test_an_edit_is_reflected_with_no_stale_hits`, which asserts both halves, because an
+index that only ever ADDS postings passes the first check while answering with text
+that is no longer in the file. All ten files were restored from a byte copy afterwards
+and `git status --porcelain` on m365dotnet is identical before and after (5
+pre-existing dirty entries, untouched).
+
+---
+
+## M2 — warm call cost on m365dotnet
+
+`tools/m2_battery.sh`, unchanged, six canonical prompts, one discarded warm-up then
+`RUNS=3` timed runs per prompt; wall-clock is the median, RSS is the maximum observed.
+
+```bash
+RUNS=3 tools/m2_battery.sh /tmp/g6bin/neo-<arm> <platform-root>/m365dotnet /tmp/g6_m2_<arm>
+```
+
+| id | shape | main median | **branch median** | main peak RSS | **branch peak RSS** |
+|---|---|---|---|---|---|
+| P1 | file-named | 60.25 s | **17.08 s** | 1615.6 MiB | **1384.7 MiB** |
+| P2 | file-named | 54.25 s | **18.45 s** | 1686.2 MiB | **1386.4 MiB** |
+| P3 | concept-only | 52.49 s | **19.00 s** | 1801.5 MiB | **1383.3 MiB** |
+| P4 | concept-only | 53.52 s | **18.09 s** | 1698.0 MiB | **1383.6 MiB** |
+| P5 | mixed | 52.46 s | **18.79 s** | 1851.3 MiB | **1384.2 MiB** |
+| P6 | symptom | 39.55 s | **19.27 s** | 1856.8 MiB | **1384.2 MiB** |
+| **BATTERY** | | **53.47 s** | **18.50 s** | **1856.8 MiB (1.95 GB)** | **1386.4 MiB (1.45 GB)** |
+
+Selection identical on both arms: 180 context entries, 111 battery-union distinct
+files, 69 battery-wide repeats, 45 within-prompt.
+
+### Cold build, reported separately
+
+First invocation in a repository with no store, timed with `/usr/bin/time -l`:
+
+| repo | eligible files | cold build | peak RSS | store on disk |
+|---|---|---|---|---|
+| m365dotnet | 9,353 | **122.14 s** | 1.47 GB | 109 MB |
+| neo | 307 | **2.3 s** | — | 5 MB |
+
+It announces itself before it starts and reports progress every 250 files, so the
+minutes are visible rather than silent:
+
+```
+[Neo] Content index: no usable index for this repository - building one over 9353 files.
+      This runs once; later calls update only what changed.
+[Neo] Content index: 250/9353 files tokenized
+...
+[Neo] Content index: cold build of 9353 files (first run for this repository) in 122.1s
+```
+
+### Where M2 actually goes
+
+Warm profile, m365dotnet, one process, `ru_maxrss` sampled per stage:
+
+```
+T imports                      +  1.16s  cum   1.16s  rss=    82MB
+T eligibility walk (9348)      +  4.64s  cum   5.80s  rss=    87MB
+T content index refresh (warm) +  0.41s  cum   6.22s  rss=   127MB
+T content index scores (7266)  +  0.12s  cum   6.33s  rss=   127MB
+T project index boost          +  0.12s  cum   6.46s  rss=   140MB
+T fact store history boost     +  2.94s  cum   9.40s  rss=  1404MB
+```
+
+Three readings, stated plainly:
+
+1. **The cost Goal 6 owns is gone.** Content indexing is 0.53 s of a warm call, down
+   from the ~35–45 s it contributed to main's 53.47 s median. It is no longer the
+   dominant term, or close to it.
+2. **The 500 MB RSS target is not reachable from file selection.** 1.26 GB of the
+   1.4 GB arrives in a single step — `_history_boost` loading the FactStore, which on
+   this machine is 152 MB of JSON carrying 768-dim embeddings that inflate to ~1.3 GB
+   of Python objects. Goal 1's 1.43 GB M2 baseline was therefore never the gatherer's
+   memory; it was the memory system's, measured through the gatherer. No change to
+   how files are chosen can move it, and a Goal 6 that "hit 500 MB" would have done so
+   by deleting a retrieval channel, not by indexing better.
+3. **The next wall-clock item is the eligibility walk**, at 4.6 s for 9,348 admitted
+   files out of ~345k filesystem entries — 97 ignore patterns evaluated per path
+   component, CPU-bound and stable across repeats (5.88 / 6.91 / 6.63 s in three
+   consecutive in-process calls). That is #208's shared walker, untouched here, and it
+   is the largest remaining component of a warm call.
+
+Neither (2) nor (3) is a defect introduced by this branch, and neither is in Goal 6's
+scope. They are recorded here because the plan assigns M2's ≤5 s / ≤500 MB to this
+goal, and the profile says which later goal can actually deliver each half.
+
+---
+
+## M3 — freshness cost
+
+Ten `.cs` files in m365dotnet edited, then one refresh:
+
+```
+M3 walk=4.42s  refresh=0.79s  mode=incremental changed=10 added=0 removed=0 indexed=10 total=9353
+```
+
+**0.79 s of index work against a ≤5 s target — met.** Stated with its neighbour so the
+number is not read as more than it is: the walk that precedes it costs 4.42 s, so
+walk + refresh is 5.21 s. The walk is not re-indexing work, it is the eligibility scan
+every invocation pays regardless of what changed (see reading 3 above), and Goal 6
+neither added it nor can remove it.
+
+---
+
+## G1-invariant on m365dotnet
+
+Computed over the full battery on **both** arms, with the script from
+`docs/eval-baselines-2026-08.md` pointed at each arm's output directory.
+
+| label | distinct | `git check-ignore` excludes | duplicate copies | inside `.worktrees/` | unresolvable |
+|---|---|---|---|---|---|
+| P1 | 22 | 0 | 0 | 0 | 0 |
+| P2 | 23 | 0 | 0 | 0 | 0 |
+| P3 | 24 | 0 | 0 | 0 | 0 |
+| P4 | 22 | 0 | 0 | 0 | 0 |
+| P5 | 24 | 0 | 0 | 0 | 0 |
+| P6 | 20 | 0 | 0 | 0 | 0 |
+| **BATTERY UNION** | **111** | **0** | **0** | **0** | **0** |
+
+Identical on main and branch — which is the point: the index consumes the walker's
+verdict and cannot widen it.
+
+---
+
+## What this document does not contain
+
+| Missing | Reason |
+|---|---|
+| A `dense` / RRF lane comparison | Unbaselined on the flagships since Goal 1 and unchanged by this goal; see that document's own note. |
+| M2 on neo or aieweb | The battery's six prompts are m365dotnet-specific by construction (they name m365dotnet paths). The plan measures M2 there. |
+| A distinct count for main's cold build | main has no persistent store; its per-call rebuild IS the 53.47 s median, and quoting it as a separate "cold" number would double-count. |
+| Concurrency measurements | Two Neo processes in one repository are handled (WAL, busy timeout, memory fallback) and unit-tested, but the contended path is not timed here. |

--- a/docs/goal6-content-index-measurements-2026-08-12.md
+++ b/docs/goal6-content-index-measurements-2026-08-12.md
@@ -50,6 +50,16 @@ cases, 50 per repo, zero failed cases, `--no-git` (the default).
 Byte-identical in every cell. Repo HEADs at measurement: neo `5bbee46747c8`,
 aieweb `26fff07e0f4a`, m365dotnet `61dc4a171bdf`.
 
+**Measurement condition, disclosed because it happened mid-run.** m365dotnet is a live
+working tree on a shared machine, and an unrelated session ran `git reset` in it at
+20:58:59 (`git reflog --date=iso`) — between the m365dotnet `main` arm (20:53–21:27)
+and the `branch` arm (21:27–21:42). That reverted one modified tracked file and removed
+two untracked paths, so the two arms saw corpora differing by a handful of files. HEAD
+did not move. The arms still agree in every cell, which says the perturbation was
+immaterial to these 50 cases — it is not evidence that it could never matter, and a
+re-measure wanting a stricter guarantee should pin the tree. The neo and aieweb arms
+ran either side of no such event.
+
 ```bash
 for repo in neo aieweb m365dotnet; do
   for arm in main branch; do

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -739,7 +739,7 @@ def _report_dry_run(args, calls) -> None:
     the first had.
     """
     if args.json:
-        print(json.dumps({
+        payload = {
             "dry_run": True,
             "calls": calls,
             "note": (
@@ -747,10 +747,33 @@ def _report_dry_run(args, calls) -> None:
                 "adapter restructures them (Anthropic hoists system, Google "
                 "remaps roles, Ollama flattens, CAR adds intent_json)"
             ),
-        }, indent=2))
+        }
+        # `--json` implies `--quiet`, so the stderr note the content index
+        # emits is suppressed on exactly the path a machine consumer reads.
+        # It is a fact about what the run cost and it belongs in the report.
+        report = _content_index_report()
+        if report is not None:
+            payload["content_index"] = report
+        print(json.dumps(payload, indent=2))
         _emit_dry_run_terminal_event()
     else:
         print(render(calls), file=sys.stderr)
+
+
+def _content_index_report():
+    """This process's content-index freshness report, or None.
+
+    None means the index never ran -- `--no-scan`, or a gather that found no
+    eligible file at all. That is a real distinction and it is reported as an
+    absent key rather than as an empty one, which would read as "the index ran
+    and did nothing".
+    """
+    try:
+        from neo.index.content_index import last_report
+    except ImportError:  # pragma: no cover - the module ships with neo
+        return None
+    report = last_report()
+    return report.to_dict() if report is not None else None
 
 
 def _emit_dry_run_terminal_event() -> None:
@@ -790,6 +813,14 @@ def _print_selected_files(gathered) -> None:
     eligible.
     """
     print("\n=== DRY RUN: files selected, in rank order ===\n", file=sys.stderr)
+    # Whether the ranking above came out of a cold build, an incremental
+    # update or a warm read is the difference between a 60-second call and a
+    # 2-second one, and it is invisible from the file list. Printed inside the
+    # block rather than left to the progress note so it cannot drift away from
+    # the selection it describes.
+    report = _content_index_report()
+    if report is not None:
+        print(f"  [{report['summary']}]\n", file=sys.stderr)
     for gf in gathered:
         lines_info = f" (lines {gf.start}-{gf.end})" if gf.start else ""
         print(

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -167,13 +167,21 @@ def filter_candidates(
     keeps its `fnmatch` dialect, which is a user-facing CLI contract rather
     than a gitignore rule and was already applied after eligibility.
 
-    Note the one thing this cannot reproduce: the walk PRUNES an excluded
-    directory instead of testing every file beneath it. A `--exclude` pattern
-    naming a directory therefore no longer saves the cost of descending into
-    it. It still excludes every file under it — `should_ignore` matches a
-    non-final path component — and the directories that make pruning matter
-    (`node_modules`, `.worktrees`, build output) are in the shared default
-    list, which the walk still prunes.
+    Two things this cannot reproduce, both cost rather than correctness, and
+    stated in full because the first draft of this note understated the second:
+
+    - The walk PRUNES an excluded directory instead of testing every file
+      beneath it, so a `--exclude` naming a directory no longer saves the cost
+      of descending into it. It still excludes every file under it —
+      `should_ignore` matches a non-final path component — and the directories
+      that make pruning matter (`node_modules`, `.worktrees`, build output)
+      are in the shared default list, which the walk still prunes.
+    - A file this function drops is still INDEXED: the content index is
+      refreshed from the unfiltered walk, so an `--exts py` run reads,
+      tokenizes and stores the whole repository. That is the deliberate trade —
+      the index is a property of the repository, and pruning it to one call's
+      flags would make the next call rebuild — but it means `--exclude` does
+      not stop a file being read, only being ranked and delivered.
     """
     ext_set = eligibility.normalize_exts(exts) if exts else None
     out: list[eligibility.EligiblePath] = []

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -130,26 +130,73 @@ class GatherConfig:
 MAX_FILE_BYTES = 512_000
 
 
-def iter_paths(root: str, includes: list[str], excludes: list[str], exts: Optional[list[str]]) -> list[tuple[str, str, int]]:
-    """Walk `root` via the shared eligibility module, then apply `--include`.
+def base_paths(root: str) -> list[eligibility.EligiblePath]:
+    """The repository's indexable corpus: the shared walk, no per-call flags.
 
-    The walk, the ignore rules and the gitignore matcher all live in
-    `neo.eligibility` and are shared with the project index — there is no
-    second copy here to drift. What stays is the gatherer's own policy: the
-    512 KB ceiling, and `--include`, whose `fnmatch` dialect is a user-facing
-    CLI contract rather than a gitignore rule and is therefore applied after
-    eligibility rather than folded into it.
+    Split out from `iter_paths` because the persistent content index and one
+    invocation's candidate list are answers to different questions. The index
+    is a property of the REPOSITORY — it must survive a call that passed
+    `--exts py` without being pruned to Python and rebuilt on the next call
+    that did not. A call's candidates are a property of THAT CALL.
+
+    So the walk happens once, unfiltered by anything the caller typed, and
+    `--exts` / `--exclude` / `--include` are applied afterwards to the result.
+    That also keeps the two in lockstep by construction: a candidate is always
+    a subset of what was indexed, so a per-call flag can only ever narrow the
+    answer, never smuggle in a file the walker did not admit.
+
+    What stays here is the gatherer's own policy: the 512 KB ceiling. The
+    walk, the ignore rules and the gitignore matcher live in
+    `neo.eligibility`, shared with the project index — there is no second copy
+    here to drift.
     """
-    result = eligibility.walk_paths(
-        root,
-        extra_ignores=excludes,
-        exts=exts or None,
-        max_file_bytes=MAX_FILE_BYTES,
-    )
+    return eligibility.walk_paths(root, max_file_bytes=MAX_FILE_BYTES).paths
+
+
+def filter_candidates(
+    paths: list[eligibility.EligiblePath],
+    includes: list[str],
+    excludes: list[str],
+    exts: Optional[list[str]],
+) -> list[eligibility.EligiblePath]:
+    """Narrow the corpus to what this invocation's flags admit.
+
+    `--exclude` is evaluated with `eligibility.should_ignore`, the same
+    gitignore dialect the walk applies to its own patterns, so moving the
+    evaluation out of the walk did not change what a pattern means. `--include`
+    keeps its `fnmatch` dialect, which is a user-facing CLI contract rather
+    than a gitignore rule and was already applied after eligibility.
+
+    Note the one thing this cannot reproduce: the walk PRUNES an excluded
+    directory instead of testing every file beneath it. A `--exclude` pattern
+    naming a directory therefore no longer saves the cost of descending into
+    it. It still excludes every file under it — `should_ignore` matches a
+    non-final path component — and the directories that make pruning matter
+    (`node_modules`, `.worktrees`, build output) are in the shared default
+    list, which the walk still prunes.
+    """
+    ext_set = eligibility.normalize_exts(exts) if exts else None
+    out: list[eligibility.EligiblePath] = []
+    for entry in paths:
+        if excludes and eligibility.should_ignore(entry.rel_path, list(excludes)):
+            continue
+        if ext_set is not None:
+            ext = os.path.splitext(entry.rel_path)[1].lstrip('.').lower()
+            if ext not in ext_set:
+                continue
+        if includes and not any(
+            fnmatch.fnmatch(entry.rel_path, g) for g in includes
+        ):
+            continue
+        out.append(entry)
+    return out
+
+
+def iter_paths(root: str, includes: list[str], excludes: list[str], exts: Optional[list[str]]) -> list[tuple[str, str, int]]:
+    """`(abs_path, rel_path, size)` for everything this call admits."""
     return [
         (entry.path, entry.rel_path, entry.size)
-        for entry in result.paths
-        if not includes or any(fnmatch.fnmatch(entry.rel_path, g) for g in includes)
+        for entry in filter_candidates(base_paths(root), includes, excludes, exts)
     ]
 
 
@@ -768,8 +815,13 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
 
     parser_cache: dict = {}
 
-    # Discover candidates
-    candidates = iter_paths(root, config.includes, config.excludes, config.exts)
+    # Discover candidates. ONE walk: the corpus the persistent content index
+    # maintains, then this call's flags applied to it.
+    eligible = base_paths(root)
+    admitted = filter_candidates(
+        eligible, config.includes, config.excludes, config.exts
+    )
+    candidates = [(e.path, e.rel_path, e.size) for e in admitted]
 
     # Get git context if enabled
     git_recent = set()
@@ -796,13 +848,24 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # rot starting.
     demote_tests = not prompt_targets_tests(config.prompt)
 
-    # Read the files. This is the change: selection used to happen on the path
-    # string and the byte count alone, with content first opened afterwards to
-    # chunk whatever had already been chosen.
-    from neo.file_retrieval import build_index, normalize
+    # Content relevance. Selection used to happen on the path string and the
+    # byte count alone, with content first opened afterwards to chunk whatever
+    # had already been chosen; #194 made it BM25 over file content, and this
+    # is where that stopped being re-derived from scratch on every call. The
+    # index lives in the repository's `.neo/`, is brought level with the walk
+    # above, and re-reads only what moved.
+    from neo.file_retrieval import normalize
+    from neo.index.content_index import ContentIndex
 
-    file_index = build_index(candidates)
-    relevance = normalize(file_index.scores(config.prompt)) if file_index else {}
+    relevance: dict[str, float] = {}
+    if eligible:
+        with ContentIndex(root) as content_index:
+            content_index.refresh(eligible)
+            relevance = normalize(
+                content_index.scores(
+                    config.prompt, [entry.rel_path for entry in admitted]
+                )
+            )
     if relevance:
         progress.note(f"Content relevance: {len(relevance)} files match the prompt")
 

--- a/src/neo/eligibility.py
+++ b/src/neo/eligibility.py
@@ -347,10 +347,18 @@ class EligiblePath:
     `rel_path` is repository-relative and always POSIX-separated, so a
     downstream comparison against a `.gitignore` pattern, a git path or
     another `rel_path` needs no per-platform normalization.
+
+    `mtime_ns` rides along because the walk already stats every file it
+    admits, so carrying the modification time costs one attribute read rather
+    than a second stat. It is what lets the persistent content index decide
+    which files to hash without reading the repository's every byte on every
+    invocation. Defaulted, so a caller constructing one by hand — a test, a
+    synthetic candidate — is not forced to invent a timestamp.
     """
     path: str
     rel_path: str
     size: int
+    mtime_ns: int = 0
 
 
 @dataclass(frozen=True)
@@ -465,14 +473,18 @@ def walk(root: str, policy: Optional[WalkPolicy] = None) -> WalkResult:
                 if ext not in policy.exts:
                     continue
             try:
-                size = os.path.getsize(abs_path)
+                # One `stat`, two facts. `os.path.getsize` is a `stat` that
+                # throws the rest of the struct away, and the modification
+                # time it discards is what an incremental index needs.
+                info = os.stat(abs_path)
             except OSError:
                 # Vanished between the walk and the stat, or unreadable.
                 continue
+            size = info.st_size
             if policy.max_file_bytes is not None and size > policy.max_file_bytes:
                 continue
 
-            paths.append(EligiblePath(abs_path, rel_path, size))
+            paths.append(EligiblePath(abs_path, rel_path, size, info.st_mtime_ns))
 
     paths.sort(key=lambda entry: entry.rel_path)
     return WalkResult(paths, excluded_dirs=excluded_dirs, excluded_files=excluded_files)

--- a/src/neo/file_retrieval.py
+++ b/src/neo/file_retrieval.py
@@ -172,11 +172,22 @@ def _read(path: str, limit: int = MAX_INDEXED_CHARS) -> str:
 
 
 class FileIndex:
-    """BM25 over candidate file content, built once per gather.
+    """BM25 over candidate file content, built in memory for one gather.
 
-    Rebuilt per invocation rather than cached. The gatherer already reads every
-    file it selects, and a cache keyed on content would need invalidation that
-    a one-shot CLI cannot amortize. Measure before adding one.
+    **No longer the gatherer's normal path.** This class rebuilt the whole
+    corpus on every invocation, which was the honest first cut and then became
+    the dominant cost of a Neo call: ~60 s wall and ~1.8 GB peak RSS on
+    m365dotnet's 4,272 files, all of it re-deriving something the previous
+    call had already derived (#195). `neo.index.content_index` persists the
+    same postings in the repository's `.neo/` and re-reads only what changed.
+
+    It stays because the persistent store can be unavailable — a read-only
+    checkout, a full disk, a peer process holding the write lock — and a slow
+    correct ranking is a better answer than an empty one, which a caller
+    cannot tell apart from "your prompt matches nothing". `ContentIndex`
+    falls back to this and says so. It is also the reference implementation
+    the parity test scores against, which is why the document construction
+    lives in one expression that both paths use.
     """
 
     __slots__ = ("paths", "_bm25")

--- a/src/neo/index/content_index.py
+++ b/src/neo/index/content_index.py
@@ -32,15 +32,15 @@ both ways and asserts the two agree to floating-point tolerance, because a
 persistence change that quietly re-ranked would be indistinguishable from a
 retrieval regression.
 
-One deliberate difference, stated because it is real: corpus statistics (N,
-document frequency, average document length) come from the whole indexed
-repository, not from the subset of files a particular call's `--exts` /
-`--exclude` / `--include` flags admit. The per-call index recomputed IDF over
-whatever that call happened to look at, so the same file could earn a
-different score depending on an unrelated flag. Global statistics are both
-standard IR practice and stable; with no filters — the shape every eval and
-every default invocation takes — the two sets are identical and so are the
-scores.
+**A filtered call gets filtered statistics.** N, document frequency and
+average document length are computed over the files that call admitted, not
+over the whole indexed repository — because the per-call index computed them
+over exactly that set, and BM25's score depends on all three. Repo-global
+statistics were the first cut and they are the more defensible IR design in
+the abstract; they are also a re-ranking. Measured: unflagged runs matched
+`main` exactly while `--exts py` changed all 25 selected lines. Parity with
+the ranker being replaced is the requirement here, so the subset is the
+corpus and `scores(prompt, candidates)` takes both from `candidates`.
 
 **Freshness is inline and cheap.** `refresh()` takes the eligibility walk's
 own output (there is no second walk, and no file-walking or exclusion logic
@@ -393,18 +393,40 @@ class ContentIndex:
                 progress.note(report.describe())
             return report
 
+        forced = "rebuilt" if self._rebuilt_from_corruption else None
+        # Consumed, not carried: leaving it set made a REUSED instance report
+        # `rebuilt` and wipe the whole repository on its second refresh, long
+        # after the corruption that justified the first one.
+        self._rebuilt_from_corruption = False
         try:
             report = self._refresh_persistent(
-                conn,
-                candidates,
-                started,
-                quiet=quiet,
-                forced_cold="rebuilt" if self._rebuilt_from_corruption else None,
+                conn, candidates, started, quiet=quiet, forced_cold=forced
+            )
+        except sqlite3.OperationalError as exc:
+            # Locked by a peer, read-only filesystem, disk full. Serve this
+            # call from memory rather than failing it — and, above all, DO NOT
+            # fall through to the corruption handler below.
+            #
+            # `OperationalError` is a SUBCLASS of `DatabaseError`, so an
+            # `except DatabaseError` written first catches lock contention and
+            # deletes the store, which is the worst available response: it
+            # throws away a valid index (109 MB and 122 s of rebuild on
+            # m365dotnet) AND destroys the peer, whose transaction then commits
+            # into an unlinked inode and vanishes without an error. Two Neo
+            # invocations in one repository is an ordinary situation — an
+            # editor plugin and a shell — not an exotic one. This clause is
+            # ordered FIRST because Python matches except clauses in order and
+            # subclass-before-superclass is the only ordering that works;
+            # `test_a_peer_holding_the_write_lock_does_not_delete_the_store`
+            # fails if it is ever moved or merged.
+            logger.warning("Content index not writable (%s); using memory", exc)
+            report = self._build_in_memory(
+                candidates, started, f"store busy or not writable ({exc})"
             )
         except sqlite3.DatabaseError as exc:
-            # Corruption is not recoverable and not worth diagnosing: the
-            # store is derived from the working tree, so throwing it away
-            # loses nothing but the time to rebuild.
+            # Genuine corruption: a malformed image, never a lock. Not worth
+            # diagnosing — the store is derived from the working tree, so
+            # throwing it away loses nothing but the time to rebuild.
             logger.warning("Content index unusable (%s); rebuilding", exc)
             self._discard_store()
             conn = self._connect()
@@ -422,11 +444,9 @@ class ContentIndex:
                         candidates, started, f"content index write failed ({second})"
                     )
         except sqlite3.Error as exc:
-            # Locked by a peer, read-only filesystem, disk full. Serve this
-            # call from memory rather than failing it.
-            logger.warning("Content index not writable (%s); using memory", exc)
+            logger.warning("Content index unavailable (%s); using memory", exc)
             report = self._build_in_memory(
-                candidates, started, f"store not writable ({exc})"
+                candidates, started, f"store unavailable ({exc})"
             )
 
         _LAST_REPORT = report
@@ -457,15 +477,26 @@ class ContentIndex:
             )
             mode = "rebuilt"
 
-        if mode is not None:
-            conn.execute("DELETE FROM postings")
-            conn.execute("DELETE FROM files")
-            conn.execute("DELETE FROM terms")
+        wipe = mode is not None
+        if wipe:
             stamps: dict[str, FileStamp] = {}
         else:
             stamps = self._load_stamps(conn)
             if not stamps:
                 mode = "cold"
+
+        # BEFORE `detect_changes`, which sha256s the whole repository on a cold
+        # build. Announcing after it meant the promised "no silent stall" still
+        # opened with a full-repo byte read in silence — small on a toy repo,
+        # a real wait on m365dotnet. The count is the candidate count rather
+        # than the work count for the same reason: the work count is not known
+        # until the hashing this line exists to announce has finished.
+        if mode in ("cold", "rebuilt") and candidates and not quiet:
+            progress.note(
+                f"Content index: no usable index for this repository - "
+                f"building one over {len(candidates)} files. This runs once; "
+                f"later calls update only what changed."
+            )
 
         changes = detect_changes(stamps, candidates, file_content_hash)
         work = changes.needs_indexing
@@ -473,40 +504,47 @@ class ContentIndex:
         if mode is None:
             mode = "incremental" if not changes.is_clean else "warm"
 
-        if mode in ("cold", "rebuilt") and work and not quiet:
-            progress.note(
-                f"Content index: no usable index for this repository - "
-                f"building one over {len(work)} files. This runs once; "
-                f"later calls update only what changed."
-            )
-
-        self._vocab = {
-            term: term_id
-            for term_id, term in conn.execute("SELECT id, term FROM terms")
-        }
-
-        with conn:  # one transaction; SQLite gives us the atomicity
-            for rel_path in changes.removed:
-                self._delete_file(conn, rel_path)
-            for index, candidate in enumerate(work, 1):
-                self._index_file(
-                    conn, candidate, changes.hashes.get(candidate.rel_path, "")
-                )
-                if not quiet and mode in ("cold", "rebuilt") and index % _PROGRESS_EVERY == 0:
-                    progress.note(
-                        f"Content index: {index}/{len(work)} files tokenized"
+        # A warm call must not open a WRITE transaction. Rewriting the
+        # (unchanged) signature unconditionally made every single invocation a
+        # writer, so two ordinary overlapping calls contended for the store on
+        # the steady-state path rather than only during a rebuild.
+        if wipe or work or changes.touched or changes.removed or stored != signature:
+            with conn:  # one transaction; SQLite gives us the atomicity
+                if wipe:
+                    conn.execute("DELETE FROM postings")
+                    conn.execute("DELETE FROM files")
+                    conn.execute("DELETE FROM terms")
+                # AFTER the wipe, never before. Loading the vocabulary first
+                # and then emptying `terms` left `_index_file` believing every
+                # term already existed, so it skipped the inserts and wrote
+                # postings pointing at deleted term ids — a rebuilt index that
+                # answered nothing.
+                self._vocab = {
+                    term: term_id
+                    for term_id, term in conn.execute("SELECT id, term FROM terms")
+                }
+                for rel_path in changes.removed:
+                    self._delete_file(conn, rel_path)
+                for index, candidate in enumerate(work, 1):
+                    self._index_file(
+                        conn, candidate, changes.hashes.get(candidate.rel_path, "")
                     )
-            for candidate in changes.touched:
-                # Content identical, metadata moved. Stamp only — re-reading
-                # would be work with a known-empty result.
-                conn.execute(
-                    "UPDATE files SET size = ?, mtime_ns = ? WHERE rel_path = ?",
-                    (candidate.size, candidate.mtime_ns, candidate.rel_path),
+                    if (not quiet and mode in ("cold", "rebuilt")
+                            and index % _PROGRESS_EVERY == 0):
+                        progress.note(
+                            f"Content index: {index}/{len(work)} files tokenized"
+                        )
+                for candidate in changes.touched:
+                    # Content identical, metadata moved. Stamp only —
+                    # re-reading would be work with a known-empty result.
+                    conn.execute(
+                        "UPDATE files SET size = ?, mtime_ns = ? WHERE rel_path = ?",
+                        (candidate.size, candidate.mtime_ns, candidate.rel_path),
+                    )
+                conn.executemany(
+                    "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                    sorted(signature.items()),
                 )
-            conn.executemany(
-                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
-                sorted(signature.items()),
-            )
 
         self._load_query_state(conn)
         self._persistent = True
@@ -621,10 +659,15 @@ class ContentIndex:
     ) -> dict[str, float]:
         """BM25 score per `rel_path` for `prompt`; unmatched files are absent.
 
-        `candidates` restricts the ANSWER to a subset of the indexed corpus —
-        the files this call's `--exts` / `--include` / `--exclude` admitted.
-        It does not restrict the corpus STATISTICS; see the module docstring
-        for why that is deliberate.
+        `candidates` restricts the corpus to the subset this call's `--exts` /
+        `--include` / `--exclude` admitted — the ANSWER *and* the statistics.
+        Restricting only the answer is the obvious shortcut and it silently
+        re-ranks: N, document frequency and average document length all come
+        out of the corpus, so leaving them repo-global scores a filtered call
+        differently from the per-call index that preceded this one. Measured
+        before it was fixed: unflagged runs matched `main` exactly while
+        `--exts py` changed all 25 selected lines. Parity is the requirement,
+        so the subset is a corpus.
         """
         if not self._persistent:
             raw = self._memory_index.scores(prompt)
@@ -671,25 +714,47 @@ class ContentIndex:
         """
         by_id: dict[int, float] = {}
         doc_lens = {fid: dl for fid, dl in self._files.values()}
+
+        # The corpus is the subset when there is one, statistics included.
+        if allowed_ids is None:
+            n, avgdl = self._n, self._avgdl
+        else:
+            n = len(allowed_ids)
+            avgdl = (
+                sum(doc_lens.get(fid, 0) for fid in allowed_ids) / n if n else 0.0
+            )
+
+        # Term ids are resolved per query rather than from a preloaded
+        # vocabulary. Loading every term to answer for ten of them read the
+        # whole `terms` table — a few hundred thousand rows on a large repo —
+        # on the warm path this module exists to make cheap.
+        wanted = list(repeats)
+        placeholders = ",".join("?" * len(wanted))
+        term_ids = dict(
+            conn.execute(
+                f"SELECT term, id FROM terms WHERE term IN ({placeholders})", wanted
+            )
+        )
+
         for term, occurrences in repeats.items():
-            term_id = self._vocab.get(term)
+            term_id = term_ids.get(term)
             if term_id is None:
                 continue
             rows = conn.execute(
                 "SELECT file_id, tf FROM postings WHERE term_id = ?", (term_id,)
             ).fetchall()
+            if allowed_ids is not None:
+                rows = [r for r in rows if r[0] in allowed_ids]
             if not rows:
                 continue
-            idf = _idf(self._n, len(rows))
+            # Document frequency counts documents IN THIS CORPUS, so it is
+            # taken after the subset filter, never before.
+            idf = _idf(n, len(rows))
             for file_id, tf in rows:
-                if allowed_ids is not None and file_id not in allowed_ids:
-                    continue
                 dl = doc_lens.get(file_id, 0)
                 if dl == 0:
                     continue
-                denom_norm = (
-                    K1 * (1.0 - B + B * dl / self._avgdl) if self._avgdl > 0 else K1
-                )
+                denom_norm = K1 * (1.0 - B + B * dl / avgdl) if avgdl > 0 else K1
                 contribution = idf * (tf * (K1 + 1.0)) / (tf + denom_norm)
                 by_id[file_id] = by_id.get(file_id, 0.0) + contribution * occurrences
 

--- a/src/neo/index/content_index.py
+++ b/src/neo/index/content_index.py
@@ -1,0 +1,748 @@
+"""The keyword content index, persisted beside the semantic catalog.
+
+`neo.file_retrieval` introduced BM25 over file CONTENT and took file selection
+from MRR 0.05 to 0.61 on the largest flagship. It also read and tokenized
+every eligible file on every invocation, and on m365dotnet (4,272 C# files)
+that is the whole cost of a Neo call: a median of ~60 s wall and ~1.8 GB peak
+RSS to assemble context, before a single token reaches the model (#195).
+
+Nothing about that work is per-call. The corpus changes when the repository
+changes, which between two invocations is usually not at all. So it moves to
+disk, next to the semantic catalog in the repository's own `.neo/`, and every
+invocation pays only for the files that actually moved.
+
+**SQLite, not JSON, and the reason is the metric.** The catalog next door is
+JSON because it is read whole — every chunk's embedding participates in every
+query. A keyword index is the opposite: a prompt touches the postings of ten
+or twenty terms out of a few hundred thousand, so a format that must be parsed
+whole to answer anything would spend the entire warm budget deserializing
+postings no query asked for. Measured on m365dotnet the corpus is ~2.5 M
+postings; a term-indexed table answers from a handful of B-tree probes and
+keeps resident memory in the tens of megabytes, where holding the same
+postings as Python lists of ints would cost several hundred. The store still
+holds INDEX ARTIFACTS ONLY — postings, lengths, stamps and hashes, never a
+file body. Delivery reads whole files fresh from disk, as it always did.
+
+**Ranking parity is a hard requirement, not an aspiration.** The scorer here
+reimplements nothing: `K1`, `B` and the IDF formula are imported from
+`neo.memory.bm25`, and the document is built by the same expression the
+per-call index used — `code_tokens(rel_path) * PATH_TOKEN_WEIGHT +
+code_tokens(content)`. `tests/test_content_index.py` scores the same corpus
+both ways and asserts the two agree to floating-point tolerance, because a
+persistence change that quietly re-ranked would be indistinguishable from a
+retrieval regression.
+
+One deliberate difference, stated because it is real: corpus statistics (N,
+document frequency, average document length) come from the whole indexed
+repository, not from the subset of files a particular call's `--exts` /
+`--exclude` / `--include` flags admit. The per-call index recomputed IDF over
+whatever that call happened to look at, so the same file could earn a
+different score depending on an unrelated flag. Global statistics are both
+standard IR practice and stable; with no filters — the shape every eval and
+every default invocation takes — the two sets are identical and so are the
+scores.
+
+**Freshness is inline and cheap.** `refresh()` takes the eligibility walk's
+own output (there is no second walk, and no file-walking or exclusion logic
+lives in this module), compares stamps via `index.freshness`, and re-tokenizes
+only what changed. A file the walker no longer admits — newly gitignored, or
+deleted — has its postings dropped in the same pass, so a stale index can
+never answer with a file the walker excludes.
+
+**Every degradation is loud and none is fatal.** A missing store cold-builds
+and says so before it starts, because a silent multi-minute stall on a large
+repository is indistinguishable from a hang. A corrupt store is discarded and
+rebuilt with a warning. A store that cannot be written — a read-only checkout,
+a peer process holding the write lock — still serves scores for this call from
+memory and warns; it does not raise, and it does not silently return an empty
+ranking, which would look exactly like "no file matches your prompt".
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import sqlite3
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+from neo import progress
+from neo.eligibility import file_content_hash
+from neo.file_retrieval import (
+    MAX_INDEXED_CHARS,
+    PATH_TOKEN_WEIGHT,
+    _read,
+    code_tokens,
+)
+from neo.index.freshness import Candidate, FileStamp, detect_changes
+from neo.memory.bm25 import B, K1
+
+logger = logging.getLogger(__name__)
+
+#: Bumped when the on-disk LAYOUT changes. An older store is discarded rather
+#: than migrated: it is a derived cache of the working tree, so rebuilding is
+#: always available and always correct, and migration code for a cache is
+#: liability with no upside.
+SCHEMA_VERSION = 3
+
+#: Bumped when the same file would produce DIFFERENT TOKENS than it did
+#: before. That covers `code_tokens` itself, `PATH_TOKEN_WEIGHT`, the
+#: `MAX_INDEXED_CHARS` read limit and the binary-file rule in `_read` — change
+#: any of them and every stored posting is wrong in a way no per-file hash can
+#: detect, because the files did not change, the tokenizer did. The stored
+#: value records the read limit and path weight alongside the version so a
+#: mismatch is visible in the store rather than only in a constant.
+TOKENIZER_VERSION = 1
+
+#: Files between progress notes during a cold build. A build of a large
+#: repository takes minutes; silence for minutes is the failure mode this
+#: exists to prevent, and one line per few hundred files is enough to show
+#: motion without flooding stderr.
+_PROGRESS_EVERY = 250
+
+#: How long to wait for a peer process's write transaction before giving up
+#: and serving this call from memory. Two Neo invocations in the same
+#: repository is an ordinary situation (an editor plugin and a shell), and the
+#: loser of that race must degrade, not fail.
+_BUSY_TIMEOUT_MS = 5_000
+
+#: The store lives inside the repository's own `.neo/`, beside `index.json`.
+INDEX_FILENAME = "content_index.sqlite3"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS files (
+    id           INTEGER PRIMARY KEY,
+    rel_path     TEXT NOT NULL UNIQUE,
+    size         INTEGER NOT NULL,
+    mtime_ns     INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    doc_len      INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS terms (
+    id   INTEGER PRIMARY KEY,
+    term TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS postings (
+    term_id INTEGER NOT NULL,
+    file_id INTEGER NOT NULL,
+    tf      INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS postings_term ON postings(term_id);
+CREATE INDEX IF NOT EXISTS postings_file ON postings(file_id);
+"""
+
+
+@dataclass
+class IndexReport:
+    """What the index did on this invocation, in the words the operator needs.
+
+    `mode` is the headline and the four values are not interchangeable:
+
+    - ``cold``        — no usable store existed; the whole repository was read.
+    - ``rebuilt``     — a store existed but was unusable (corrupt, or written
+                        by a different schema/tokenizer) and was discarded.
+    - ``incremental`` — a store was reused and some files were re-read.
+    - ``warm``        — a store was reused and nothing had to be re-read.
+    - ``memory``      — the store could not be used at all this call; the index
+                        was built in memory and not persisted.
+
+    ``rebuilt`` is kept distinct from ``cold`` on purpose. Both read every
+    file, but only one of them means something went wrong, and reporting a
+    discarded corrupt store as an ordinary first run hides a store that is
+    being thrown away on every single call.
+    """
+
+    mode: str
+    total_files: int = 0
+    indexed: int = 0
+    added: int = 0
+    changed: int = 0
+    touched: int = 0
+    removed: int = 0
+    elapsed_ms: float = 0.0
+    warning: Optional[str] = None
+
+    def describe(self) -> str:
+        """One line for stderr. Never claims work it did not do."""
+        seconds = self.elapsed_ms / 1000.0
+        if self.mode in ("cold", "rebuilt"):
+            why = (
+                "first run for this repository"
+                if self.mode == "cold"
+                else "previous store discarded"
+            )
+            head = (
+                f"Content index: cold build of {self.total_files} files "
+                f"({why}) in {seconds:.1f}s"
+            )
+        elif self.mode == "incremental":
+            parts = []
+            if self.added:
+                parts.append(f"{self.added} added")
+            if self.changed:
+                parts.append(f"{self.changed} changed")
+            if self.removed:
+                parts.append(f"{self.removed} removed")
+            if self.touched:
+                parts.append(f"{self.touched} touched (content identical)")
+            head = (
+                f"Content index: incrementally updated {self.indexed} of "
+                f"{self.total_files} files ({', '.join(parts)}) in {seconds:.1f}s"
+            )
+        elif self.mode == "warm":
+            head = (
+                f"Content index: read warm, {self.total_files} files "
+                f"unchanged ({seconds:.1f}s)"
+            )
+        else:
+            head = (
+                f"Content index: built in memory for this call only, "
+                f"{self.total_files} files in {seconds:.1f}s"
+            )
+        return head if not self.warning else f"{head} - {self.warning}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "total_files": self.total_files,
+            "indexed": self.indexed,
+            "added": self.added,
+            "changed": self.changed,
+            "touched": self.touched,
+            "removed": self.removed,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+            "warning": self.warning,
+            "summary": self.describe(),
+        }
+
+
+#: The most recent refresh in this process, for reporting surfaces that run
+#: after the gather has returned — `--dry-run`'s JSON report in particular,
+#: where `--quiet` is implied and the stderr note the operator would otherwise
+#: read is suppressed. Process-global for the same reason `progress` is: it is
+#: a report about the run, read once, five layers up from where it is
+#: produced.
+_LAST_REPORT: Optional[IndexReport] = None
+
+
+def last_report() -> Optional[IndexReport]:
+    """The `IndexReport` from this process's most recent `refresh`, if any."""
+    return _LAST_REPORT
+
+
+def _document(rel_path: str, abs_path: str) -> list[str]:
+    """The token list for one file — the ONE definition of a document.
+
+    Identical by construction to what `file_retrieval.FileIndex` built per
+    call. A file that reads as binary or cannot be decoded still contributes
+    its path tokens, exactly as before: it is a real name in the repository
+    even when its bytes are not text.
+    """
+    return code_tokens(rel_path) * PATH_TOKEN_WEIGHT + code_tokens(_read(abs_path))
+
+
+class ContentIndex:
+    """Persistent BM25 over repository file content.
+
+    Construct, `refresh()` with the eligibility walk's output, then `scores()`
+    as many times as needed. `close()` when done; the object is also a context
+    manager.
+    """
+
+    def __init__(self, repo_root: str, db_path: Optional[str] = None):
+        self.repo_root = Path(repo_root).resolve()
+        self.neo_dir = self.repo_root / ".neo"
+        self.db_path = Path(db_path) if db_path else self.neo_dir / INDEX_FILENAME
+        self._conn: Optional[sqlite3.Connection] = None
+        self._persistent = True
+        #: rel_path -> (file_id, doc_len), loaded once per refresh. A few
+        #: thousand small tuples; the postings themselves stay on disk.
+        self._files: dict[str, tuple[int, int]] = {}
+        self._n = 0
+        self._avgdl = 0.0
+        self._vocab: dict[str, int] = {}
+        #: Only populated on the fallback path; see `_build_in_memory`.
+        self._memory_index: Optional[Any] = None
+        #: Set by `_connect` when it threw a corrupt store away, so the report
+        #: says `rebuilt` rather than `cold`. Both read every file; only one of
+        #: them means something went wrong, and a store being discarded on
+        #: every single call must not read as an ordinary first run.
+        self._rebuilt_from_corruption = False
+
+    # ---------------------------------------------------------------- store
+
+    def _connect(self, *, discard_corrupt: bool = True) -> Optional[sqlite3.Connection]:
+        """Open (creating if needed) the on-disk store, or None if impossible.
+
+        Returning None rather than raising is the contract: every caller of
+        this module has a working fallback (build in memory, score, do not
+        persist), and a read-only checkout or a full disk must cost a warning,
+        not a run.
+
+        A CORRUPT store is not that case and must not be allowed to reach the
+        fallback, because the fallback is permanent — a store that fails to
+        open is never repaired, so every future invocation in that repository
+        would silently pay the full per-call rebuild this module exists to
+        remove. Corruption is detected here (SQLite raises while opening, not
+        while querying), the file is deleted, and the open is retried once.
+
+        The two are told apart by exception CLASS, which for `sqlite3` is
+        precise enough to rely on: a malformed or non-database file raises
+        `DatabaseError` itself, while a locked, read-only or full store raises
+        the `OperationalError` subclass. Anything unrecognized keeps the
+        conservative behaviour and degrades rather than deleting a file it
+        does not understand.
+        """
+        if self._conn is not None:
+            return self._conn
+        try:
+            self.neo_dir.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self.db_path), timeout=_BUSY_TIMEOUT_MS / 1000)
+            conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+            # WAL lets a reader run while a peer writes, which is the common
+            # two-process case. It is a no-op on filesystems that refuse it.
+            try:
+                conn.execute("PRAGMA journal_mode = WAL")
+            except sqlite3.Error:
+                pass
+            conn.executescript(_SCHEMA)
+            self._conn = conn
+            return conn
+        except sqlite3.DatabaseError as exc:
+            if discard_corrupt and not isinstance(exc, sqlite3.OperationalError):
+                logger.warning(
+                    "Content index at %s is corrupt (%s); discarding and rebuilding",
+                    self.db_path,
+                    exc,
+                )
+                self._discard_store()
+                self._rebuilt_from_corruption = True
+                return self._connect(discard_corrupt=False)
+            logger.warning("Content index unavailable at %s: %s", self.db_path, exc)
+            return None
+        except (sqlite3.Error, OSError) as exc:
+            logger.warning("Content index unavailable at %s: %s", self.db_path, exc)
+            return None
+
+    def _discard_store(self) -> None:
+        """Delete the store on disk so the next open starts clean."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                pass
+            self._conn = None
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.unlink(str(self.db_path) + suffix)
+            except OSError:
+                pass
+
+    def _stored_signature(self, conn: sqlite3.Connection) -> dict[str, str]:
+        rows = conn.execute("SELECT key, value FROM meta").fetchall()
+        return {key: value for key, value in rows}
+
+    def _signature(self) -> dict[str, str]:
+        """What this build of Neo would write. Any mismatch invalidates."""
+        return {
+            "schema_version": str(SCHEMA_VERSION),
+            "tokenizer_version": str(TOKENIZER_VERSION),
+            "path_token_weight": str(PATH_TOKEN_WEIGHT),
+            "max_indexed_chars": str(MAX_INDEXED_CHARS),
+        }
+
+    def _load_stamps(self, conn: sqlite3.Connection) -> dict[str, FileStamp]:
+        rows = conn.execute(
+            "SELECT rel_path, size, mtime_ns, content_hash FROM files"
+        ).fetchall()
+        return {
+            rel_path: FileStamp(size=size, mtime_ns=mtime_ns, content_hash=digest)
+            for rel_path, size, mtime_ns, digest in rows
+        }
+
+    # --------------------------------------------------------------- refresh
+
+    def refresh(self, paths: Sequence[Any], *, quiet: bool = False) -> IndexReport:
+        """Bring the store level with `paths` and load the query-side state.
+
+        `paths` is the eligibility walk's own output — `EligiblePath` records,
+        or anything carrying `path` / `rel_path` / `size` / `mtime_ns`. This
+        module never walks; it is handed what the one walker admitted, which
+        is what makes "a file the walker excludes cannot remain queryable"
+        true by construction rather than by a second exclusion list.
+        """
+        global _LAST_REPORT
+        started = time.time()
+        candidates = _as_candidates(paths)
+
+        conn = self._connect()
+        if conn is None:
+            report = self._build_in_memory(
+                candidates, started, "content index could not be opened"
+            )
+            _LAST_REPORT = report
+            if not quiet:
+                progress.note(report.describe())
+            return report
+
+        try:
+            report = self._refresh_persistent(
+                conn,
+                candidates,
+                started,
+                quiet=quiet,
+                forced_cold="rebuilt" if self._rebuilt_from_corruption else None,
+            )
+        except sqlite3.DatabaseError as exc:
+            # Corruption is not recoverable and not worth diagnosing: the
+            # store is derived from the working tree, so throwing it away
+            # loses nothing but the time to rebuild.
+            logger.warning("Content index unusable (%s); rebuilding", exc)
+            self._discard_store()
+            conn = self._connect()
+            if conn is None:
+                report = self._build_in_memory(
+                    candidates, started, "content index could not be rebuilt"
+                )
+            else:
+                try:
+                    report = self._refresh_persistent(
+                        conn, candidates, started, quiet=quiet, forced_cold="rebuilt"
+                    )
+                except sqlite3.Error as second:
+                    report = self._build_in_memory(
+                        candidates, started, f"content index write failed ({second})"
+                    )
+        except sqlite3.Error as exc:
+            # Locked by a peer, read-only filesystem, disk full. Serve this
+            # call from memory rather than failing it.
+            logger.warning("Content index not writable (%s); using memory", exc)
+            report = self._build_in_memory(
+                candidates, started, f"store not writable ({exc})"
+            )
+
+        _LAST_REPORT = report
+        if not quiet:
+            progress.note(report.describe())
+        return report
+
+    def _refresh_persistent(
+        self,
+        conn: sqlite3.Connection,
+        candidates: list[Candidate],
+        started: float,
+        *,
+        quiet: bool = False,
+        forced_cold: Optional[str] = None,
+    ) -> IndexReport:
+        signature = self._signature()
+        stored = self._stored_signature(conn)
+        mode = forced_cold
+        if mode is None and stored and stored != signature:
+            # A tokenizer or layout change makes every posting wrong while
+            # every file hash still matches, so per-file freshness cannot see
+            # it. Wipe rather than reconcile.
+            logger.info(
+                "Content index signature changed (%s -> %s); rebuilding",
+                stored,
+                signature,
+            )
+            mode = "rebuilt"
+
+        if mode is not None:
+            conn.execute("DELETE FROM postings")
+            conn.execute("DELETE FROM files")
+            conn.execute("DELETE FROM terms")
+            stamps: dict[str, FileStamp] = {}
+        else:
+            stamps = self._load_stamps(conn)
+            if not stamps:
+                mode = "cold"
+
+        changes = detect_changes(stamps, candidates, file_content_hash)
+        work = changes.needs_indexing
+
+        if mode is None:
+            mode = "incremental" if not changes.is_clean else "warm"
+
+        if mode in ("cold", "rebuilt") and work and not quiet:
+            progress.note(
+                f"Content index: no usable index for this repository - "
+                f"building one over {len(work)} files. This runs once; "
+                f"later calls update only what changed."
+            )
+
+        self._vocab = {
+            term: term_id
+            for term_id, term in conn.execute("SELECT id, term FROM terms")
+        }
+
+        with conn:  # one transaction; SQLite gives us the atomicity
+            for rel_path in changes.removed:
+                self._delete_file(conn, rel_path)
+            for index, candidate in enumerate(work, 1):
+                self._index_file(
+                    conn, candidate, changes.hashes.get(candidate.rel_path, "")
+                )
+                if not quiet and mode in ("cold", "rebuilt") and index % _PROGRESS_EVERY == 0:
+                    progress.note(
+                        f"Content index: {index}/{len(work)} files tokenized"
+                    )
+            for candidate in changes.touched:
+                # Content identical, metadata moved. Stamp only — re-reading
+                # would be work with a known-empty result.
+                conn.execute(
+                    "UPDATE files SET size = ?, mtime_ns = ? WHERE rel_path = ?",
+                    (candidate.size, candidate.mtime_ns, candidate.rel_path),
+                )
+            conn.executemany(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                sorted(signature.items()),
+            )
+
+        self._load_query_state(conn)
+        self._persistent = True
+        return IndexReport(
+            mode=mode,
+            total_files=self._n,
+            indexed=len(work),
+            added=len(changes.added),
+            changed=len(changes.changed),
+            touched=len(changes.touched),
+            removed=len(changes.removed),
+            elapsed_ms=(time.time() - started) * 1000.0,
+        )
+
+    def _delete_file(self, conn: sqlite3.Connection, rel_path: str) -> None:
+        row = conn.execute(
+            "SELECT id FROM files WHERE rel_path = ?", (rel_path,)
+        ).fetchone()
+        if row is None:
+            return
+        conn.execute("DELETE FROM postings WHERE file_id = ?", (row[0],))
+        conn.execute("DELETE FROM files WHERE id = ?", (row[0],))
+
+    def _index_file(
+        self, conn: sqlite3.Connection, candidate: Candidate, digest: str
+    ) -> None:
+        tokens = _document(candidate.rel_path, candidate.abs_path)
+        counts = Counter(tokens)
+
+        row = conn.execute(
+            "SELECT id FROM files WHERE rel_path = ?", (candidate.rel_path,)
+        ).fetchone()
+        if row is None:
+            cursor = conn.execute(
+                "INSERT INTO files(rel_path, size, mtime_ns, content_hash, doc_len)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    candidate.rel_path,
+                    candidate.size,
+                    candidate.mtime_ns,
+                    digest,
+                    len(tokens),
+                ),
+            )
+            file_id = cursor.lastrowid
+        else:
+            file_id = row[0]
+            conn.execute(
+                "UPDATE files SET size = ?, mtime_ns = ?, content_hash = ?,"
+                " doc_len = ? WHERE id = ?",
+                (candidate.size, candidate.mtime_ns, digest, len(tokens), file_id),
+            )
+            conn.execute("DELETE FROM postings WHERE file_id = ?", (file_id,))
+
+        new_terms = [(term,) for term in counts if term not in self._vocab]
+        if new_terms:
+            conn.executemany("INSERT OR IGNORE INTO terms(term) VALUES (?)", new_terms)
+            placeholders = ",".join("?" * len(new_terms))
+            for term_id, term in conn.execute(
+                f"SELECT id, term FROM terms WHERE term IN ({placeholders})",
+                [t[0] for t in new_terms],
+            ):
+                self._vocab[term] = term_id
+
+        conn.executemany(
+            "INSERT INTO postings(term_id, file_id, tf) VALUES (?, ?, ?)",
+            [(self._vocab[term], file_id, tf) for term, tf in counts.items()],
+        )
+
+    def _load_query_state(self, conn: sqlite3.Connection) -> None:
+        self._files = {
+            rel_path: (file_id, doc_len)
+            for file_id, rel_path, doc_len in conn.execute(
+                "SELECT id, rel_path, doc_len FROM files"
+            )
+        }
+        self._n = len(self._files)
+        total_len = sum(doc_len for _fid, doc_len in self._files.values())
+        self._avgdl = (total_len / self._n) if self._n else 0.0
+
+    # -------------------------------------------------------------- fallback
+
+    def _build_in_memory(
+        self, candidates: list[Candidate], started: float, warning: str
+    ) -> IndexReport:
+        """Last resort: the pre-persistence behaviour, for this call only.
+
+        Slow — it is exactly the per-call cost this module removes — but a
+        slow correct ranking beats an empty one, which the caller cannot
+        distinguish from "your prompt matches nothing".
+        """
+        from neo.file_retrieval import FileIndex
+
+        self._memory_index = FileIndex(
+            [(c.abs_path, c.rel_path, c.size) for c in candidates]
+        )
+        self._persistent = False
+        self._files = {}
+        return IndexReport(
+            mode="memory",
+            total_files=len(candidates),
+            indexed=len(candidates),
+            added=len(candidates),
+            elapsed_ms=(time.time() - started) * 1000.0,
+            warning=warning,
+        )
+
+    # ----------------------------------------------------------------- query
+
+    def scores(
+        self, prompt: str, candidates: Optional[Iterable[str]] = None
+    ) -> dict[str, float]:
+        """BM25 score per `rel_path` for `prompt`; unmatched files are absent.
+
+        `candidates` restricts the ANSWER to a subset of the indexed corpus —
+        the files this call's `--exts` / `--include` / `--exclude` admitted.
+        It does not restrict the corpus STATISTICS; see the module docstring
+        for why that is deliberate.
+        """
+        if not self._persistent:
+            raw = self._memory_index.scores(prompt)
+            if candidates is None:
+                return raw
+            allowed = set(candidates)
+            return {p: s for p, s in raw.items() if p in allowed}
+
+        conn = self._conn
+        if conn is None or not self._n:
+            return {}
+        terms = code_tokens(prompt)
+        if not terms:
+            return {}
+
+        allowed_ids: Optional[set[int]] = None
+        if candidates is not None:
+            allowed_ids = {
+                self._files[p][0] for p in candidates if p in self._files
+            }
+            if not allowed_ids:
+                return {}
+
+        # Query-term MULTIPLICITY is preserved, because the in-memory scorer
+        # this replaces iterated the term LIST: a prompt naming `getUserById`
+        # emits `get`, `user`, `by`, `id` once each plus the whole identifier,
+        # and a prompt saying "user" twice weighs `user` twice. Collapsing to
+        # a set here would be a silent ranking change, so the count is carried
+        # as a multiplier instead of the term being scored twice.
+        return self._score_terms(conn, Counter(terms), allowed_ids)
+
+    def _score_terms(
+        self,
+        conn: sqlite3.Connection,
+        repeats: "Counter[str]",
+        allowed_ids: Optional[set[int]],
+    ) -> dict[str, float]:
+        """Accumulate the BM25 sum over the query's terms.
+
+        The length normalization belongs inside the per-(file, term) term,
+        not outside it: BM25's denominator contains `tf`, so a version that
+        summed `idf * tf` first and normalized once per file would be a
+        different formula wearing the same name.
+        """
+        by_id: dict[int, float] = {}
+        doc_lens = {fid: dl for fid, dl in self._files.values()}
+        for term, occurrences in repeats.items():
+            term_id = self._vocab.get(term)
+            if term_id is None:
+                continue
+            rows = conn.execute(
+                "SELECT file_id, tf FROM postings WHERE term_id = ?", (term_id,)
+            ).fetchall()
+            if not rows:
+                continue
+            idf = _idf(self._n, len(rows))
+            for file_id, tf in rows:
+                if allowed_ids is not None and file_id not in allowed_ids:
+                    continue
+                dl = doc_lens.get(file_id, 0)
+                if dl == 0:
+                    continue
+                denom_norm = (
+                    K1 * (1.0 - B + B * dl / self._avgdl) if self._avgdl > 0 else K1
+                )
+                contribution = idf * (tf * (K1 + 1.0)) / (tf + denom_norm)
+                by_id[file_id] = by_id.get(file_id, 0.0) + contribution * occurrences
+
+        id_to_path = {fid: path for path, (fid, _dl) in self._files.items()}
+        return {
+            id_to_path[fid]: score
+            for fid, score in by_id.items()
+            if score > 0.0 and fid in id_to_path
+        }
+
+    # ------------------------------------------------------------- lifecycle
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                pass
+            self._conn = None
+
+    def __enter__(self) -> "ContentIndex":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+
+def _idf(n: int, df: int) -> float:
+    """Lucene-style smoothed IDF — the same expression `memory.bm25` uses."""
+    return math.log((n - df + 0.5) / (df + 0.5) + 1.0)
+
+
+def _as_candidates(paths: Sequence[Any]) -> list[Candidate]:
+    """Accept `EligiblePath` records or plain tuples, emit `Candidate`s.
+
+    `mtime_ns` is read from the walk when it carries one and stat-ed here when
+    it does not, so a caller holding older `(abs, rel, size)` tuples still
+    gets correct freshness rather than a silently degraded one.
+    """
+    out: list[Candidate] = []
+    for entry in paths:
+        if isinstance(entry, tuple):
+            abs_path, rel_path, size = entry[0], entry[1], entry[2]
+            mtime_ns = 0
+        else:
+            abs_path = entry.path
+            rel_path = entry.rel_path
+            size = entry.size
+            mtime_ns = getattr(entry, "mtime_ns", 0)
+        if not mtime_ns:
+            try:
+                mtime_ns = os.stat(abs_path).st_mtime_ns
+            except OSError:
+                continue
+        out.append(Candidate(abs_path, rel_path, size, mtime_ns))
+    return out

--- a/src/neo/index/freshness.py
+++ b/src/neo/index/freshness.py
@@ -122,10 +122,25 @@ def detect_changes(
 ) -> Changes:
     """Compare the recorded stamps against what is on disk now.
 
-    A file that cannot be hashed (deleted between the walk and here, or
-    unreadable) is dropped from the result entirely rather than recorded with
-    an empty hash: an empty hash would compare equal to the next unreadable
-    file's, which is how "unreadable" silently becomes "unchanged".
+    **A file that cannot be hashed stays in the result**, carrying the empty
+    hash the hasher returned. An earlier cut dropped it — which reads as the
+    careful choice and is not, because the caller's `removed` set is
+    "everything the walk no longer admits", so dropping a candidate the walk
+    DID admit deletes it from the index. Measured: `chmod 000` on a file made
+    it vanish from the corpus permanently, while the per-call index this
+    replaces still ranked it on its path tokens (its content simply read as
+    empty). Permission was withdrawn from the CONTENT; the name is still a
+    real name in the repository, and losing it is a silent retrieval
+    regression.
+
+    The empty hash is safe as a comparison value precisely because stamps are
+    keyed by path: `"" == ""` is only ever asked of one file against its own
+    previous state, where it correctly means "still unreadable, nothing to
+    re-tokenize". It never compares two different files.
+
+    A file that vanished between the walk and here takes the same path and
+    self-heals: it is re-indexed to its path tokens now, and the next walk
+    does not list it, so it lands in `removed` then.
     """
     changes = Changes()
     seen: set[str] = set()
@@ -146,12 +161,6 @@ def detect_changes(
             continue
 
         digest = hasher(candidate.abs_path)
-        if not digest:
-            # Vanished or unreadable. It is not "unchanged" and it is not a
-            # deletion we can prove, so leave whatever is stored alone.
-            seen.discard(candidate.rel_path)
-            continue
-
         changes.hashes[candidate.rel_path] = digest
         if stamp is None:
             changes.added.append(candidate)

--- a/src/neo/index/freshness.py
+++ b/src/neo/index/freshness.py
@@ -1,0 +1,203 @@
+"""The one answer to "which indexed files went stale since we last looked?".
+
+Both on-disk indexes — the semantic catalog (`index.project_index`) and the
+keyword content index (`index.content_index`) — persist a per-file stamp and
+compare it against the filesystem on every open. That comparison is the same
+question twice, so it is written once here.
+
+This module owns the COMPARISON only, never the storage. The two indexes keep
+their own files (`.neo/index.json`, `.neo/content_index.sqlite3`) because they
+hold different artifacts on different write schedules; what they must not do
+is disagree about what "changed" means.
+
+Two stamp strengths, and the difference is the whole performance story:
+
+- **`content_hash`** is authoritative. Two files with the same bytes are the
+  same document no matter what their metadata says.
+- **`size` + `mtime_ns`** is the cheap pre-filter. The walk already stats every
+  file, so this costs nothing extra, whereas hashing means reading every byte
+  of the repository on every invocation — precisely the per-call cost this
+  index exists to remove.
+
+The pre-filter is used to decide *what to hash*, never to decide that a file
+changed. A file whose size and mtime both match is treated as unchanged; a
+file where either differs is hashed, and only a hash mismatch counts as a real
+change. So a `touch` with no edit updates the stamp and re-tokenizes nothing,
+and an edit that preserves size is caught because mtime moved. The residual
+blind spot is an edit that preserves size AND restores mtime — which requires
+deliberate effort — and `force_rehash` exists for callers who cannot accept
+even that.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Mapping, Optional
+
+#: A hasher takes an absolute path and returns a hex digest, or `""` when the
+#: file cannot be read. `eligibility.file_content_hash` is the implementation;
+#: it is injected rather than imported so a caller can supply a cheaper one and
+#: so tests can count calls.
+Hasher = Callable[[str], str]
+
+
+#: `size` / `mtime_ns` value meaning "this store never recorded one". It is
+#: NEGATIVE rather than zero because zero is a legal size and a legal mtime,
+#: and it is checked explicitly rather than left to compare unequal against
+#: real values: an earlier cut stamped both the store AND the candidate with
+#: the sentinel, so `-1 == -1` took the cheap path and reported every changed
+#: file as unchanged. A sentinel that can be mistaken for data is not one.
+UNRECORDED = -1
+
+
+@dataclass(frozen=True)
+class FileStamp:
+    """What was recorded about one file the last time it was indexed.
+
+    `size` or `mtime_ns` may be `UNRECORDED`, which disables the cheap
+    pre-filter for that file and forces a hash — the honest behaviour for a
+    store that persists hashes alone.
+    """
+
+    size: int
+    mtime_ns: int
+    content_hash: str
+
+    @property
+    def has_cheap_stamp(self) -> bool:
+        return self.size >= 0 and self.mtime_ns >= 0
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One file the walk currently admits, with its cheap stamp already read.
+
+    `abs_path` is what a hasher is handed; `rel_path` is the identity a stamp
+    is keyed on, so the same repository indexed through two different absolute
+    prefixes (a worktree, a container mount) still matches its own history.
+    """
+
+    abs_path: str
+    rel_path: str
+    size: int
+    mtime_ns: int
+
+
+@dataclass
+class Changes:
+    """The verdict: what to index, what to drop, what to leave alone.
+
+    `touched` is deliberately separate from `changed`. Both need a stamp
+    rewrite, but only `changed` needs the file re-read and re-tokenized, and
+    conflating them turns `touch *` into a full rebuild. The two are reported
+    separately for the same reason a truncation is reported: a caller that
+    prints "re-indexed 400 files" when it re-tokenized none is lying about its
+    own work.
+    """
+
+    added: list[Candidate] = field(default_factory=list)
+    changed: list[Candidate] = field(default_factory=list)
+    touched: list[Candidate] = field(default_factory=list)
+    unchanged: list[Candidate] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    hashes: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def needs_indexing(self) -> list[Candidate]:
+        """Files whose CONTENT must be read again."""
+        return self.added + self.changed
+
+    @property
+    def is_clean(self) -> bool:
+        """True when nothing at all has to be written."""
+        return not (self.added or self.changed or self.touched or self.removed)
+
+
+def detect_changes(
+    stored: Mapping[str, FileStamp],
+    current: Iterable[Candidate],
+    hasher: Hasher,
+    *,
+    force_rehash: bool = False,
+) -> Changes:
+    """Compare the recorded stamps against what is on disk now.
+
+    A file that cannot be hashed (deleted between the walk and here, or
+    unreadable) is dropped from the result entirely rather than recorded with
+    an empty hash: an empty hash would compare equal to the next unreadable
+    file's, which is how "unreadable" silently becomes "unchanged".
+    """
+    changes = Changes()
+    seen: set[str] = set()
+
+    for candidate in current:
+        seen.add(candidate.rel_path)
+        stamp = stored.get(candidate.rel_path)
+
+        if (
+            stamp is not None
+            and not force_rehash
+            and stamp.has_cheap_stamp
+            and stamp.size == candidate.size
+            and stamp.mtime_ns == candidate.mtime_ns
+        ):
+            changes.unchanged.append(candidate)
+            changes.hashes[candidate.rel_path] = stamp.content_hash
+            continue
+
+        digest = hasher(candidate.abs_path)
+        if not digest:
+            # Vanished or unreadable. It is not "unchanged" and it is not a
+            # deletion we can prove, so leave whatever is stored alone.
+            seen.discard(candidate.rel_path)
+            continue
+
+        changes.hashes[candidate.rel_path] = digest
+        if stamp is None:
+            changes.added.append(candidate)
+        elif stamp.content_hash != digest:
+            changes.changed.append(candidate)
+        else:
+            changes.touched.append(candidate)
+
+    changes.removed = sorted(set(stored) - seen)
+    return changes
+
+
+def stale_paths(
+    stored: Mapping[str, FileStamp],
+    current: Iterable[Candidate],
+    hasher: Hasher,
+) -> tuple[list[str], list[str]]:
+    """`(changed_or_added, removed)` as plain paths, for callers wanting names.
+
+    `ProjectIndex.check_staleness` speaks this shape; the content index wants
+    the richer `Changes`. One comparison, two projections.
+    """
+    changes = detect_changes(stored, current, hasher)
+    return (
+        [c.rel_path for c in changes.needs_indexing],
+        list(changes.removed),
+    )
+
+
+def stamps_from_hashes(
+    hashes: Mapping[str, str],
+    sizes: Optional[Mapping[str, int]] = None,
+) -> dict[str, FileStamp]:
+    """Adapt a bare `rel_path -> hash` map into stamps.
+
+    The semantic catalog persists hashes only, so its stamps carry no cheap
+    pre-filter and every file it tracks gets hashed. That is the honest
+    translation: claiming a size and mtime it never recorded would make a
+    changed file look unchanged.
+    """
+    sizes = sizes or {}
+    return {
+        path: FileStamp(
+            size=sizes.get(path, UNRECORDED),
+            mtime_ns=UNRECORDED,
+            content_hash=digest,
+        )
+        for path, digest in hashes.items()
+    }

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -29,6 +29,7 @@ from typing import Optional, List, Dict, Tuple, Any
 import numpy as np
 
 from neo.eligibility import file_content_hash
+from neo.index import freshness
 from neo.index.language_parser import TreeSitterParser
 
 # Import FAISS for fast similarity search
@@ -724,6 +725,17 @@ class ProjectIndex:
         """
         Check if index is stale (files have changed).
 
+        The comparison itself lives in `index.freshness`, shared with the
+        persistent content index next door. Two on-disk indexes answering
+        "what changed since I last looked?" with two implementations is how
+        they end up disagreeing about it; the storage stays separate because
+        they hold different artifacts, the verdict does not.
+
+        This catalog persists hashes only — no size, no mtime — so the shared
+        comparison has no cheap pre-filter to apply here and hashes every
+        tracked file, exactly as this method always did. Claiming a stamp it
+        never recorded would make a changed file look unchanged.
+
         Returns:
             (is_stale, staleness_ratio, changed_files)
         """
@@ -735,20 +747,29 @@ class ProjectIndex:
         if current_commit != self.snapshot.commit_hash:
             logger.info(f"Commit changed: {self.snapshot.commit_hash[:7]} -> {current_commit[:7]}")
 
-        # Check file hashes
-        changed_files = []
-        for rel_path, old_hash in self.snapshot.file_hashes.items():
-            file_path = self.repo_root / rel_path
-            if not file_path.exists():
-                changed_files.append(rel_path)
-                continue
-
-            new_hash = self._compute_file_hash(file_path)
-            if new_hash != old_hash:
-                changed_files.append(rel_path)
+        tracked = self.snapshot.file_hashes
+        current = [
+            freshness.Candidate(
+                abs_path=str(self.repo_root / rel_path),
+                rel_path=rel_path,
+                size=freshness.UNRECORDED,
+                mtime_ns=freshness.UNRECORDED,
+            )
+            for rel_path in tracked
+            if (self.repo_root / rel_path).exists()
+        ]
+        moved, gone = freshness.stale_paths(
+            freshness.stamps_from_hashes(tracked),
+            current,
+            self._compute_file_hash,
+        )
+        # Reported in the order the snapshot tracks them, so two calls on an
+        # unchanged tree cannot disagree about the list.
+        stale = set(moved) | set(gone)
+        changed_files = [rel_path for rel_path in tracked if rel_path in stale]
 
         # Calculate staleness ratio
-        total_files = len(self.snapshot.file_hashes)
+        total_files = len(tracked)
         staleness_ratio = len(changed_files) / total_files if total_files > 0 else 0.0
         is_stale = staleness_ratio > STALENESS_THRESHOLD
 
@@ -1010,7 +1031,7 @@ class ProjectIndex:
 
         logger.info(f"Built FAISS index with {self.faiss_index.ntotal} vectors (dim={dim})")
 
-    def _compute_file_hash(self, file_path: Path) -> str:
+    def _compute_file_hash(self, file_path) -> str:
         """SHA-256 of file contents, via the shared dedup primitive.
 
         Kept as a method because it is the seam `_select_files` hashes

--- a/tests/test_content_index.py
+++ b/tests/test_content_index.py
@@ -1,0 +1,445 @@
+"""Tests for the persistent BM25 content index.
+
+Three properties carry the change, and each of them is a way it could have
+gone wrong silently:
+
+1. **Parity.** Persisting the index must not re-rank anything. Every test in
+   `TestParity` scores the same corpus through both the per-call `FileIndex`
+   and the persisted `ContentIndex` and asserts they agree — a persistence
+   change that quietly moved scores would present as a retrieval regression
+   with no diff to blame it on.
+2. **Freshness.** An index that answers from stale postings is worse than no
+   index, because the answer looks right. `TestFreshness` edits, adds, deletes
+   and touches files and asserts what comes back.
+3. **Degradation.** Corrupt, unwritable, or written by a different tokenizer —
+   each must produce a warning and a correct answer, never a crash and never a
+   silently empty ranking.
+"""
+
+import os
+
+
+import pytest
+
+from neo import eligibility
+from neo.file_retrieval import FileIndex, code_tokens
+from neo.index import content_index as ci
+from neo.index.content_index import ContentIndex
+
+
+def _walk(root):
+    return eligibility.walk_paths(str(root), max_file_bytes=512_000).paths
+
+
+def _repo(tmp_path, files):
+    for rel, text in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return tmp_path
+
+
+CORPUS = {
+    "src/store.py": (
+        "def supersede(fact, other):\n"
+        "    '''Retire a fact superseded by a newer one.'''\n"
+        "    threshold = 0.85\n"
+        "    return fact.similarity(other) >= threshold\n"
+    ),
+    "src/engine.py": (
+        "class Engine:\n"
+        "    def process(self, request):\n"
+        "        return self.reason(request)\n"
+    ),
+    "src/parser/lexer.py": "def tokenize(text):\n    return text.split()\n",
+    "README.md": "# Project\n\nA store of facts with supersession.\n",
+    "tests/test_store.py": "def test_supersede():\n    assert True\n",
+}
+
+
+class TestParity:
+    """The persisted index ranks exactly like the per-call one it replaces."""
+
+    def _both(self, tmp_path, prompt):
+        paths = _walk(tmp_path)
+        memory = FileIndex([(p.path, p.rel_path, p.size) for p in paths])
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(paths, quiet=True)
+            return memory.scores(prompt), index.scores(prompt)
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "supersession threshold",
+            "how does the engine process a request",
+            "tokenize",
+            "supersede supersede supersede",  # repeated term: multiplicity
+            "getUserById",  # camelCase split
+            "src/parser/lexer.py",  # a path as the query
+        ],
+    )
+    def test_scores_match_the_in_memory_index(self, tmp_path, prompt):
+        _repo(tmp_path, CORPUS)
+        expected, actual = self._both(tmp_path, prompt)
+        assert set(expected) == set(actual)
+        for path, score in expected.items():
+            assert actual[path] == pytest.approx(score, rel=1e-9, abs=1e-12)
+
+    def test_ranking_order_matches(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        expected, actual = self._both(tmp_path, "supersession threshold")
+        rank = lambda scores: [  # noqa: E731 - a local, used twice
+            p for p, _ in sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+        assert rank(expected) == rank(actual)
+
+    def test_query_term_multiplicity_is_preserved(self, tmp_path):
+        """A term repeated in the prompt weighs more, as it did in the list.
+
+        The obvious optimization -- dedupe the query terms before hitting the
+        postings table -- is a silent ranking change, because the scorer this
+        replaces iterated the token LIST and `code_tokens` emits a repeated
+        word repeatedly.
+        """
+        _repo(tmp_path, CORPUS)
+        assert code_tokens("supersede supersede").count("supersede") == 2
+        once, _ = self._both(tmp_path, "supersede")
+        twice, persisted_twice = self._both(tmp_path, "supersede supersede")
+        assert twice["src/store.py"] > once["src/store.py"]
+        assert persisted_twice["src/store.py"] == pytest.approx(twice["src/store.py"])
+
+    def test_gibberish_scores_nothing(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        expected, actual = self._both(tmp_path, "zzqx wibble frobnicate")
+        assert expected == {}
+        assert actual == {}
+
+    def test_a_binary_file_still_contributes_its_path(self, tmp_path):
+        """Its bytes are not text; its name is still a real name in the repo."""
+        _repo(tmp_path, CORPUS)
+        (tmp_path / "src" / "supersede.bin").write_bytes(b"\x00\x01\x02binary")
+        expected, actual = self._both(tmp_path, "supersede")
+        assert "src/supersede.bin" in expected
+        assert actual["src/supersede.bin"] == pytest.approx(
+            expected["src/supersede.bin"]
+        )
+
+
+class TestFreshness:
+    """Only what moved is re-read, and what moved is always reflected."""
+
+    def _refresh(self, tmp_path, index):
+        return index.refresh(_walk(tmp_path), quiet=True)
+
+    def test_first_run_is_cold_and_says_so(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+        assert report.mode == "cold"
+        assert report.indexed == len(CORPUS)
+        assert "cold build" in report.describe()
+
+    def test_second_run_is_warm_and_re_reads_nothing(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+        assert report.mode == "warm"
+        assert report.indexed == 0
+        assert "read warm" in report.describe()
+
+    def test_an_edit_is_reflected_with_no_stale_hits(self, tmp_path):
+        """The staleness test the plan asks for: edit, re-run, see the change.
+
+        Both halves matter. The new content has to become findable, and the
+        old content has to stop being findable -- an index that only ever adds
+        postings passes the first check and answers with text that is no
+        longer in the file.
+        """
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+            assert "src/engine.py" in index.scores("reason request")
+            assert not index.scores("quantumleap")
+
+        (tmp_path / "src" / "engine.py").write_text(
+            "class Engine:\n    def quantumleap(self):\n        return 1\n"
+        )
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+            assert report.mode == "incremental"
+            assert report.changed == 1
+            assert report.indexed == 1
+            assert index.scores("quantumleap").get("src/engine.py", 0) > 0
+            # The removed word must be gone from the postings, not merely
+            # outranked.
+            assert "src/engine.py" not in index.scores("reason request")
+
+    def test_an_added_file_becomes_queryable(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        (tmp_path / "src" / "cache.py").write_text("def evict(entry):\n    pass\n")
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+            assert report.added == 1
+            assert "src/cache.py" in index.scores("evict")
+
+    def test_a_deleted_file_stops_answering(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        os.unlink(tmp_path / "src" / "parser" / "lexer.py")
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+            assert report.removed == 1
+            assert "src/parser/lexer.py" not in index.scores("tokenize")
+
+    def test_a_newly_excluded_file_stops_answering(self, tmp_path):
+        """Eligibility is the walker's verdict, and the index obeys it.
+
+        A file that becomes gitignored is still on disk and still hashes the
+        same, so nothing about the FILE changed. It leaves the index because
+        it left the walk -- which is the only reason this module never needs
+        an exclusion rule of its own.
+        """
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+            assert "src/parser/lexer.py" in index.scores("tokenize")
+
+        (tmp_path / ".gitignore").write_text("src/parser/\n")
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+            assert "src/parser/lexer.py" not in index.scores("tokenize")
+
+    def test_a_touch_without_an_edit_re_tokenizes_nothing(self, tmp_path):
+        """`touch` moves mtime; the hash says the content did not move.
+
+        Reported separately from a real change, because a run that says it
+        re-indexed 400 files when it tokenized none is lying about its work.
+        """
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        target = tmp_path / "src" / "store.py"
+        stat = target.stat()
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+        assert report.touched == 1
+        assert report.changed == 0
+        assert report.indexed == 0
+        assert "touched (content identical)" in report.describe()
+
+    def test_a_touch_is_stamped_so_it_is_not_re_hashed_forever(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        target = tmp_path / "src" / "store.py"
+        stat = target.stat()
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+        with ContentIndex(str(tmp_path)) as index:
+            self._refresh(tmp_path, index)
+        with ContentIndex(str(tmp_path)) as index:
+            report = self._refresh(tmp_path, index)
+        assert report.mode == "warm"
+
+
+class TestCorpusScope:
+    """Per-call flags narrow the answer; they never prune the stored corpus."""
+
+    def test_a_candidate_subset_narrows_the_result(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+            everything = index.scores("supersede")
+            subset = index.scores("supersede", ["src/store.py"])
+        assert len(everything) > 1
+        assert set(subset) == {"src/store.py"}
+        # The score itself is unchanged: corpus statistics are global, so
+        # narrowing the answer cannot move a file's number.
+        assert subset["src/store.py"] == pytest.approx(everything["src/store.py"])
+
+    def test_an_unknown_candidate_path_is_simply_absent(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+            assert index.scores("supersede", ["nope/missing.py"]) == {}
+
+
+class TestDegradation:
+    """Every failure is loud, correct, and survivable."""
+
+    def test_a_tokenizer_bump_invalidates_cleanly(self, tmp_path, monkeypatch):
+        """Every posting is wrong and no file hash can tell you so."""
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+
+        monkeypatch.setattr(ci, "TOKENIZER_VERSION", ci.TOKENIZER_VERSION + 1)
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh(_walk(tmp_path), quiet=True)
+            assert report.mode == "rebuilt"
+            assert report.indexed == len(CORPUS)
+            # And it still answers.
+            assert index.scores("supersede")
+
+    def test_a_schema_bump_invalidates_cleanly(self, tmp_path, monkeypatch):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        monkeypatch.setattr(ci, "SCHEMA_VERSION", ci.SCHEMA_VERSION + 1)
+        with ContentIndex(str(tmp_path)) as index:
+            assert index.refresh(_walk(tmp_path), quiet=True).mode == "rebuilt"
+
+    def test_a_corrupt_store_is_rebuilt_not_raised(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        db = tmp_path / ".neo" / ci.INDEX_FILENAME
+        db.write_bytes(b"this is not a database, it is a sentence" * 64)
+
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh(_walk(tmp_path), quiet=True)
+            assert report.mode in ("cold", "rebuilt")
+            assert index.scores("supersede")
+
+    def test_a_truncated_store_is_rebuilt_not_raised(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        db = tmp_path / ".neo" / ci.INDEX_FILENAME
+        raw = db.read_bytes()
+        db.write_bytes(raw[: len(raw) // 3])
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh(_walk(tmp_path), quiet=True)
+            assert report.mode in ("cold", "rebuilt")
+            assert index.scores("supersede")
+
+    def test_an_unwritable_store_still_scores_and_warns(self, tmp_path, monkeypatch):
+        """A read-only checkout costs a warning, not a run.
+
+        The alternative failure is worse than a crash: an empty ranking is
+        indistinguishable, to the operator reading the output, from "nothing
+        in your repository matches this prompt".
+        """
+        _repo(tmp_path, CORPUS)
+        index = ContentIndex(str(tmp_path))
+        monkeypatch.setattr(index, "_connect", lambda: None)
+        report = index.refresh(_walk(tmp_path), quiet=True)
+        assert report.mode == "memory"
+        assert report.warning
+        assert index.scores("supersede")
+        assert "src/store.py" in index.scores("supersede")
+
+    def test_the_memory_fallback_honours_a_candidate_subset(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        index = ContentIndex(str(tmp_path))
+        index._connect = lambda: None
+        index.refresh(_walk(tmp_path), quiet=True)
+        assert set(index.scores("supersede", ["src/store.py"])) == {"src/store.py"}
+
+    def test_an_empty_repository_scores_nothing_and_does_not_raise(self, tmp_path):
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh([], quiet=True)
+            assert report.total_files == 0
+            assert index.scores("anything") == {}
+
+
+class TestReporting:
+    """`--dry-run` has to be able to say which of the three happened."""
+
+    def test_last_report_survives_the_index_being_closed(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        report = ci.last_report()
+        assert report is not None
+        assert report.mode == "cold"
+        assert report.to_dict()["summary"] == report.describe()
+
+    def test_the_report_serializes_for_json_consumers(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh(_walk(tmp_path), quiet=True)
+        payload = report.to_dict()
+        assert payload["mode"] == "cold"
+        assert payload["total_files"] == len(CORPUS)
+        assert set(payload) >= {
+            "mode",
+            "total_files",
+            "indexed",
+            "added",
+            "changed",
+            "touched",
+            "removed",
+            "elapsed_ms",
+            "summary",
+        }
+
+    def test_an_incremental_report_names_what_moved(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        (tmp_path / "src" / "engine.py").write_text("def replaced():\n    pass\n")
+        (tmp_path / "src" / "new.py").write_text("def added():\n    pass\n")
+        os.unlink(tmp_path / "README.md")
+        with ContentIndex(str(tmp_path)) as index:
+            report = index.refresh(_walk(tmp_path), quiet=True)
+        summary = report.describe()
+        assert "1 added" in summary
+        assert "1 changed" in summary
+        assert "1 removed" in summary
+
+    def test_a_cold_build_announces_itself_before_it_starts(self, tmp_path, capsys):
+        """Silence for minutes is indistinguishable from a hang."""
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path))
+        err = capsys.readouterr().err
+        assert "no usable index for this repository" in err
+        assert "runs once" in err
+
+
+class TestNoSecondWalker:
+    """The index is handed eligibility; it never computes it."""
+
+    def test_the_module_does_not_walk_the_filesystem(self):
+        source = (
+            __import__("pathlib")
+            .Path(ci.__file__)
+            .read_text()
+        )
+        for forbidden in ("os.walk", "rglob", "iglob", "glob.glob"):
+            assert forbidden not in source, (
+                f"{forbidden} in content_index.py: eligibility has exactly one "
+                "implementation and it is neo.eligibility"
+            )
+
+    def test_it_accepts_the_walkers_own_records(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        paths = _walk(tmp_path)
+        assert all(isinstance(p, eligibility.EligiblePath) for p in paths)
+        with ContentIndex(str(tmp_path)) as index:
+            assert index.refresh(paths, quiet=True).total_files == len(CORPUS)
+
+    def test_it_also_accepts_bare_tuples(self, tmp_path):
+        """Older callers hold `(abs, rel, size)`; they get real freshness."""
+        _repo(tmp_path, CORPUS)
+        tuples = [(p.path, p.rel_path, p.size) for p in _walk(tmp_path)]
+        with ContentIndex(str(tmp_path)) as index:
+            assert index.refresh(tuples, quiet=True).total_files == len(CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            assert index.refresh(tuples, quiet=True).mode == "warm"
+
+
+class TestWalkerCarriesMtime:
+    """The stat the walk already does now yields the freshness stamp too."""
+
+    def test_eligible_paths_carry_mtime(self, tmp_path):
+        _repo(tmp_path, CORPUS)
+        for entry in _walk(tmp_path):
+            assert entry.mtime_ns > 0
+            assert entry.mtime_ns == os.stat(entry.path).st_mtime_ns

--- a/tests/test_content_index.py
+++ b/tests/test_content_index.py
@@ -17,7 +17,7 @@ gone wrong silently:
 """
 
 import os
-
+import sqlite3
 
 import pytest
 
@@ -258,9 +258,31 @@ class TestCorpusScope:
             subset = index.scores("supersede", ["src/store.py"])
         assert len(everything) > 1
         assert set(subset) == {"src/store.py"}
-        # The score itself is unchanged: corpus statistics are global, so
-        # narrowing the answer cannot move a file's number.
-        assert subset["src/store.py"] == pytest.approx(everything["src/store.py"])
+
+    def test_a_filtered_call_matches_a_filtered_in_memory_index(self, tmp_path):
+        """The subset is a CORPUS, not just a filter on the answer.
+
+        N, document frequency and average document length all feed BM25, and
+        the per-call index computed all three over exactly the files that call
+        admitted. Keeping them repo-global scores a `--exts py` run
+        differently from `main` — measured, all 25 selected lines changed —
+        so the subset supplies the statistics too. This test is the one that
+        fails if anyone "optimizes" that back to global.
+        """
+        _repo(tmp_path, CORPUS)
+        keep = ["src/store.py", "src/engine.py", "src/parser/lexer.py"]
+        paths = _walk(tmp_path)
+        memory = FileIndex(
+            [(p.path, p.rel_path, p.size) for p in paths if p.rel_path in keep]
+        )
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(paths, quiet=True)
+            for prompt in ("supersede", "tokenize text", "engine process request"):
+                expected = memory.scores(prompt)
+                actual = index.scores(prompt, keep)
+                assert set(expected) == set(actual), prompt
+                for path, score in expected.items():
+                    assert actual[path] == pytest.approx(score, rel=1e-9, abs=1e-12)
 
     def test_an_unknown_candidate_path_is_simply_absent(self, tmp_path):
         _repo(tmp_path, CORPUS)
@@ -285,6 +307,23 @@ class TestDegradation:
             assert report.indexed == len(CORPUS)
             # And it still answers.
             assert index.scores("supersede")
+
+    def test_a_reused_instance_does_not_rebuild_forever(self, tmp_path):
+        """The corruption flag is consumed, not carried.
+
+        Left set, a second `refresh()` on the same object reported `rebuilt`
+        and wiped the whole repository again, long after the corruption that
+        justified the first one.
+        """
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        db = tmp_path / ".neo" / ci.INDEX_FILENAME
+        db.write_bytes(b"not a database" * 64)
+        index = ContentIndex(str(tmp_path))
+        assert index.refresh(_walk(tmp_path), quiet=True).mode == "rebuilt"
+        assert index.refresh(_walk(tmp_path), quiet=True).mode == "warm"
+        index.close()
 
     def test_a_schema_bump_invalidates_cleanly(self, tmp_path, monkeypatch):
         _repo(tmp_path, CORPUS)
@@ -341,11 +380,129 @@ class TestDegradation:
         index.refresh(_walk(tmp_path), quiet=True)
         assert set(index.scores("supersede", ["src/store.py"])) == {"src/store.py"}
 
+    def test_an_unreadable_file_keeps_its_path_tokens(self, tmp_path):
+        """Permission was withdrawn from the CONTENT, not from the name.
+
+        The per-call index this replaces still ranked such a file on its path
+        tokens, because its content simply read as empty. An earlier cut of
+        `detect_changes` dropped any candidate it could not hash, which made
+        `chmod 000` delete the file from the corpus permanently — a silent
+        retrieval regression that no test would have caught.
+        """
+        _repo(tmp_path, CORPUS)
+        secret = tmp_path / "src" / "secret_alpha_module.py"
+        secret.write_text("def alpha():\n    return 'secret'\n")
+        paths = _walk(tmp_path)
+        os.chmod(secret, 0o000)
+        try:
+            memory = FileIndex([(p.path, p.rel_path, p.size) for p in paths])
+            with ContentIndex(str(tmp_path)) as index:
+                index.refresh(paths, quiet=True)
+                expected = memory.scores("secret alpha module")
+                actual = index.scores("secret alpha module")
+            assert "src/secret_alpha_module.py" in expected
+            assert set(expected) == set(actual)
+            for path, score in expected.items():
+                assert actual[path] == pytest.approx(score, rel=1e-9, abs=1e-12)
+        finally:
+            os.chmod(secret, 0o644)
+
+    def test_an_unreadable_file_is_not_re_read_every_call(self, tmp_path):
+        """The empty hash compares equal to itself, which is `touched`."""
+        _repo(tmp_path, CORPUS)
+        secret = tmp_path / "src" / "secret.py"
+        secret.write_text("def alpha():\n    pass\n")
+        os.chmod(secret, 0o000)
+        try:
+            with ContentIndex(str(tmp_path)) as index:
+                index.refresh(_walk(tmp_path), quiet=True)
+            with ContentIndex(str(tmp_path)) as index:
+                assert index.refresh(_walk(tmp_path), quiet=True).mode == "warm"
+        finally:
+            os.chmod(secret, 0o644)
+
     def test_an_empty_repository_scores_nothing_and_does_not_raise(self, tmp_path):
         with ContentIndex(str(tmp_path)) as index:
             report = index.refresh([], quiet=True)
             assert report.total_files == 0
             assert index.scores("anything") == {}
+
+
+class TestConcurrency:
+    """Two Neo processes in one repository is ordinary, not exotic."""
+
+    def test_a_peer_holding_the_write_lock_does_not_delete_the_store(
+        self, tmp_path, monkeypatch
+    ):
+        """The regression this class exists for, and it was a bad one.
+
+        `sqlite3.OperationalError` ("database is locked") is a SUBCLASS of
+        `sqlite3.DatabaseError`, so an `except DatabaseError` written first
+        caught lock contention and ran the corruption handler: `os.unlink` on
+        a perfectly good store. That throws away a valid index — 109 MB and
+        122 s of rebuild on m365dotnet — and destroys the PEER, whose
+        transaction then commits into an unlinked inode and disappears with no
+        error anywhere. Ordering the `OperationalError` clause first is the
+        entire fix, and Python matches except clauses in order, so merging or
+        reordering them reintroduces it.
+        """
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        db = tmp_path / ".neo" / ci.INDEX_FILENAME
+        before = db.stat().st_ino
+
+        # A peer mid-write. Force a real lock rather than simulating one.
+        peer = sqlite3.connect(str(db), timeout=0.1)
+        peer.execute("BEGIN EXCLUSIVE")
+        peer.execute("INSERT OR REPLACE INTO meta(key, value) VALUES ('peer', '1')")
+        try:
+            # Something must be written, or the warm path never opens a
+            # transaction and the lock is never contended.
+            (tmp_path / "src" / "engine.py").write_text("def moved():\n    pass\n")
+            monkeypatch.setattr(ci, "_BUSY_TIMEOUT_MS", 200)
+            index = ContentIndex(str(tmp_path))
+            report = index.refresh(_walk(tmp_path), quiet=True)
+        finally:
+            peer.commit()
+            peer.close()
+
+        assert db.exists(), "the store was deleted by a LOCK, not by corruption"
+        assert db.stat().st_ino == before, "the store was recreated, not reused"
+        assert report.mode == "memory", report.mode
+        assert report.warning and "busy" in report.warning.lower()
+        # Degraded, but still correct and still not empty -- an empty ranking
+        # reads to the operator as "nothing here matches your prompt".
+        assert "src/store.py" in index.scores("supersede")
+        index.close()
+
+        # The peer's committed write survived, which is the half that was
+        # silently lost: it had been committing into an unlinked inode.
+        conn = sqlite3.connect(str(db))
+        assert conn.execute(
+            "SELECT value FROM meta WHERE key = 'peer'"
+        ).fetchone() == ("1",)
+        conn.close()
+
+    def test_a_warm_call_takes_no_write_transaction(self, tmp_path):
+        """Or every invocation is a writer and two of them collide."""
+        _repo(tmp_path, CORPUS)
+        with ContentIndex(str(tmp_path)) as index:
+            index.refresh(_walk(tmp_path), quiet=True)
+        db = tmp_path / ".neo" / ci.INDEX_FILENAME
+
+        peer = sqlite3.connect(str(db), timeout=0.1)
+        peer.execute("BEGIN EXCLUSIVE")
+        try:
+            index = ContentIndex(str(tmp_path))
+            report = index.refresh(_walk(tmp_path), quiet=True)
+            # Warm: nothing to write, so the peer's lock is irrelevant.
+            assert report.mode == "warm"
+            assert index.scores("supersede")
+            index.close()
+        finally:
+            peer.rollback()
+            peer.close()
 
 
 class TestReporting:


### PR DESCRIPTION
## Description

Moves #194's per-call BM25 content index onto disk, into the repository's own `.neo/`
beside the semantic catalog, with inline incremental freshness. Closes #195. Goal 6 of
`docs/unified-store-plan.md`.

#194 made file selection BM25 over file CONTENT and took m365dotnet from MRR 0.051 to
0.607. It also read and tokenized every eligible file on every invocation, which then
became the entire cost of a Neo call: a **53.47 s median wall / 1.95 GB peak RSS** to
assemble context on m365dotnet, before a single token reached the model. None of that
work is per-call — the corpus changes when the repository changes, which between two
invocations is usually not at all.

- **`index/content_index.py`** — postings, per-file content hashes, doc lengths and a
  tokenizer/schema signature in SQLite. SQLite rather than the catalog's JSON because
  the access shapes are opposite: the catalog is read whole, a keyword query touches
  ten terms out of a few hundred thousand, and a parse-whole format would spend the
  warm budget deserializing postings no query asked for. **Index artifacts only** —
  never a file body (plan ruling 2); delivery still reads whole files fresh from disk.
- **`index/freshness.py`** — one implementation of "what changed since I last looked?",
  now shared with `ProjectIndex.check_staleness`. size + mtime is the cheap pre-filter
  that decides *what to hash*; only a hash mismatch counts as a change, so `touch`
  re-stamps and re-tokenizes nothing.
- **Eligibility comes from the #208 walker and is never recomputed** — a file the
  walker stops admitting (newly gitignored, deleted) has its postings dropped on the
  same pass, so a stale index cannot answer with an excluded file.
  `test_the_module_does_not_walk_the_filesystem` fails on an `os.walk`/`glob` here.
- **One walk per invocation, unfiltered**; `--exts`/`--include`/`--exclude` narrow the
  answer afterwards. The index is a property of the repository, so `--exts py` can no
  longer prune it and force the next call to rebuild.
- **`--dry-run` reports which of cold / rebuilt / incremental (N files) / warm / memory
  happened** (G3-inv), in the selected-files block and in the `--json` payload's
  `content_index` key — `--json` implies `--quiet`, so the stderr note is suppressed on
  exactly the path a machine consumer reads.
- `EligiblePath` now carries `mtime_ns`: the walk already stats every file, and
  `os.path.getsize` was discarding the half an incremental index needs.

## Type of Change

- [x] Performance improvement
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Fixes #195

---

## Evidence

Full tables, exact commands and repo HEADs:
**`docs/goal6-content-index-measurements-2026-08-12.md`**.
Arms: `main` = `9b0c16d` (post-#208), `branch` = `06c3ae9`.

### M1 — retrieval quality: **identical**, all three flagships

`tools/rank_mine_eval.py`, 50 git-mined cases per repo, `--no-git`, 0 failed cases.

| repo | arm | MRR | R@1 | R@3 | R@10 | H@10 |
|---|---|---|---|---|---|---|
| neo | main | 0.712 | 0.307 | 0.502 | 0.708 | 0.980 |
| neo | **branch** | **0.712** | **0.307** | **0.502** | **0.708** | **0.980** |
| aieweb | main | 0.728 | 0.487 | 0.654 | 0.778 | 0.880 |
| aieweb | **branch** | **0.728** | **0.487** | **0.654** | **0.778** | **0.880** |
| m365dotnet | main | 0.669 | 0.312 | 0.497 | 0.771 | 0.860 |
| m365dotnet | **branch** | **0.669** | **0.312** | **0.497** | **0.771** | **0.860** |

Byte-identical in every cell. **Disclosed measurement condition:** m365dotnet is a live
tree on a shared machine and an unrelated session ran `git reset` in it at 20:58:59
(reflog), between the m365dotnet main arm and the branch arm — HEAD did not move, a
handful of untracked/modified files did. The arms agree in every cell anyway, which says
the perturbation was immaterial to these 50 cases, not that it could never matter.

Stronger still, on the M2 battery: all six canonical
prompts selected **the same files in the same rank order** on both arms (`diff` of the
per-prompt selected-file lists is empty, six for six).

**Staleness test.** Ten `.cs` files in m365dotnet given a unique marker each, index
refreshed, marker searched:
`S3 files matching the unique edit token: 1 -> ['src/Ink.Core/Editing/ApplyEditPlanResult.cs']`.
New content findable, attributed to exactly the file holding it. The converse — old
content ceasing to be findable — is pinned by
`test_an_edit_is_reflected_with_no_stale_hits`, which asserts both halves, because an
index that only ever ADDS postings passes the first check while answering with text
that is no longer in the file. All ten files restored byte-for-byte; m365dotnet's
`git status --porcelain` identical before and after.

### Post-review fix: a fresh non-author verification pass found five defects

The routing protocol requires a fresh non-author Claude to verify; it did, and it
earned its keep. All five are fixed in `260e56c`, each with a test.

1. **CRITICAL — a peer holding the write lock made Neo DELETE the index.**
   `sqlite3.OperationalError` ("database is locked") is a SUBCLASS of
   `sqlite3.DatabaseError`, and `refresh` caught `DatabaseError` first, so lock
   contention ran the corruption handler and `os.unlink`ed a perfectly good store.
   The `except sqlite3.Error` clause below it — comment: *"Locked by a peer ...
   serve this call from memory"* — was unreachable. Reproduced: the store is
   deleted and recreated, and the PEER then commits into an unlinked inode, so its
   write vanishes with no error anywhere. On m365dotnet each collision costs a
   109 MB store and a 122 s rebuild. Two Neo invocations in one repo (editor plugin
   + shell) is ordinary. `_connect` had the guard right; `refresh` did not.
   Mutation-verified: `test_a_peer_holding_the_write_lock_does_not_delete_the_store`
   fails on the original clause ordering. (The first mutation I tried swapped the
   clause headers without their bodies and passed — a vacuous check, caught and
   redone.)
2. **HIGH — every warm call opened a write transaction**, rewriting the unchanged
   signature, so two ordinary overlapping calls contended on the steady-state path.
   That is what made #1 reachable in normal use, not just during a rebuild.
3. **MEDIUM — a filtered call was re-ranked.** Corpus statistics were repo-global
   while the per-call index computed them over exactly the files that call
   admitted, and BM25 reads all of N, df and avgdl. Unflagged runs matched main
   exactly; `--exts py` changed all 25 selected lines. Now byte-identical under
   none / `--exts py` / `--exts py,md` / `--exclude docs` / `--exclude
   src/neo/memory` / `--include 'src/neo/*.py'` — table in the measurements doc.
   The "one stated difference" caveat this PR previously carried is gone, because
   the difference is gone.
4. **MEDIUM — `chmod 000` deleted a file from the corpus permanently.**
   `detect_changes` dropped any candidate it could not hash, and the caller reads
   "absent from the walk's set" as removed. The per-call index still ranked such a
   file on its path tokens. Permission was withdrawn from the CONTENT; the name is
   still a real name in the repository.
5. **LOW — the corruption flag was sticky**, so a reused `ContentIndex` reported
   `rebuilt` and wiped the repository on its second refresh.

Plus, from the same pass: the cold-build announcement now precedes the full-repo
sha256 instead of following it in silence, and term ids resolve per query rather
than preloading a few hundred thousand `terms` rows on the warm path. Fixing #1
exposed a latent bug of its own — the vocabulary was loaded BEFORE the wipe on a
rebuild, so `_index_file` believed every term already existed and wrote postings
pointing at deleted ids.

Two doc claims were false and are corrected: the measurements doc said the
concurrent path was "handled and unit-tested" (it was neither), and
`filter_candidates` understated that an `--exclude`d file is still read, tokenized
and stored.

### M2 — warm call on m365dotnet (`tools/m2_battery.sh`, RUNS=3)

| id | shape | main median | **branch median** | main peak RSS | **branch peak RSS** |
|---|---|---|---|---|---|
| P1 | file-named | 60.25 s | **17.08 s** | 1615.6 MiB | **1384.7 MiB** |
| P2 | file-named | 54.25 s | **18.45 s** | 1686.2 MiB | **1386.4 MiB** |
| P3 | concept-only | 52.49 s | **19.00 s** | 1801.5 MiB | **1383.3 MiB** |
| P4 | concept-only | 53.52 s | **18.09 s** | 1698.0 MiB | **1383.6 MiB** |
| P5 | mixed | 52.46 s | **18.79 s** | 1851.3 MiB | **1384.2 MiB** |
| P6 | symptom | 39.55 s | **19.27 s** | 1856.8 MiB | **1384.2 MiB** |
| **BATTERY** | | **53.47 s** | **18.50 s** | **1.95 GB** | **1.45 GB** |

**Cold build, reported separately:** m365dotnet 9,353 files in **122.14 s** / 1.47 GB
peak, store 109 MB on disk; neo 307 files in **2.3 s**, store 5 MB. It announces itself
before starting and reports every 250 files, so the minutes are visible rather than
silent.

### M2 targets: 2.9× better, still not met — and the profile says why

Warm profile, m365dotnet, `ru_maxrss` per stage:

```
T imports                      +  1.16s  cum   1.16s  rss=    82MB
T eligibility walk (9348)      +  4.64s  cum   5.80s  rss=    87MB
T content index refresh (warm) +  0.41s  cum   6.22s  rss=   127MB
T content index scores (7266)  +  0.12s  cum   6.33s  rss=   127MB
T project index boost          +  0.12s  cum   6.46s  rss=   140MB
T fact store history boost     +  2.94s  cum   9.40s  rss=  1404MB
```

1. **The cost this goal owns is gone.** Content indexing is **0.53 s of an 18.50 s**
   warm call, down from the ~35–45 s it contributed to main's median.
2. **≤ 500 MB is not reachable from file selection.** 1.26 GB of the 1.4 GB arrives in
   one step — `_history_boost` loading the FactStore (152 MB of JSON carrying 768-dim
   embeddings, ~1.3 GB as Python objects). Goal 1's 1.43 GB baseline was therefore
   never the gatherer's memory; it was the memory system's, measured through the
   gatherer. No change to how files are chosen moves it, and a Goal 6 that "hit
   500 MB" would have done it by deleting a retrieval channel.
3. **The largest remaining wall-clock item is #208's eligibility walk** — 4.6 s for
   9,348 admitted files out of ~345k filesystem entries, CPU-bound and stable across
   repeats (5.88 / 6.91 / 6.63 s in three consecutive in-process calls). Untouched
   here and out of this goal's scope.

Flagging rather than silently narrowing: neither remaining owner is in "move the
per-call BM25 into the on-disk store", and both are named with numbers so the shepherd
can route them. Everything Goal 6 does own is met.

### M3 — freshness cost

```
M3 walk=4.42s  refresh=0.79s  mode=incremental changed=10 added=0 removed=0 indexed=10 total=9353
```

**0.79 s of index work against ≤ 5 s — met.** Quoted with its neighbour so it is not
read as more than it is: walk + refresh is 5.21 s, and the walk is the eligibility scan
every invocation pays regardless of what changed (reading 3 above).

### G1-inv — identical on both arms

| label | distinct | `git check-ignore` excludes | duplicate copies | inside `.worktrees/` | unresolvable |
|---|---|---|---|---|---|
| **BATTERY UNION** | **111** | **0** | **0** | **0** | **0** |

Per-prompt rows in the measurements doc; every cell 0 on both arms — which is the
point, since the index consumes the walker's verdict and cannot widen it.

---

## How Has This Been Tested?

- [x] `tests/test_content_index.py` — 35 new tests in four groups. **Parity**: the same
      corpus scored through both `FileIndex` and `ContentIndex`, compared to floating
      point, over six prompt shapes including repeated terms, camelCase and a path as
      the query, plus rank-order equality. **Freshness**: cold / warm / edit / add /
      delete / newly-gitignored / touch, each asserting both the report and the answer.
      **Degradation**: corrupt store, truncated store, tokenizer bump, schema bump,
      unwritable store, empty repository. **No second walker**: the module is scanned
      for `os.walk`/`glob`.
- [x] Full suite: **2521 passed, 29 skipped, 2 failed** — both failures are
      machine-dependent latency assertions
      (`test_consolidation_performance_with_all_boosts`,
      `test_evaluation_cli_runs_without_provider_keys_or_user_memory`'s
      `performance_within_budget`) and **both fail identically on `origin/main`** in a
      clean worktree, verified before and after this change. This is the class of
      failure CLAUDE.md documents as advisory-not-correctness.
- [x] `ruff check src/ tests/ tools/` clean.
- [x] End-to-end through the real CLI on m365dotnet (9,348 files), aieweb and neo —
      cold, incremental and warm, in both `--dry-run` output modes.

**Test Configuration**: Python 3.13.7 · macOS (darwin 25.5.0) · neo 0.45.0 at
`06c3ae9`

## Checklist

- [x] Code follows the project's style
- [x] Self-review performed
- [x] Commented, particularly the load-bearing decisions (why SQLite, why the cheap
      stamp only decides what to hash, why query-term multiplicity is preserved, why
      corruption is detected at open)
- [x] Docs updated — `CLAUDE.md` retrieval section and a datestamped measurements doc
- [x] No new warnings
- [x] Tests added that prove the change works and that it did not re-rank
- [x] New and existing tests pass (see the two pre-existing failures above)

## Additional Notes

**One stated behaviour difference.** Corpus statistics (N, df, avgdl) are global to the
indexed repository rather than recomputed over each call's filtered subset. The
per-call index recomputed IDF over whatever that call happened to look at, so the same
file could score differently depending on an unrelated flag. Global statistics are
standard IR practice and stable; with no filters — every eval and every default
invocation — the two sets are identical and so are the scores, which the M1 table
above measures rather than assumes.

**`--exclude` no longer prunes a directory subtree.** It still excludes every file
under a named directory (`should_ignore` matches a non-final path component); it just
no longer saves the cost of descending. The names that make pruning matter
(`node_modules`, `.worktrees`, build output) are in the walker's shared default list,
which still prunes them.

**Store location.** `<repo>/.neo/content_index.sqlite3`, beside `index.json`, per the
plan's "on the on-disk store beside the semantic catalog". `.neo` is in the walker's
default ignore list, so Neo never indexes its own index.

Opened as **DRAFT** per the plan's option-3 governance: the shepherd verifies this
evidence and flips it ready; the car-pr-review daemon is the independent gate after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
