### PR TITLE
perf(walk): persist the eligibility walk so freshness is automatic on every call (#210)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -728,17 +728,27 @@
   selection on all six prompts and byte-identical `rank_mine_eval` on all three
   flagships.
   - **The cost is the pattern matching, not the filesystem, and that decides the
-    whole design.** Measured before the cache existed: listing the 951 surviving
-    directories 0.11 s, `should_ignore` over their 11,219 entries **6.7 s**,
-    `stat` over all 9,378 admitted files 0.10 s. Caching the syscalls would have
-    saved nothing. So what is stored per directory is the VERDICTS — which
-    subdirectories survive, which filenames survive, and the exclusion counts —
-    and the directory's mtime is what says whether they still hold.
+    whole design.** Measured before the cache existed, on m365dotnet: the full
+    walk **6.85 s**; the same traversal with the per-FILE ignore test removed
+    **0.80 s**; `stat` over all 9,378 admitted files **0.10 s**. So 6.05 s of a
+    6.85 s walk is `should_ignore` (11,219 calls), and caching the syscalls
+    would have saved almost nothing. What is stored per directory is therefore
+    the VERDICTS — which subdirectories survive, which filenames survive, and
+    the exclusion counts — with the directory's stamps saying whether they hold.
   - **Directory mtime is the right key for exactly one reason**: on every POSIX
     filesystem it moves when an entry is created, deleted or renamed inside that
     directory, and does NOT move when the content of a file inside it changes.
     An edit can change what a file SAYS; it can never change whether it is
     eligible.
+  - **mtime alone is not enough, because mtime is forgeable.** `touch -r`,
+    `tar -x`, `rsync -a` and every snapshot restore write a directory's mtime
+    back to a recorded value, so a restore that adds or deletes a file can land
+    on exactly the mtime the cache holds and be reported `warm` — reproduced
+    with two lines of `os.utime`, found by the fresh-verifier pass. `ctime_ns`
+    is stored beside it: the inode change time moves on any metadata change, no
+    API restores it, and it arrives in the same `stat`. On Windows `st_ctime` is
+    a CREATION time and hence constant, which makes the extra comparison a no-op
+    there rather than a false invalidation.
   - **Sizes and mtimes are never remembered.** They come fresh from the `stat`
     the walk owes its callers anyway (0.10 s), because the content index uses
     them as ITS freshness stamp — serving a remembered mtime would make an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -723,8 +723,8 @@
   The #208 walk is **kept on disk too**, in the same `.neo/`, because once the
   content index stopped rebuilding it became the largest single item in a warm
   call: 4.64 s on m365dotnet to re-derive that 9,348 files are eligible, on every
-  invocation, in a repository that had not changed (#210). Warm walk now 0.2 s;
-  the canonical M2 battery went 15.63 s → **9.47 s** median with byte-identical
+  invocation, in a repository that had not changed (#210). Warm walk now 0.16 s;
+  the canonical M2 battery went 15.63 s → **8.57 s** median with byte-identical
   selection on all six prompts and byte-identical `rank_mine_eval` on all three
   flagships.
   - **The cost is the pattern matching, not the filesystem, and that decides the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,6 +719,80 @@
   `test_every_chunk_query_compiles` /
   `test_every_edge_query_compiles` prove compilation ONLY, so a new query still
   needs its own behavioural assertion.
+- Persistent eligibility walk (`index/walk_cache.py`, `eligibility.DirectoryListing`).
+  The #208 walk is **kept on disk too**, in the same `.neo/`, because once the
+  content index stopped rebuilding it became the largest single item in a warm
+  call: 4.64 s on m365dotnet to re-derive that 9,348 files are eligible, on every
+  invocation, in a repository that had not changed (#210). Warm walk now 0.2 s;
+  the canonical M2 battery went 15.63 s → **9.47 s** median with byte-identical
+  selection on all six prompts and byte-identical `rank_mine_eval` on all three
+  flagships.
+  - **The cost is the pattern matching, not the filesystem, and that decides the
+    whole design.** Measured before the cache existed: listing the 951 surviving
+    directories 0.11 s, `should_ignore` over their 11,219 entries **6.7 s**,
+    `stat` over all 9,378 admitted files 0.10 s. Caching the syscalls would have
+    saved nothing. So what is stored per directory is the VERDICTS — which
+    subdirectories survive, which filenames survive, and the exclusion counts —
+    and the directory's mtime is what says whether they still hold.
+  - **Directory mtime is the right key for exactly one reason**: on every POSIX
+    filesystem it moves when an entry is created, deleted or renamed inside that
+    directory, and does NOT move when the content of a file inside it changes.
+    An edit can change what a file SAYS; it can never change whether it is
+    eligible.
+  - **Sizes and mtimes are never remembered.** They come fresh from the `stat`
+    the walk owes its callers anyway (0.10 s), because the content index uses
+    them as ITS freshness stamp — serving a remembered mtime would make an
+    edited file look unedited and turn one cache's staleness into another's.
+    `TestStampsAreNeverCached` pins it, mutation-verified.
+  - **A `.gitignore` edit invalidates by CONTENT, not by any timestamp.** No
+    directory's mtime moves when a pattern file is edited, so every stored
+    verdict looks current while every one of them may now be wrong. The
+    signature hashes the effective pattern list (shared defaults + the repo's own
+    `.gitignore`/`.ignore`), plus a `MATCHER_VERSION` for the case the patterns
+    are identical and `should_ignore` is not. Cost of an edit: one full walk,
+    then warm again.
+  - **`os.walk(followlinks=False)` had been doing work no one had named.** The
+    traversal now recurses by hand, one directory at a time, so that flag
+    protects only the single read it is passed — a link to an ancestor became an
+    infinite descent and a link to `/` walked the machine. The refusal to
+    descend into a symlinked DIRECTORY is restated explicitly and is not gated by
+    `skip_symlinks`, which is about whether a symlinked FILE is delivered.
+  - **A directory modified within `RACY_WINDOW_NS` (1 s) of being read is not
+    trusted.** Timestamp granularity is not always finer than the interval
+    between two events — HFS+ stamps whole seconds — so a directory read at E
+    with mtime M can be modified afterwards into the same bucket whenever
+    `E - M` is under one tick. Git carries the same guard under the name "racily
+    clean". Its test had to pre-create `.neo/` to mean anything: writing the
+    cache creates that directory, which moves the repository ROOT's mtime, so
+    the call after a first-ever call re-lists the root whatever the guard does —
+    the first cut of that test passed with the guard deleted.
+  - **`extra_ignores` is never served from a cache and never writes one.** A
+    caller's patterns are appended after the repo's own and gitignore is
+    last-match-wins, so a `!negation` there can re-include what a stored verdict
+    excluded — the stored verdict is not a stale answer, it is an answer to a
+    different question. Nothing in Neo takes that path today (`--exclude` is
+    applied after the walk); the guard exists so a future caller gets a correct
+    answer rather than a fast wrong one. Reported as mode `bypassed`.
+  - **JSON, not SQLite — the opposite conclusion from the same question.** Every
+    directory is validated on every call, so the file is read whole every time,
+    which is what JSON is for and what the semantic catalog beside it already
+    uses. 507 KB and ~10 ms for m365dotnet. The neighbouring content index went
+    to SQLite because a query touches ten terms of a few hundred thousand; the
+    access shape decides, not the size.
+  - The verdicts are the IGNORE layer only, so one cache serves every consumer:
+    `--exts` / `match_globs` / `max_file_bytes` / `skip_symlinks` are applied on
+    top, per call. `--index` and `architecture_metrics.compute` (which runs on
+    the outcome-detection path of every real invocation) go through the same
+    cache, so `--index` warms the walk as well as the catalog.
+  - Degradations are loud and none is fatal: a corrupt, truncated, malformed or
+    foreign-signature cache is discarded with a warning and the walk runs in
+    full; an unwritable `.neo/` costs a warning and nothing else. A malformed
+    ENTRY discards the whole file rather than the entry, because half a cache is
+    half a repository, silently. `--dry-run` names which of cold / rebuilt /
+    incremental (N of M directories) / warm / bypassed happened, in the
+    selected-files block and in the `--json` payload's `walk_cache` key. A cold
+    walk announces itself BEFORE it starts, since a first call on a large
+    repository is seconds of otherwise-silent work.
 - Persistent content index (`index/content_index.py`, `index/freshness.py`). The
   BM25 corpus above is **built once and kept on disk**, in the repository's own
   `.neo/` beside the semantic catalog, not re-derived per call. Rebuilding it per

--- a/docs/goal7-walk-cache-measurements-2026-08-13.md
+++ b/docs/goal7-walk-cache-measurements-2026-08-13.md
@@ -46,14 +46,15 @@ cost is the ignore-pattern matching; the filesystem is nearly free.
 | arm | time | what it did |
 |---|---|---|
 | raw `os.walk`, no ignore logic, no pruning | 10.394 s | 30,839 dirs / 307,115 files |
-| `os.walk` + directory pruning only, no per-file test | **0.801 s** | 951 directories visited, 11,109 entries |
+| `os.walk` + directory pruning only, no per-file test | **0.801 s** | 951 directories visited |
 | full `eligibility.walk` as shipped | **6.853 s** | 9,378 admitted, 109 dirs + 763 files excluded |
 | `os.stat` over exactly the 9,378 admitted files | **0.102 s** | — |
 
 The second and third rows do the same traversal; the only difference is testing each
-FILE entry against the pattern set. That is **6.05 s of a 6.85 s walk**, and the
-`stat` a cache cannot avoid is 0.102 s. So a cache of directory listings would have
-saved almost nothing, and a cache of verdicts saves almost everything.
+FILE entry against the pattern set (11,219 `should_ignore` calls, counted by
+`cProfile` on the same run). That is **6.05 s of a 6.85 s walk**, and the `stat` a
+cache cannot avoid is 0.102 s. So a cache of directory listings would have saved
+almost nothing, and a cache of verdicts saves almost everything.
 
 It also settles what must NOT be cached: file sizes and mtimes cost 0.1 s to read
 fresh and are the content index's own freshness stamp, so they are read on every walk.

--- a/docs/goal7-walk-cache-measurements-2026-08-13.md
+++ b/docs/goal7-walk-cache-measurements-2026-08-13.md
@@ -1,0 +1,274 @@
+# Goal 7 — auto-freshness / persistent eligibility walk: measurements
+
+**Measured:** 2026-08-13
+**Goal:** Unified Store Plan, Goal 7 (Auto-freshness) — see `docs/unified-store-plan.md`
+**Closes:** #210
+**Arms:** `main` = `9b0c16d63cfc` (post-#208) · `base` = `260e56c` (PR #209 head, the
+tree this branch is built on) · `branch` = `cc7d98c1eeb9`
+**Companions:** `docs/goal6-content-index-measurements-2026-08-12.md` (Goal 6) and
+`docs/eval-baselines-2026-08.md` (Goal 1), whose M2 battery and mining parameters are
+canonical and unchanged here.
+
+Every number below was produced by running the command printed beside it. Nothing is
+estimated, projected or interpolated. `<platform-root>` is the checkout holding the
+child repos.
+
+**Three arms rather than two, because #209 is open and unmerged.** `base` is the tree
+this branch was cut from, so `base → branch` is the delta this goal owns; `main` is
+carried so the absolute number is comparable with the Goal 1 and Goal 6 tables.
+
+---
+
+## Headline
+
+| Metric | main | base (#209) | branch | Target | Verdict |
+|---|---|---|---|---|---|
+| **M2** warm median wall, m365dotnet | 52.20 s | 15.63 s | **9.47 s** | ≤ 5 s | **not met including the memory system; met excluding it** — see the profile |
+| **M2** peak RSS, m365dotnet | 1.98 GB | 1.45 GB | **1.45 GB** | ≤ 500 MB | not met — 1.26 GB of it is the FactStore (#211) |
+| **eligibility walk**, warm, m365dotnet | 4.6–6.9 s | 4.6–6.9 s | **0.16 s** | — | the item this goal owns |
+| **M3** walk + index refresh, 10 files edited | n/a | 0.79 s | **0.78 s** | ≤ 5 s | **met** |
+| **M3** walk + index refresh, 10 files added | n/a | n/a | **1.05 s** | ≤ 5 s | **met** |
+| **M1** MRR, three flagships | 0.712 / 0.728 / 0.906 | — | **identical** | no regression | **met** |
+| **G1-inv** ignored / duplicate selections | 0 / 0 | 0 / 0 | **0 / 0** | 0 | **met** |
+| cold walk, first call in a repository | n/a | n/a | 0.36 / 0.96 / **5.3 s** | bounded + announced | **met** |
+
+---
+
+## Why a cache of *verdicts* and not of anything else
+
+The design follows from one measurement, taken before any of this existed. The walk's
+cost is the ignore-pattern matching; the filesystem is nearly free.
+
+```bash
+<branch>/.venv/bin/python /tmp/g7_profile_walk.py <platform-root>/m365dotnet
+```
+
+| arm | time | what it did |
+|---|---|---|
+| raw `os.walk`, no ignore logic, no pruning | 10.394 s | 30,839 dirs / 307,115 files |
+| `os.walk` + directory pruning only, no per-file test | **0.801 s** | 951 directories visited, 11,109 entries |
+| full `eligibility.walk` as shipped | **6.853 s** | 9,378 admitted, 109 dirs + 763 files excluded |
+| `os.stat` over exactly the 9,378 admitted files | **0.102 s** | — |
+
+The second and third rows do the same traversal; the only difference is testing each
+FILE entry against the pattern set. That is **6.05 s of a 6.85 s walk**, and the
+`stat` a cache cannot avoid is 0.102 s. So a cache of directory listings would have
+saved almost nothing, and a cache of verdicts saves almost everything.
+
+It also settles what must NOT be cached: file sizes and mtimes cost 0.1 s to read
+fresh and are the content index's own freshness stamp, so they are read on every walk.
+
+---
+
+## M2 — warm call on m365dotnet
+
+```bash
+NEO_OBSERVER_AUTOSTART=0 RUNS=3 tools/m2_battery.sh \
+  <arm>/.venv/bin/neo <platform-root>/m365dotnet /tmp/g7_m2_<arm>
+```
+
+| id | shape | main | base (#209) | **branch** |
+|---|---|---|---|---|
+| P1 | file-named | 58.25 s | 15.91 s | **10.31 s** |
+| P2 | file-named | 50.95 s | 15.63 s | **10.05 s** |
+| P3 | concept-only | 49.58 s | 15.23 s | **9.35 s** |
+| P4 | concept-only | 51.45 s | 15.53 s | **9.73 s** |
+| P5 | mixed | 53.14 s | 15.60 s | **8.73 s** |
+| P6 | symptom | 52.96 s | 16.17 s | **9.40 s** |
+| **BATTERY median** | | **52.20 s** | **15.63 s** | **9.47 s** |
+| **BATTERY peak RSS** | | 1893.0 MiB | 1386.8 MiB | 1385.2 MiB |
+
+**Disclosed measurement condition:** the `main` arm ran at `RUNS=1` (n=1 per prompt,
+so min = median = max), the other two at the canonical `RUNS=3`. A 3-run `main` arm is
+~16 minutes of wall clock and this harness caps a single foreground command at 10
+minutes. The n=1 number is consistent with Goal 6's independently measured 53.47 s
+median for the same arm on the same machine and repository, which is why it is quoted
+rather than dropped — but it is one sample and should be read as one.
+
+`base` → `branch` is **6.16 s of median wall removed**, which is the eligibility walk
+and nothing else.
+
+### Where the remaining 9.47 s goes
+
+Real CLI invocation with timers wrapped around the stage functions — no profiler, so
+the parts sum to a wall-clock a stopwatch would agree with:
+
+```bash
+<branch>/.venv/bin/python /tmp/g7_cli_stage_profile.py <platform-root>/m365dotnet
+```
+
+```
+T imports                                  1.43s
+T eligibility walk                         0.14s  (1 call)   <- 4.64s in #209's profile
+T content index refresh                    0.12s  (1 call)
+T content index scores                     0.11s  (1 call)
+T project index boost                      0.07s  (1 call)
+T fact store history boost                 2.30s  (1 call)
+T fact store retrieve (memory layer)       1.79s  (1 call)
+T   of which fastembed model load          3.22s  (2 calls, inside the two above)
+T GATHER TOTAL                             3.57s  (1 call)
+T WALL TOTAL                               8.52s   peak rss = 1381 MB
+```
+
+**File selection is 0.44 s of it.** The walk, the content index and the project index
+together cost less than half a second on a 9,348-file repository.
+
+**Against the ≤ 5 s target, exactly as the goal brief asks it to be reported.**
+Excluding the memory system — `_history_boost` (2.30 s) and the engine's own fact
+retrieval (1.79 s), which between them carry both fastembed model loads and all
+1.26 GB of the RSS — the warm call is **4.43 s, under the 5 s target**. Including
+them it is 8.52 s. Neither number is presented as the other. The memory system is
+issue #211 and explicitly out of this goal's scope; nothing here touches it.
+
+(The instrumented run's 8.52 s and the battery's 9.47 s median differ by process
+start-up and printing the assembled prompt, which the battery pays and the profile
+does not.)
+
+---
+
+## M3 — freshness cost, and staleness correctness, on the live repository
+
+One script, three scenarios, each timing the FULL pipeline an invocation pays — the
+eligibility walk plus the content index refresh — and then asserting the answer
+actually changed. A unique token is written into the touched files and searched for
+through the index; the same search after the restore must find nothing.
+
+```bash
+NEO_OBSERVER_AUTOSTART=0 <branch>/.venv/bin/python /tmp/g7_m3.py \
+  <platform-root>/m365dotnet
+```
+
+```
+baseline (settled)     walk= 0.18s [warm, 0/951 re-listed]  refresh= 0.13s [warm]                  TOTAL= 0.31s  files=9348
+A: 10 files edited     walk= 0.18s [warm, 0/951 re-listed]  refresh= 0.60s [incremental, chg=10]   TOTAL= 0.78s  files=9348
+   -> marker findable in 10 file(s)
+A: restored            walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.52s [incremental, chg=10]   TOTAL= 0.68s  files=9348
+   -> marker findable in 0 file(s)
+B: 10 files added      walk= 0.63s [incremental, 1/951]     refresh= 0.42s [incremental, add=10]   TOTAL= 1.05s  files=9358
+   -> marker findable in 10 file(s): src/NeoGoal7Probe0.cs …
+B: removed again       walk= 0.24s [incremental, 1/951]     refresh= 0.42s [incremental, rm=10]    TOTAL= 0.66s  files=9348
+   -> marker findable in 0 file(s)
+C: one file gitignored walk= 6.17s [rebuilt]   files=9347   still eligible: False
+C: gitignore restored  walk= 5.29s [rebuilt]   files=9348   back: True
+
+git status --porcelain identical before/after: True
+```
+
+Read the three scenarios as the three shapes of change, because they exercise three
+different mechanisms:
+
+- **A — an edit does not move any directory's mtime**, so the walk stays warm and
+  re-lists nothing, and the file's new size and mtime are still read fresh. That is
+  the cross-cache invariant: the content index sees the edit (`changed=10`) *through*
+  a fully reused set of directory listings. Had the stamps been cached, this line
+  would read `warm, 0 changed` and the index would answer with text the file no
+  longer holds.
+- **B — an add or a delete moves exactly one directory's mtime**, so one of 951
+  directories is re-listed and the other 950 are not.
+- **C — a `.gitignore` edit moves no mtime at all.** Every stored verdict looks
+  current and every one of them may now be wrong, so the signature (a hash of the
+  effective pattern list) discards the cache and the walk runs in full: 6.17 s once,
+  then warm again. The newly-ignored file leaves the corpus on the next call and
+  comes back when the pattern is removed.
+
+**Both M3 shapes are met: 0.78 s and 1.05 s against ≤ 5 s.** The live tree was
+restored byte-for-byte; `git status --porcelain` is identical before and after.
+
+---
+
+## M1 — retrieval quality: identical, on all three flagships
+
+Persisting the walk must not re-rank, and it does not.
+
+```bash
+<branch>/.venv/bin/python <branch>/tools/rank_mine_eval.py \
+  --repo <platform-root>/$repo --tree <arm> --json
+```
+
+| repo | arm | cases | MRR | R@1 | R@3 | R@10 | H@10 |
+|---|---|---|---|---|---|---|---|
+| neo | main | 50 | 0.712 | 0.307 | 0.502 | 0.708 | 0.980 |
+| neo | **branch** | 50 | **0.712** | **0.307** | **0.502** | **0.708** | **0.980** |
+| aieweb | main | 50 | 0.728 | 0.487 | 0.654 | 0.778 | 0.880 |
+| aieweb | **branch** | 50 | **0.728** | **0.487** | **0.654** | **0.778** | **0.880** |
+| m365dotnet | main | 8 | 0.906 | 0.583 | 0.729 | 0.958 | 1.000 |
+| m365dotnet | **branch** | 8 | **0.906** | **0.583** | **0.729** | **0.958** | **1.000** |
+
+Byte-identical in every cell. Repo HEADs at measurement: neo `5bbee46747c8`, aieweb
+`26fff07e0f4a`, m365dotnet `61dc4a171bdf`. Zero failed cases on every arm, `--no-git`
+(the default).
+
+**Disclosed: m365dotnet ran 8 cases, not 50.** Its `main` arm costs ~52 s per case, so
+50 cases is ~40 minutes in one foreground command against this harness's 10-minute cap.
+The absolute MRR is therefore not comparable with Goal 6's 50-case 0.669 for that repo
+— only the two arms of the same 8 cases are comparable with each other, which is what
+this table claims. The stronger m365dotnet statement is the battery one below.
+
+**Stronger than the MRR table, and the one to quote:** all six canonical M2 prompts
+selected **the same files in the same rank order** on all three arms, compared as
+text — 18 comparisons, no output.
+
+```bash
+for p in P1 P2 P3 P4 P5 P6; do
+  diff /tmp/g7_m2_base/${p}_run1.files /tmp/g7_m2_branch/${p}_run1.files
+done
+diff /tmp/g7_m2_main/union.files /tmp/g7_m2_base/union.files
+diff /tmp/g7_m2_base/union.files /tmp/g7_m2_branch/union.files
+```
+
+---
+
+## G1-inv — the walker's verdict is not widened by caching it
+
+The battery union, checked against `git check-ignore` in the target repository.
+
+| label | distinct | `git check-ignore` excludes | duplicate content copies | inside `.worktrees/` | unresolvable |
+|---|---|---|---|---|---|
+| **BATTERY UNION**, main | 111 | 0 | 0 | 0 | 0 |
+| **BATTERY UNION**, base | 111 | 0 | 0 | 0 | 0 |
+| **BATTERY UNION**, branch | **111** | **0** | **0** | **0** | **0** |
+
+The three union files are byte-identical, which is the point: a cache of the walker's
+verdicts cannot widen them.
+
+---
+
+## Cold cost — what a fresh clone's first call pays, once
+
+```bash
+<branch>/.venv/bin/python -c "…cached_walk three times, timing each…" <repo>
+```
+
+| repo | files | directories | uncached walk | first call (cold) | second call | cache on disk |
+|---|---|---|---|---|---|---|
+| neo | 285 | 43 | 0.41 s | 0.36 s | **0.01 s** (warm) | 15 KB |
+| aieweb | 902 | 221 | 1.05 s | 0.96 s | **0.06 s** (warm) | 64 KB |
+| m365dotnet | 9,348 | 951 | 6.85 s | 5.3 s | **0.16 s** (warm) | 507 KB |
+
+The first call in a repository announces the walk before it starts, for the same
+reason the content index announces its cold build: seconds of silence are
+indistinguishable from a hang. `neo --index` warms this cache as well as the semantic
+catalog, so it remains an optional way to pay the cost deliberately — but it is
+optional, because any invocation pays it once and every later one is warm.
+
+The warm 0.16 s on m365dotnet is three things and nothing else: 951 directory `stat`s,
+9,378 file `stat`s (0.102 s measured on its own, above) and a 507 KB JSON parse. No
+directory is listed and no path is matched against a pattern.
+
+---
+
+## What is NOT claimed
+
+- **The 500 MB M2 target is still not met and is still not reachable from file
+  selection.** 1.26 GB of the 1.38 GB peak arrives in `_history_boost`, loading the
+  FactStore. Goal 6 established this; nothing here changes it. Issue #211.
+- **The ≤ 5 s M2 target is met only excluding the memory system.** Stated in both
+  forms above rather than in the flattering one.
+- **The `main` arm of M2 is n=1 and the m365dotnet M1 arms are 8 cases**, both for the
+  same reason (a 10-minute foreground cap), both disclosed at the table rather than in
+  a footnote.
+- **A `.gitignore` edit costs a full walk.** Measured at 6.17 s on m365dotnet. The
+  alternative — deriving which directories a pattern edit could have affected — is a
+  large amount of machinery guarding a cost paid when someone edits a `.gitignore`.
+- **Two clones of one repository do not share a cache.** It lives in each working
+  tree's own `.neo/`, because it is keyed on that tree's directory mtimes.

--- a/docs/goal7-walk-cache-measurements-2026-08-13.md
+++ b/docs/goal7-walk-cache-measurements-2026-08-13.md
@@ -4,7 +4,8 @@
 **Goal:** Unified Store Plan, Goal 7 (Auto-freshness) — see `docs/unified-store-plan.md`
 **Closes:** #210
 **Arms:** `main` = `9b0c16d63cfc` (post-#208) · `base` = `260e56c` (PR #209 head, the
-tree this branch is built on) · `branch` = `cc7d98c1eeb9`
+tree this branch is built on) · `branch` = `0db7695fc003` (HEAD), with the earlier
+`cc7d98c1eeb9` kept where it was measured and labelled as such
 **Companions:** `docs/goal6-content-index-measurements-2026-08-12.md` (Goal 6) and
 `docs/eval-baselines-2026-08.md` (Goal 1), whose M2 battery and mining parameters are
 canonical and unchanged here.
@@ -23,11 +24,11 @@ carried so the absolute number is comparable with the Goal 1 and Goal 6 tables.
 
 | Metric | main | base (#209) | branch | Target | Verdict |
 |---|---|---|---|---|---|
-| **M2** warm median wall, m365dotnet | 52.20 s | 15.63 s | **9.47 s** | ≤ 5 s | **not met including the memory system; met excluding it** — see the profile |
+| **M2** warm median wall, m365dotnet | 52.20 s | 15.63 s | **8.57 s** | ≤ 5 s | **not met including the memory system; met excluding it** — see the profile |
 | **M2** peak RSS, m365dotnet | 1.98 GB | 1.45 GB | **1.45 GB** | ≤ 500 MB | not met — 1.26 GB of it is the FactStore (#211) |
 | **eligibility walk**, warm, m365dotnet | 4.6–6.9 s | 4.6–6.9 s | **0.16 s** | — | the item this goal owns |
-| **M3** walk + index refresh, 10 files edited | n/a | 0.79 s | **0.78 s** | ≤ 5 s | **met** |
-| **M3** walk + index refresh, 10 files added | n/a | n/a | **1.05 s** | ≤ 5 s | **met** |
+| **M3** walk + index refresh, 10 files edited | n/a | 0.79 s | **0.84 s** | ≤ 5 s | **met** |
+| **M3** walk + index refresh, 10 files added | n/a | n/a | **0.75 s** | ≤ 5 s | **met** |
 | **M1** MRR, three flagships | 0.712 / 0.728 / 0.906 | — | **identical** | no regression | **met** |
 | **G1-inv** ignored / duplicate selections | 0 / 0 | 0 / 0 | **0 / 0** | 0 | **met** |
 | cold walk, first call in a repository | n/a | n/a | 0.36 / 0.96 / **5.3 s** | bounded + announced | **met** |
@@ -68,28 +69,37 @@ NEO_OBSERVER_AUTOSTART=0 RUNS=3 tools/m2_battery.sh \
   <arm>/.venv/bin/neo <platform-root>/m365dotnet /tmp/g7_m2_<arm>
 ```
 
-| id | shape | main | base (#209) | **branch** |
-|---|---|---|---|---|
-| P1 | file-named | 58.25 s | 15.91 s | **10.31 s** |
-| P2 | file-named | 50.95 s | 15.63 s | **10.05 s** |
-| P3 | concept-only | 49.58 s | 15.23 s | **9.35 s** |
-| P4 | concept-only | 51.45 s | 15.53 s | **9.73 s** |
-| P5 | mixed | 53.14 s | 15.60 s | **8.73 s** |
-| P6 | symptom | 52.96 s | 16.17 s | **9.40 s** |
-| **BATTERY median** | | **52.20 s** | **15.63 s** | **9.47 s** |
-| **BATTERY peak RSS** | | 1893.0 MiB | 1386.8 MiB | 1385.2 MiB |
+| id | shape | main | base (#209) | branch @ `cc7d98c` | **branch @ HEAD** |
+|---|---|---|---|---|---|
+| P1 | file-named | 58.25 s | 15.91 s | 10.31 s | **8.86 s** |
+| P2 | file-named | 50.95 s | 15.63 s | 10.05 s | **8.69 s** |
+| P3 | concept-only | 49.58 s | 15.23 s | 9.35 s | **8.07 s** |
+| P4 | concept-only | 51.45 s | 15.53 s | 9.73 s | **8.37 s** |
+| P5 | mixed | 53.14 s | 15.60 s | 8.73 s | **8.41 s** |
+| P6 | symptom | 52.96 s | 16.17 s | 9.40 s | **9.11 s** |
+| **BATTERY median** | | **52.20 s** | **15.63 s** | 9.47 s | **8.57 s** |
+| **BATTERY peak RSS** | | 1893.0 MiB | 1386.8 MiB | 1385.2 MiB | 1387.2 MiB |
 
-**Disclosed measurement condition:** the `main` arm ran at `RUNS=1` (n=1 per prompt,
-so min = median = max), the other two at the canonical `RUNS=3`. A 3-run `main` arm is
-~16 minutes of wall clock and this harness caps a single foreground command at 10
-minutes. The n=1 number is consistent with Goal 6's independently measured 53.47 s
-median for the same arm on the same machine and repository, which is why it is quoted
-rather than dropped — but it is one sample and should be read as one.
+**Three disclosed measurement conditions, at the table rather than in a footnote:**
 
-`base` → `branch` is **6.16 s of median wall removed**, which is the eligibility walk
+1. The `main` arm ran at `RUNS=1` (n=1 per prompt, so min = median = max); the others
+   at the canonical `RUNS=3`. A 3-run `main` arm is ~16 minutes of wall clock and this
+   harness caps a single foreground command at 10 minutes. The n=1 number is
+   consistent with Goal 6's independently measured 53.47 s median for the same arm on
+   the same machine and repository, which is why it is quoted rather than dropped —
+   but it is one sample and should be read as one.
+2. The branch is measured TWICE because a fresh-verifier pass landed changes after the
+   first run, and this doc claims every number is reproducible from the sha beside it.
+   Both runs are kept.
+3. This is a shared developer laptop and its load varied across the session (a load
+   average of 28 was observed near the end). The two branch columns differ by 0.9 s
+   with no change to file selection between them, which is the size of that noise. The
+   `main` → `branch` conclusion is 6× and survives it; a 0.9 s reading does not.
+
+`base` → `branch` is **7.06 s of median wall removed**, which is the eligibility walk
 and nothing else.
 
-### Where the remaining 9.47 s goes
+### Where the remaining 8.57 s goes
 
 Real CLI invocation with timers wrapped around the stage functions — no profiler, so
 the parts sum to a wall-clock a stopwatch would agree with:
@@ -99,29 +109,29 @@ the parts sum to a wall-clock a stopwatch would agree with:
 ```
 
 ```
-T imports                                  1.43s
-T eligibility walk                         0.14s  (1 call)   <- 4.64s in #209's profile
-T content index refresh                    0.12s  (1 call)
-T content index scores                     0.11s  (1 call)
-T project index boost                      0.07s  (1 call)
-T fact store history boost                 2.30s  (1 call)
-T fact store retrieve (memory layer)       1.79s  (1 call)
-T   of which fastembed model load          3.22s  (2 calls, inside the two above)
-T GATHER TOTAL                             3.57s  (1 call)
-T WALL TOTAL                               8.52s   peak rss = 1381 MB
+T imports                                  1.24s
+T eligibility walk                         0.16s  (1 call)   <- 4.64s in #209's profile
+T content index refresh                    0.11s  (1 call)
+T content index scores                     0.12s  (1 call)
+T project index boost                      0.10s  (1 call)
+T fact store history boost                 2.25s  (1 call)
+T fact store retrieve (memory layer)       1.65s  (1 call)
+T   of which fastembed model load          2.73s  (2 calls, inside the two above)
+T GATHER TOTAL                             3.55s  (1 call)
+T WALL TOTAL                               7.67s   peak rss = 1385 MB
 ```
 
-**File selection is 0.44 s of it.** The walk, the content index and the project index
-together cost less than half a second on a 9,348-file repository.
+**File selection is 0.49 s of it.** The walk, the content index and the project index
+together cost half a second on a 9,348-file repository.
 
 **Against the ≤ 5 s target, exactly as the goal brief asks it to be reported.**
-Excluding the memory system — `_history_boost` (2.30 s) and the engine's own fact
-retrieval (1.79 s), which between them carry both fastembed model loads and all
-1.26 GB of the RSS — the warm call is **4.43 s, under the 5 s target**. Including
-them it is 8.52 s. Neither number is presented as the other. The memory system is
+Excluding the memory system — `_history_boost` (2.25 s) and the engine's own fact
+retrieval (1.65 s), which between them carry both fastembed model loads and all
+1.26 GB of the RSS — the warm call is **3.77 s, under the 5 s target**. Including
+them it is 7.67 s. Neither number is presented as the other. The memory system is
 issue #211 and explicitly out of this goal's scope; nothing here touches it.
 
-(The instrumented run's 8.52 s and the battery's 9.47 s median differ by process
+(The instrumented run's 7.67 s and the battery's 8.57 s median differ by process
 start-up and printing the assembled prompt, which the battery pays and the profile
 does not.)
 
@@ -140,17 +150,17 @@ NEO_OBSERVER_AUTOSTART=0 <branch>/.venv/bin/python /tmp/g7_m3.py \
 ```
 
 ```
-baseline (settled)     walk= 0.18s [warm, 0/951 re-listed]  refresh= 0.13s [warm]                  TOTAL= 0.31s  files=9348
-A: 10 files edited     walk= 0.18s [warm, 0/951 re-listed]  refresh= 0.60s [incremental, chg=10]   TOTAL= 0.78s  files=9348
+baseline (settled)     walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.10s [warm]                  TOTAL= 0.27s  files=9348
+A: 10 files edited     walk= 0.15s [warm, 0/951 re-listed]  refresh= 0.69s [incremental, chg=10]   TOTAL= 0.84s  files=9348
    -> marker findable in 10 file(s)
-A: restored            walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.52s [incremental, chg=10]   TOTAL= 0.68s  files=9348
+A: restored            walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.51s [incremental, chg=10]   TOTAL= 0.68s  files=9348
    -> marker findable in 0 file(s)
-B: 10 files added      walk= 0.63s [incremental, 1/951]     refresh= 0.42s [incremental, add=10]   TOTAL= 1.05s  files=9358
+B: 10 files added      walk= 0.22s [incremental, 1/951]     refresh= 0.53s [incremental, add=10]   TOTAL= 0.75s  files=9358
    -> marker findable in 10 file(s): src/NeoGoal7Probe0.cs …
-B: removed again       walk= 0.24s [incremental, 1/951]     refresh= 0.42s [incremental, rm=10]    TOTAL= 0.66s  files=9348
+B: removed again       walk= 0.25s [incremental, 1/951]     refresh= 0.42s [incremental, rm=10]    TOTAL= 0.67s  files=9348
    -> marker findable in 0 file(s)
-C: one file gitignored walk= 6.17s [rebuilt]   files=9347   still eligible: False
-C: gitignore restored  walk= 5.29s [rebuilt]   files=9348   back: True
+C: one file gitignored walk= 5.67s [rebuilt]   files=9347   still eligible: False
+C: gitignore restored  walk= 5.30s [rebuilt]   files=9348   back: True
 
 git status --porcelain identical before/after: True
 ```
@@ -172,7 +182,7 @@ different mechanisms:
   then warm again. The newly-ignored file leaves the corpus on the next call and
   comes back when the pattern is removed.
 
-**Both M3 shapes are met: 0.78 s and 1.05 s against ≤ 5 s.** The live tree was
+**Both M3 shapes are met: 0.84 s and 0.75 s against ≤ 5 s.** The live tree was
 restored byte-for-byte; `git status --porcelain` is identical before and after.
 
 ---
@@ -199,6 +209,16 @@ Byte-identical in every cell. Repo HEADs at measurement: neo `5bbee46747c8`, aie
 `26fff07e0f4a`, m365dotnet `61dc4a171bdf`. Zero failed cases on every arm, `--no-git`
 (the default).
 
+**Disclosed: the branch arms of this table ran at `cc7d98c`, not at HEAD.** A re-run
+at HEAD needs ~10 minutes per arm on a machine that reached a load average of 28
+during this session, and two attempts hit the harness's 10-minute foreground cap. What
+carries the claim to HEAD instead is direct rather than statistical: the M2 battery was
+re-run at HEAD and its six per-prompt selected-file lists and its union are
+**byte-identical to the `cc7d98c` run and to `base`**. The commits between the two
+shas change only cache VALIDITY (the ctime key, the empty-cache rejection, which walk
+becomes `last_report()`); none of them can reach the ranker, and the battery measures
+that they did not.
+
 **Disclosed: m365dotnet ran 8 cases, not 50.** Its `main` arm costs ~52 s per case, so
 50 cases is ~40 minutes in one foreground command against this harness's 10-minute cap.
 The absolute MRR is therefore not comparable with Goal 6's 50-case 0.669 for that repo
@@ -211,10 +231,12 @@ text — 18 comparisons, no output.
 
 ```bash
 for p in P1 P2 P3 P4 P5 P6; do
-  diff /tmp/g7_m2_base/${p}_run1.files /tmp/g7_m2_branch/${p}_run1.files
+  diff /tmp/g7_m2_base/${p}_run1.files /tmp/g7_m2_branch/${p}_run1.files    # cc7d98c
+  diff /tmp/g7_m2_base/${p}_run1.files /tmp/g7_m2_branch2/${p}_run1.files   # HEAD
 done
 diff /tmp/g7_m2_main/union.files /tmp/g7_m2_base/union.files
 diff /tmp/g7_m2_base/union.files /tmp/g7_m2_branch/union.files
+diff /tmp/g7_m2_branch/union.files /tmp/g7_m2_branch2/union.files
 ```
 
 ---
@@ -265,9 +287,13 @@ directory is listed and no path is matched against a pattern.
   FactStore. Goal 6 established this; nothing here changes it. Issue #211.
 - **The ≤ 5 s M2 target is met only excluding the memory system.** Stated in both
   forms above rather than in the flattering one.
-- **The `main` arm of M2 is n=1 and the m365dotnet M1 arms are 8 cases**, both for the
-  same reason (a 10-minute foreground cap), both disclosed at the table rather than in
-  a footnote.
+- **The `main` arm of M2 is n=1, the m365dotnet M1 arms are 8 cases, and the M1 branch
+  arms were measured two commits before HEAD** — all three for the same reason (a
+  10-minute foreground cap on a loaded shared laptop), all three disclosed at their
+  table rather than in a footnote.
+- **A directory whose mtime AND ctime are both restored would still be trusted.** The
+  ctime is what closes `touch -r` / `tar -x` / snapshot restores, and nothing in a
+  normal userland can rewrite it; a filesystem image edited offline could.
 - **A `.gitignore` edit costs a full walk.** Measured at 6.17 s on m365dotnet. The
   alternative — deriving which directories a pattern edit could have affected — is a
   large amount of machinery guarding a cost paid when someone edits a `.gitignore`.

--- a/src/neo/architecture_metrics.py
+++ b/src/neo/architecture_metrics.py
@@ -32,7 +32,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable, Literal, Optional
 
-from neo.eligibility import walk_paths
+from neo.eligibility import WalkPolicy, normalize_exts
 from neo.index.language_parser import QUERIES, TreeSitterParser
 from neo.languages import EXTENSION_TO_LANGUAGE
 
@@ -259,7 +259,14 @@ def _iter_source_files(root: Path) -> Iterable[Path]:
     # Extension matching is exact and case-insensitive: `name.endswith(".c")`
     # would also match `foo.bc`, which is not a C file.
     wanted = {".py", *extras}
-    for entry in walk_paths(str(root), exts=wanted).paths:
+    # Through the cache, because this runs on the outcome-detection path of
+    # every real invocation, not only on `--index`. The cache stores ignore
+    # verdicts, which are policy-independent, so this share the one the
+    # gatherer built and pays no walk of its own on a warm repository.
+    from neo.index.walk_cache import cached_walk
+
+    policy = WalkPolicy(exts=normalize_exts(wanted))
+    for entry in cached_walk(str(root), policy).paths:
         yield Path(entry.path)
 
 

--- a/src/neo/architecture_metrics.py
+++ b/src/neo/architecture_metrics.py
@@ -266,7 +266,11 @@ def _iter_source_files(root: Path) -> Iterable[Path]:
     from neo.index.walk_cache import cached_walk
 
     policy = WalkPolicy(exts=normalize_exts(wanted))
-    for entry in cached_walk(str(root), policy).paths:
+    # `record=False` / `quiet=True`: this is a secondary, extension-filtered
+    # walk running after the answer is assembled. It must not narrate over the
+    # result, and it must not become the walk `--dry-run` reports — that one is
+    # the corpus walk, and this one's file count is a subset of it.
+    for entry in cached_walk(str(root), policy, quiet=True, record=False).paths:
         yield Path(entry.path)
 
 

--- a/src/neo/cli.py
+++ b/src/neo/cli.py
@@ -748,12 +748,18 @@ def _report_dry_run(args, calls) -> None:
                 "remaps roles, Ollama flattens, CAR adds intent_json)"
             ),
         }
-        # `--json` implies `--quiet`, so the stderr note the content index
-        # emits is suppressed on exactly the path a machine consumer reads.
-        # It is a fact about what the run cost and it belongs in the report.
-        report = _content_index_report()
-        if report is not None:
-            payload["content_index"] = report
+        # `--json` implies `--quiet`, so the stderr notes the walk cache and
+        # the content index emit are suppressed on exactly the path a machine
+        # consumer reads. They are facts about what the run cost and they
+        # belong in the report. Both keys, because the two caches fail
+        # independently: a warm index behind a cold walk and a warm walk behind
+        # a rebuilt index are different diagnoses.
+        for key, report in (
+            ("walk_cache", _walk_cache_report()),
+            ("content_index", _content_index_report()),
+        ):
+            if report is not None:
+                payload[key] = report
         print(json.dumps(payload, indent=2))
         _emit_dry_run_terminal_event()
     else:
@@ -770,6 +776,21 @@ def _content_index_report():
     """
     try:
         from neo.index.content_index import last_report
+    except ImportError:  # pragma: no cover - the module ships with neo
+        return None
+    report = last_report()
+    return report.to_dict() if report is not None else None
+
+
+def _walk_cache_report():
+    """This process's eligibility-walk report, or None if no walk ran.
+
+    Absent for the same reason as the index report above: `--no-scan` and a
+    caller that supplied its own files never walk, and an empty report would
+    read as "the walk ran and found nothing".
+    """
+    try:
+        from neo.index.walk_cache import last_report
     except ImportError:  # pragma: no cover - the module ships with neo
         return None
     report = last_report()
@@ -817,10 +838,17 @@ def _print_selected_files(gathered) -> None:
     # update or a warm read is the difference between a 60-second call and a
     # 2-second one, and it is invisible from the file list. Printed inside the
     # block rather than left to the progress note so it cannot drift away from
-    # the selection it describes.
-    report = _content_index_report()
-    if report is not None:
-        print(f"  [{report['summary']}]\n", file=sys.stderr)
+    # the selection it describes. In pipeline order — which files exist, then
+    # what they say — so the two lines read as the two stages they are.
+    summaries = [
+        report["summary"]
+        for report in (_walk_cache_report(), _content_index_report())
+        if report is not None
+    ]
+    for summary in summaries:
+        print(f"  [{summary}]", file=sys.stderr)
+    if summaries:
+        print(file=sys.stderr)
     for gf in gathered:
         lines_info = f" (lines {gf.start}-{gf.end})" if gf.start else ""
         print(

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -149,8 +149,17 @@ def base_paths(root: str) -> list[eligibility.EligiblePath]:
     walk, the ignore rules and the gitignore matcher live in
     `neo.eligibility`, shared with the project index — there is no second copy
     here to drift.
+
+    The walk itself runs through `index.walk_cache`, which remembers each
+    directory's ignore verdicts and re-lists only the directories whose
+    contents moved. That is a cost change and never a result change: the cache
+    is keyed on a hash of the effective ignore patterns and on each directory's
+    mtime, and every failure mode degrades to the full walk.
     """
-    return eligibility.walk_paths(root, max_file_bytes=MAX_FILE_BYTES).paths
+    from neo.index.walk_cache import cached_walk
+
+    policy = eligibility.WalkPolicy(max_file_bytes=MAX_FILE_BYTES)
+    return cached_walk(root, policy).paths
 
 
 def filter_candidates(

--- a/src/neo/eligibility.py
+++ b/src/neo/eligibility.py
@@ -38,6 +38,7 @@ import hashlib
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional, Sequence
@@ -389,6 +390,79 @@ class WalkPolicy:
     skip_symlinks: bool = True
 
 
+#: How close a directory's modification time may sit to the moment its entries
+#: were read before that reading stops being trustworthy.
+#:
+#: Filesystem timestamp granularity is not always finer than the interval
+#: between two events. HFS+ stamps whole seconds; a network mount can be
+#: coarser still. So a directory read at time E, whose recorded mtime is M,
+#: can be modified afterwards and land in the SAME timestamp bucket whenever
+#: `E - M` is under one granularity tick — and the next walk then compares two
+#: equal mtimes and concludes, wrongly, that nothing was added or deleted.
+#:
+#: One second is the coarsest granularity worth defending against, and the
+#: cost of the defence is that a directory touched in the second before it was
+#: read is re-listed on the next call rather than trusted. Git carries the same
+#: guard for the same reason, under the name "racily clean".
+RACY_WINDOW_NS = 1_000_000_000
+
+
+@dataclass(frozen=True)
+class DirectoryListing:
+    """The ignore-rule verdicts for the entries of ONE directory.
+
+    This is what makes the walk cacheable. Deciding whether a path is ignored
+    means matching it against every pattern in the repository's effective
+    ignore set, and on a large repository that pattern matching — not the
+    filesystem — is the entire cost of the walk: measured on m365dotnet,
+    11,219 `should_ignore` calls take 6.7 s of a 6.9 s walk, while listing the
+    same directories costs 0.11 s and stat-ing all 9,378 admitted files costs
+    0.10 s. Caching the syscalls would save nothing; caching the verdicts
+    saves everything.
+
+    A verdict is a function of the entry's NAME and the pattern set, so it
+    stays valid for exactly as long as the directory's entry names do. On
+    every POSIX filesystem a directory's mtime moves when an entry is created,
+    removed or renamed inside it — and does NOT move when the CONTENT of a
+    file inside it changes, which is precisely the distinction wanted here: an
+    edit cannot change who is eligible, only what they say.
+
+    Three fields exist to keep that promise honest:
+
+    - `scanned_at_ns` pairs with `RACY_WINDOW_NS` above.
+    - `symlinks` is kept beside `files` rather than dropped, because
+      `WalkPolicy.skip_symlinks` is a per-consumer choice and a cache that
+      recorded only one consumer's answer would silently give the other the
+      wrong one.
+    - `excluded_dirs` / `excluded_files` are counts of what THIS directory's
+      rules rejected, so a reused listing reports the same exclusion totals a
+      fresh walk would. A cache that quietly reported zero exclusions would
+      make `--dry-run`'s G1 accounting depend on whether the last call
+      happened to be warm.
+
+    What is deliberately NOT here: sizes, mtimes and content hashes of the
+    files. Those are read fresh on every walk, from the `stat` the walk owes
+    its callers anyway, because the persistent content index next door uses
+    them as its own freshness stamp — serving it a remembered mtime would make
+    an edited file look unedited and turn one cache's staleness into another's.
+    """
+
+    mtime_ns: int
+    scanned_at_ns: int
+    subdirs: tuple[str, ...]
+    files: tuple[str, ...]
+    symlinks: tuple[str, ...] = ()
+    excluded_dirs: int = 0
+    excluded_files: int = 0
+
+    def is_current(self, mtime_ns: int) -> bool:
+        """True when this listing may be reused for a directory now at `mtime_ns`."""
+        return (
+            self.mtime_ns == mtime_ns
+            and self.mtime_ns <= self.scanned_at_ns - RACY_WINDOW_NS
+        )
+
+
 @dataclass
 class WalkResult:
     """The admitted paths plus an honest account of what was left out.
@@ -399,10 +473,18 @@ class WalkResult:
     is a deliberate trade — the previous index-side count enumerated every
     file under `.worktrees/` in order to report "200 paths excluded", which
     cost a full walk of the very trees the exclusion exists to avoid.
+
+    `listings` is the walk's own record of what it decided, ready to be
+    persisted by `index.walk_cache` and handed back on the next call.
+    `reused_dirs` / `rescanned_dirs` are how much of it survived, which is the
+    only honest basis for reporting a cache as warm.
     """
     paths: list[EligiblePath]
     excluded_dirs: int = 0
     excluded_files: int = 0
+    listings: Optional[dict[str, DirectoryListing]] = None
+    reused_dirs: int = 0
+    rescanned_dirs: int = 0
 
     @property
     def excluded(self) -> int:
@@ -410,12 +492,89 @@ class WalkResult:
         return self.excluded_dirs + self.excluded_files
 
 
-def walk(root: str, policy: Optional[WalkPolicy] = None) -> WalkResult:
+def _read_directory(
+    abs_dir: str,
+    rel_dir: str,
+    mtime_ns: int,
+    patterns: list[str],
+) -> Optional[DirectoryListing]:
+    """List one directory and apply the ignore rules to its entries.
+
+    `next(os.walk(...))` rather than `os.listdir`, and that is not a stylistic
+    preference: `os.walk` is a generator that reads one directory per step, so
+    taking only its first item costs exactly one directory read and nothing
+    below it. It also keeps every directory read in this package behind a
+    single primitive, which `tests/test_eligibility_single_source.py` enforces
+    — a second traversal spelling is how both historical copies of this logic
+    began.
+
+    A directory that cannot be read yields nothing and returns `None`, which
+    is the behaviour `os.walk` had here before: one unreadable directory costs
+    that directory, not the walk.
+    """
+    walked = next(os.walk(abs_dir, followlinks=False), None)
+    if walked is None:
+        return None
+    _, dirnames, filenames = walked
+
+    prefix = '' if not rel_dir else rel_dir + '/'
+    subdirs: list[str] = []
+    files: list[str] = []
+    symlinks: list[str] = []
+    excluded_dirs = 0
+    excluded_files = 0
+
+    for name in dirnames:
+        if should_ignore(prefix + name, patterns, is_dir=True):
+            excluded_dirs += 1
+        else:
+            subdirs.append(name)
+
+    for name in filenames:
+        if should_ignore(prefix + name, patterns):
+            excluded_files += 1
+            continue
+        # Before anything that stats the target. `os.path.getsize`,
+        # `Path.is_file` and `Path.resolve` all dereference, and the point of
+        # rejecting a symlink is to not touch what it points at. Recorded
+        # rather than dropped so that `skip_symlinks=False` still gets a true
+        # answer out of a reused listing.
+        if os.path.islink(os.path.join(abs_dir, name)):
+            symlinks.append(name)
+        else:
+            files.append(name)
+
+    # AFTER the entries are in hand, so the stamp bounds the read it describes
+    # rather than starting before it. See `RACY_WINDOW_NS`.
+    return DirectoryListing(
+        mtime_ns=mtime_ns,
+        scanned_at_ns=time.time_ns(),
+        subdirs=tuple(subdirs),
+        files=tuple(files),
+        symlinks=tuple(symlinks),
+        excluded_dirs=excluded_dirs,
+        excluded_files=excluded_files,
+    )
+
+
+def walk(
+    root: str,
+    policy: Optional[WalkPolicy] = None,
+    listings: Optional[dict[str, DirectoryListing]] = None,
+) -> WalkResult:
     """The one filesystem walk. Yields every eligible file under `root`.
 
     Ignored directories are PRUNED rather than filtered per-file, which is
     both git's semantics and the difference between a warm call and a walk of
     `node_modules`.
+
+    `listings` is the previous walk's `WalkResult.listings`, if a caller kept
+    one. A directory whose mtime still matches its listing is not read again
+    and its entries are not re-tested against the pattern set; its files are
+    still `stat`-ed, because that is where their size and mtime come from and
+    those must never be remembered (see `DirectoryListing`). Passing `None` —
+    the default, and what every caller that does not want a cache does — walks
+    exactly as before.
 
     Results are sorted by `rel_path`. Directory-entry order is whatever the
     filesystem hands back, so without this a tie anywhere downstream — two
@@ -431,47 +590,73 @@ def walk(root: str, policy: Optional[WalkPolicy] = None) -> WalkResult:
         if policy.match_globs is not None
         else None
     )
+    if policy.extra_ignores:
+        # A listing records verdicts reached under the repository's OWN ignore
+        # rules. `extra_ignores` is appended after those, and gitignore is
+        # last-match-wins, so a caller's `!negation` can re-include something
+        # the recorded verdict excluded. Reusing a listing here would not be a
+        # stale answer, it would be the wrong question — so the cache is not
+        # consulted, and `index.walk_cache` does not persist one either.
+        listings = None
 
     paths: list[EligiblePath] = []
     excluded_dirs = 0
     excluded_files = 0
+    fresh: dict[str, DirectoryListing] = {}
+    reused = 0
+    rescanned = 0
 
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        rel_dir = os.path.relpath(dirpath, root)
-        prefix = '' if rel_dir == '.' else rel_dir.replace(os.sep, '/') + '/'
+    # `(rel_dir, abs_dir)` in step, rather than joining `root` to a POSIX
+    # `rel_dir` at use time: `rel_path` is separator-normalized by contract and
+    # `path` must stay native, and deriving one from the other produces the
+    # mixed `C:\repo\src/neo` spelling on Windows.
+    pending = [('', root)]
+    while pending:
+        rel_dir, abs_dir = pending.pop()
+        try:
+            dir_mtime = os.stat(abs_dir).st_mtime_ns
+        except OSError:
+            # Removed between being listed by its parent and being reached.
+            continue
 
-        kept: list[str] = []
-        for name in dirnames:
-            if should_ignore(prefix + name, patterns, is_dir=True):
-                excluded_dirs += 1
-            else:
-                kept.append(name)
-        # In-place, because that is how `os.walk` is told not to descend.
-        dirnames[:] = kept
+        cached = listings.get(rel_dir) if listings is not None else None
+        if cached is not None and cached.is_current(dir_mtime):
+            listing = cached
+            reused += 1
+        else:
+            listing = _read_directory(abs_dir, rel_dir, dir_mtime, patterns)
+            if listing is None:
+                continue
+            rescanned += 1
 
-        for name in filenames:
+        fresh[rel_dir] = listing
+        excluded_dirs += listing.excluded_dirs
+        excluded_files += listing.excluded_files
+
+        prefix = '' if not rel_dir else rel_dir + '/'
+        for name in listing.subdirs:
+            pending.append((prefix + name, os.path.join(abs_dir, name)))
+
+        names = listing.files
+        if not policy.skip_symlinks:
+            names = names + listing.symlinks
+        elif listing.symlinks:
+            # Named, because the index used to warn here and an operator
+            # asking "why is this file not indexed?" got an answer. A policy
+            # rejection is not an ignore-rule verdict, so it is not counted
+            # into `excluded_*` — but it must not be silent.
+            for name in listing.symlinks:
+                logger.debug("Skipping symlink: %s", prefix + name)
+
+        for name in names:
             rel_path = prefix + name
-            if should_ignore(rel_path, patterns):
-                excluded_files += 1
-                continue
-
-            abs_path = os.path.join(dirpath, name)
-            # Before anything that stats the target. `os.path.getsize`,
-            # `Path.is_file` and `Path.resolve` all dereference, and the point
-            # of rejecting a symlink is to not touch what it points at.
-            if policy.skip_symlinks and os.path.islink(abs_path):
-                # Named, because the index used to warn here and an operator
-                # asking "why is this file not indexed?" got an answer. A
-                # policy rejection is not an ignore-rule verdict, so it is not
-                # counted into `excluded_*` — but it must not be silent.
-                logger.debug("Skipping symlink: %s", rel_path)
-                continue
             if globs is not None and not any(g.match(rel_path) for g in globs):
                 continue
             if policy.exts is not None:
                 ext = os.path.splitext(name)[1].lstrip('.').lower()
                 if ext not in policy.exts:
                     continue
+            abs_path = os.path.join(abs_dir, name)
             try:
                 # One `stat`, two facts. `os.path.getsize` is a `stat` that
                 # throws the rest of the struct away, and the modification
@@ -487,7 +672,14 @@ def walk(root: str, policy: Optional[WalkPolicy] = None) -> WalkResult:
             paths.append(EligiblePath(abs_path, rel_path, size, info.st_mtime_ns))
 
     paths.sort(key=lambda entry: entry.rel_path)
-    return WalkResult(paths, excluded_dirs=excluded_dirs, excluded_files=excluded_files)
+    return WalkResult(
+        paths,
+        excluded_dirs=excluded_dirs,
+        excluded_files=excluded_files,
+        listings=fresh,
+        reused_dirs=reused,
+        rescanned_dirs=rescanned,
+    )
 
 
 def normalize_exts(exts: Optional[Iterable[str]]) -> Optional[frozenset[str]]:

--- a/src/neo/eligibility.py
+++ b/src/neo/eligibility.py
@@ -414,11 +414,11 @@ class DirectoryListing:
     This is what makes the walk cacheable. Deciding whether a path is ignored
     means matching it against every pattern in the repository's effective
     ignore set, and on a large repository that pattern matching — not the
-    filesystem — is the entire cost of the walk: measured on m365dotnet,
-    11,219 `should_ignore` calls take 6.7 s of a 6.9 s walk, while listing the
-    same directories costs 0.11 s and stat-ing all 9,378 admitted files costs
-    0.10 s. Caching the syscalls would save nothing; caching the verdicts
-    saves everything.
+    filesystem — is the entire cost of the walk: measured on m365dotnet, the
+    full walk takes 6.85 s, the same traversal with the per-file ignore test
+    removed takes 0.80 s, and stat-ing all 9,378 admitted files takes 0.10 s.
+    Caching the syscalls would save almost nothing; caching the verdicts saves
+    almost everything.
 
     A verdict is a function of the entry's NAME and the pattern set, so it
     stays valid for exactly as long as the directory's entry names do. On
@@ -427,8 +427,17 @@ class DirectoryListing:
     file inside it changes, which is precisely the distinction wanted here: an
     edit cannot change who is eligible, only what they say.
 
-    Three fields exist to keep that promise honest:
+    Four fields exist to keep that promise honest:
 
+    - `ctime_ns` is stored beside `mtime_ns` because **mtime alone is
+      forgeable**. `touch -r`, `tar -x`, `rsync -a` and every snapshot restore
+      set a directory's mtime back to a recorded value, so a restore that adds
+      or removes a file can land on exactly the mtime this cache holds and be
+      reported `warm`. Reproduced with two lines of `os.utime`. The inode
+      change time moves on any metadata change and no API restores it, and it
+      arrives in the same `stat` — so the defence costs nothing. On Windows
+      `st_ctime` is a CREATION time instead, hence constant, which makes this
+      comparison a no-op there rather than a false invalidation.
     - `scanned_at_ns` pairs with `RACY_WINDOW_NS` above.
     - `symlinks` is kept beside `files` rather than dropped, because
       `WalkPolicy.skip_symlinks` is a per-consumer choice and a cache that
@@ -454,11 +463,13 @@ class DirectoryListing:
     symlinks: tuple[str, ...] = ()
     excluded_dirs: int = 0
     excluded_files: int = 0
+    ctime_ns: int = 0
 
-    def is_current(self, mtime_ns: int) -> bool:
-        """True when this listing may be reused for a directory now at `mtime_ns`."""
+    def is_current(self, mtime_ns: int, ctime_ns: int) -> bool:
+        """True when this listing may be reused for a directory now at these stamps."""
         return (
             self.mtime_ns == mtime_ns
+            and self.ctime_ns == ctime_ns
             and self.mtime_ns <= self.scanned_at_ns - RACY_WINDOW_NS
         )
 
@@ -496,6 +507,7 @@ def _read_directory(
     abs_dir: str,
     rel_dir: str,
     mtime_ns: int,
+    ctime_ns: int,
     patterns: list[str],
 ) -> Optional[DirectoryListing]:
     """List one directory and apply the ignore rules to its entries.
@@ -560,6 +572,7 @@ def _read_directory(
     # rather than starting before it. See `RACY_WINDOW_NS`.
     return DirectoryListing(
         mtime_ns=mtime_ns,
+        ctime_ns=ctime_ns,
         scanned_at_ns=time.time_ns(),
         subdirs=tuple(subdirs),
         files=tuple(files),
@@ -626,17 +639,21 @@ def walk(
     while pending:
         rel_dir, abs_dir = pending.pop()
         try:
-            dir_mtime = os.stat(abs_dir).st_mtime_ns
+            # One `stat`, two stamps. See `DirectoryListing.ctime_ns` for why
+            # the second one is not optional.
+            info = os.stat(abs_dir)
         except OSError:
             # Removed between being listed by its parent and being reached.
             continue
 
         cached = listings.get(rel_dir) if listings is not None else None
-        if cached is not None and cached.is_current(dir_mtime):
+        if cached is not None and cached.is_current(info.st_mtime_ns, info.st_ctime_ns):
             listing = cached
             reused += 1
         else:
-            listing = _read_directory(abs_dir, rel_dir, dir_mtime, patterns)
+            listing = _read_directory(
+                abs_dir, rel_dir, info.st_mtime_ns, info.st_ctime_ns, patterns
+            )
             if listing is None:
                 continue
             rescanned += 1

--- a/src/neo/eligibility.py
+++ b/src/neo/eligibility.py
@@ -527,6 +527,18 @@ def _read_directory(
     for name in dirnames:
         if should_ignore(prefix + name, patterns, is_dir=True):
             excluded_dirs += 1
+        elif os.path.islink(os.path.join(abs_dir, name)):
+            # `os.walk(followlinks=False)` LISTS a symlinked directory and
+            # refuses to descend into it. This traversal recurses by hand, so
+            # the refusal has to be restated here or `followlinks=False`
+            # protects only the one directory read at a time — a link to an
+            # ancestor becomes an infinite descent, and a link to `/` walks the
+            # machine. Not counted as an exclusion: no ignore rule rejected it,
+            # and `skip_symlinks` does not gate this. That flag is about
+            # whether a symlinked FILE is delivered; refusing to traverse a
+            # symlinked DIRECTORY is what the walk has always done, for every
+            # caller.
+            logger.debug("Not descending into symlinked directory: %s", prefix + name)
         else:
             subdirs.append(name)
 

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -418,7 +418,8 @@ class ProjectIndex:
         printed "Built index" and exited 0 whether it had indexed the
         repository or 83 files of a stale worktree copy.
         """
-        from neo.eligibility import walk_paths
+        from neo.eligibility import WalkPolicy
+        from neo.index.walk_cache import cached_walk
         from neo.languages import language_for_path
 
         # One walk, shared with prompt assembly. It prunes ignored directories
@@ -432,7 +433,13 @@ class ProjectIndex:
         # to make separately: the walk starts at the repo root and never
         # follows a link, so an admitted path is inside the repo by
         # construction.
-        walked = walk_paths(str(self.repo_root), match_globs=file_patterns)
+        # Through the shared walk cache: `--index` is the documented
+        # cache-warmer, so it must warm the walk as well as the catalog, and
+        # on a repository the gatherer has already visited it costs nothing.
+        walked = cached_walk(
+            str(self.repo_root),
+            WalkPolicy(match_globs=tuple(file_patterns)),
+        )
         excluded = walked.excluded
 
         by_language: Dict[str, List[Path]] = {}

--- a/src/neo/index/project_index.py
+++ b/src/neo/index/project_index.py
@@ -439,6 +439,7 @@ class ProjectIndex:
         walked = cached_walk(
             str(self.repo_root),
             WalkPolicy(match_globs=tuple(file_patterns)),
+            record=False,
         )
         excluded = walked.excluded
 

--- a/src/neo/index/walk_cache.py
+++ b/src/neo/index/walk_cache.py
@@ -1,0 +1,407 @@
+"""The eligibility walk, persisted beside the content index.
+
+#208 gave the repository one walker; #209 stopped the content index rebuilding
+itself on every call. What was left was the walk itself, and by the end of
+#209 it was the largest single item in a warm Neo invocation: **4.64 s to
+re-derive that 9,348 of m365dotnet's files are eligible**, on every call, from
+a repository that had not changed (#210).
+
+**The cost is the pattern matching, not the filesystem.** Measured on
+m365dotnet before this module existed:
+
+    raw directory listing, pruned     0.11 s   951 directories
+    should_ignore over the entries    6.7  s   11,219 calls
+    stat over the admitted files      0.10 s   9,378 files
+
+A file's ignore verdict is a function of its NAME and the repository's pattern
+set. Neither changes when a file is edited. So the verdicts are what gets
+stored, per directory, and a directory's mtime is what says whether they still
+hold — on every POSIX filesystem that mtime moves when an entry is created,
+deleted or renamed, and does not move when a file's content changes. Which is
+exactly the distinction: an edit can change what a file SAYS, never whether it
+is eligible.
+
+**Sizes and mtimes are never remembered.** They are read fresh from the `stat`
+the walk owes its callers anyway (0.10 s), because the content index next door
+uses them as its own freshness stamp. Serving it a remembered mtime would make
+an edited file look unedited — one cache's staleness leaking into another's,
+which is the worst failure this whole goal could produce.
+
+**JSON, not SQLite, and the reason is the access shape.** The content index is
+SQLite because a query touches ten terms of a few hundred thousand and a
+parse-whole format would spend the warm budget deserializing postings nothing
+asked for. This cache is the opposite: every directory is validated on every
+call, so the whole file is read every time — the case JSON is for, and the
+case the semantic catalog next door already uses it for. On m365dotnet the
+file is ~340 KB and parses in ~10 ms.
+
+**A gitignore edit invalidates by content, not by timestamp.** The signature
+holds a hash of the effective pattern list — the shared defaults plus the
+repo's own `.gitignore` and `.ignore` — so editing any of them, or upgrading
+Neo to a build with a different default list or a different matcher, discards
+the cache and walks. That is a full walk on the next call, which is correct
+and rare; the alternative, re-deriving which directories a pattern edit could
+have affected, is a great deal of machinery guarding against a 5-second cost
+paid when someone edits a `.gitignore`.
+
+**Every degradation is loud, and none is fatal.** A corrupt or unreadable
+cache is discarded with a warning and the walk runs in full; a cache that
+cannot be written costs a warning and nothing else. There is no path here that
+can return a wrong file list — the worst outcome available is the walk Neo did
+before this module existed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from neo import progress
+from neo.eligibility import (
+    DirectoryListing,
+    WalkPolicy,
+    WalkResult,
+    load_ignore_patterns,
+    walk,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Bumped when the on-disk LAYOUT changes. An older cache is discarded rather
+#: than migrated: it is derived from the working tree, so rebuilding is always
+#: available and always correct, and migration code for a cache is liability
+#: with no upside.
+SCHEMA_VERSION = 1
+
+#: Bumped when the same path and the same patterns would produce a DIFFERENT
+#: verdict than they did before — a change to `should_ignore`, to
+#: `compile_glob`, or to the layering in `load_ignore_patterns`. The pattern
+#: hash below cannot see those: the patterns are identical, the matcher is not,
+#: and every stored verdict is wrong in a way no per-directory stamp can
+#: detect.
+MATCHER_VERSION = 1
+
+#: Beside `index.json` and `content_index.sqlite3`, in the repository's own
+#: `.neo/` — which is in the walker's default ignore list, so Neo never walks
+#: its own cache.
+CACHE_FILENAME = "walk_cache.json"
+
+@dataclass
+class WalkReport:
+    """What the walk cost this call, and why.
+
+    The modes are the content index's, meaning the same things, so the two
+    lines an operator reads under `--dry-run` can be compared:
+
+    - ``cold``        — no cache existed. First call in this repository.
+    - ``rebuilt``     — a cache existed and was unusable: corrupt, or written
+                        under a different schema, matcher or ignore-pattern
+                        set. A `.gitignore` edit lands here.
+    - ``incremental`` — a cache was reused and some directories were re-listed.
+    - ``warm``        — a cache was reused and nothing had to be re-listed.
+    - ``bypassed``    — the caller passed `--exclude`-style extra ignore
+                        patterns, which change what a verdict MEANS, so no
+                        cache was read or written.
+
+    ``rebuilt`` is kept distinct from ``cold`` for the reason it is next door:
+    both walk everything, but only one of them means something went wrong, and
+    a cache thrown away on every call must not read as an ordinary first run.
+    """
+
+    mode: str
+    directories: int = 0
+    reused: int = 0
+    rescanned: int = 0
+    files: int = 0
+    elapsed_ms: float = 0.0
+    warning: Optional[str] = None
+
+    def describe(self) -> str:
+        """One line for stderr. Never claims work it did not do."""
+        seconds = self.elapsed_ms / 1000.0
+        if self.mode in ("cold", "rebuilt"):
+            why = (
+                "first run for this repository"
+                if self.mode == "cold"
+                else "previous cache discarded"
+            )
+            head = (
+                f"Eligibility walk: full walk of {self.directories} directories "
+                f"({why}), {self.files} files eligible, in {seconds:.1f}s"
+            )
+        elif self.mode == "incremental":
+            head = (
+                f"Eligibility walk: re-listed {self.rescanned} of "
+                f"{self.directories} directories, {self.files} files eligible, "
+                f"in {seconds:.1f}s"
+            )
+        elif self.mode == "warm":
+            head = (
+                f"Eligibility walk: read warm, {self.directories} directories "
+                f"unchanged, {self.files} files eligible ({seconds:.1f}s)"
+            )
+        else:
+            head = (
+                f"Eligibility walk: full walk of {self.directories} directories "
+                f"(not cacheable for this call), {self.files} files eligible, "
+                f"in {seconds:.1f}s"
+            )
+        return head if not self.warning else f"{head} - {self.warning}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "directories": self.directories,
+            "reused": self.reused,
+            "rescanned": self.rescanned,
+            "files": self.files,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+            "warning": self.warning,
+            "summary": self.describe(),
+        }
+
+
+#: The most recent cached walk in this process, for reporting surfaces that run
+#: after the gather has returned — `--dry-run`'s JSON report in particular,
+#: where `--quiet` is implied and the stderr note the operator would otherwise
+#: read is suppressed. Process-global for the same reason `progress` is: it is
+#: a report about the run, read once, several layers up from where it is made.
+_LAST_REPORT: Optional[WalkReport] = None
+
+
+def last_report() -> Optional[WalkReport]:
+    """The `WalkReport` from this process's most recent `cached_walk`, if any."""
+    return _LAST_REPORT
+
+
+def cache_path(repo_root: str) -> Path:
+    """Where this repository's cache lives."""
+    return Path(repo_root).resolve() / ".neo" / CACHE_FILENAME
+
+
+def signature(repo_root: str) -> dict[str, str]:
+    """What this build of Neo, in this repository, would write.
+
+    Any mismatch discards the cache. `patterns` is hashed rather than stored
+    whole because the point is equality, not readability, and a large repo's
+    `.gitignore` would otherwise dominate the file.
+    """
+    patterns = "\n".join(load_ignore_patterns(repo_root))
+    return {
+        "schema_version": str(SCHEMA_VERSION),
+        "matcher_version": str(MATCHER_VERSION),
+        "patterns_sha256": hashlib.sha256(patterns.encode("utf-8")).hexdigest(),
+    }
+
+
+def _load(path: Path, expected: dict[str, str]) -> tuple[
+    Optional[dict[str, DirectoryListing]], Optional[str]
+]:
+    """`(listings, why_not)` — the stored listings, or why there are none.
+
+    `why_not` is `None` when the file simply does not exist (an ordinary first
+    run) and a sentence when something was there and could not be used. The
+    caller turns that difference into `cold` versus `rebuilt`, which is the
+    difference between "this is the first call" and "this repository is
+    throwing its cache away on every call".
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return None, None
+    except (OSError, ValueError) as exc:
+        return None, f"cache unreadable ({exc})"
+
+    if not isinstance(raw, dict):
+        return None, "cache is not an object"
+    if raw.get("signature") != expected:
+        return None, "ignore rules or Neo version changed"
+
+    directories = raw.get("directories")
+    if not isinstance(directories, dict):
+        return None, "cache holds no directory listings"
+
+    listings: dict[str, DirectoryListing] = {}
+    try:
+        for rel_dir, entry in directories.items():
+            listings[rel_dir] = DirectoryListing(
+                mtime_ns=int(entry["mtime_ns"]),
+                scanned_at_ns=int(entry["scanned_at_ns"]),
+                subdirs=tuple(entry["subdirs"]),
+                files=tuple(entry["files"]),
+                symlinks=tuple(entry.get("symlinks", ())),
+                excluded_dirs=int(entry.get("excluded_dirs", 0)),
+                excluded_files=int(entry.get("excluded_files", 0)),
+            )
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        # A malformed entry is malformed data, not a missing feature: half a
+        # cache would give half a repository, silently.
+        return None, f"cache entry malformed ({exc})"
+    return listings, None
+
+
+def _save(path: Path, sig: dict[str, str], listings: dict[str, DirectoryListing]) -> Optional[str]:
+    """Write the cache atomically. Returns a warning string on failure, else None.
+
+    Temp file plus `os.replace`, in the destination directory so the replace is
+    atomic, so a reader can never see a half-written cache and a crash mid-write
+    leaves the previous one intact. Two Neo processes racing here is fine: both
+    write the same derived facts and the loser's work is simply superseded.
+    """
+    payload = {
+        "signature": sig,
+        "directories": {
+            rel_dir: {
+                "mtime_ns": listing.mtime_ns,
+                "scanned_at_ns": listing.scanned_at_ns,
+                "subdirs": list(listing.subdirs),
+                "files": list(listing.files),
+                "symlinks": list(listing.symlinks),
+                "excluded_dirs": listing.excluded_dirs,
+                "excluded_files": listing.excluded_files,
+            }
+            for rel_dir, listing in listings.items()
+        },
+    }
+    tmp_path = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=CACHE_FILENAME + ".", suffix=".tmp"
+        )
+        tmp_path = Path(tmp_name)
+        with os.fdopen(handle, "w") as out:
+            json.dump(payload, out)
+        # `mkstemp` creates 0600, which the cache must not keep: a checkout
+        # shared by two accounts would leave the second unable to read it, and
+        # an unreadable cache is a full walk on every call, forever, with only
+        # a warning to say so. Match the store next door, which SQLite creates
+        # world-readable.
+        os.chmod(tmp_name, 0o644)
+        os.replace(tmp_name, path)
+        tmp_path = None
+    except (OSError, TypeError, ValueError) as exc:
+        return f"cache not written ({exc})"
+    finally:
+        if tmp_path is not None:
+            # `os.replace` never ran, so the temp file is ours to remove. A
+            # SIGKILL between `mkstemp` and `replace` runs no handler and does
+            # strand one — hence the sweep below, which is the same lesson
+            # `FactStore._reap_stale_temp_files` was written for.
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+    _reap_stale_temp_files(path.parent)
+    return None
+
+
+#: How long an abandoned temp file is left alone before it is swept. Long
+#: enough that a slow concurrent write is never the thing being deleted.
+_TEMP_FILE_TTL_SECONDS = 24 * 3600
+
+
+def _reap_stale_temp_files(directory: Path) -> None:
+    """Remove this module's own abandoned temp files older than the TTL."""
+    cutoff = time.time() - _TEMP_FILE_TTL_SECONDS
+    try:
+        stale = list(directory.glob(CACHE_FILENAME + ".*.tmp"))
+    except OSError:
+        return
+    for leftover in stale:
+        try:
+            if leftover.stat().st_mtime < cutoff:
+                leftover.unlink()
+        except OSError:
+            continue
+
+
+def cached_walk(
+    repo_root: str,
+    policy: Optional[WalkPolicy] = None,
+    *,
+    quiet: bool = False,
+) -> WalkResult:
+    """`eligibility.walk`, accelerated by and refreshed into the on-disk cache.
+
+    Always returns the same `WalkResult` an uncached walk would: the cache can
+    make a call cheaper, never different. Every failure mode — no cache, a
+    corrupt one, one written under different rules, an unwritable `.neo/` —
+    degrades to the full walk and says so.
+    """
+    started = time.time()
+    policy = policy or WalkPolicy()
+
+    if policy.extra_ignores:
+        # See the matching guard in `eligibility.walk`: caller-supplied
+        # patterns are appended after the repository's own, and gitignore is
+        # last-match-wins, so a stored verdict is not an answer to this call's
+        # question. Nothing in Neo takes this path today — `--exclude` is
+        # applied after the walk by `context_gatherer.filter_candidates`, so
+        # the corpus stays a property of the repository — and it exists so that
+        # a future caller which does gets a correct answer rather than a fast
+        # wrong one.
+        result = walk(repo_root, policy)
+        return _finish(result, "bypassed", started, quiet, None)
+
+    path = cache_path(repo_root)
+    sig = signature(repo_root)
+    listings, why_not = _load(path, sig)
+    if why_not:
+        logger.warning("Eligibility walk cache at %s discarded: %s", path, why_not)
+
+    if listings is None:
+        # BEFORE the walk, not after. A first call on a large repository
+        # spends seconds here and silence for seconds is indistinguishable
+        # from a hang — the same reason the content index announces its cold
+        # build. `neo --index` warms this cache too, but it is optional: any
+        # invocation pays the one-time cost and every later one is warm.
+        if not quiet:
+            progress.note(
+                "Eligibility walk: no cache for this repository "
+                f"({why_not or 'first run'}); walking the tree once"
+            )
+
+    result = walk(repo_root, policy, listings)
+
+    warning = None
+    if listings is None or result.rescanned_dirs:
+        warning = _save(path, sig, result.listings or {})
+
+    if listings is None:
+        mode = "rebuilt" if why_not else "cold"
+    elif result.rescanned_dirs:
+        mode = "incremental"
+    else:
+        mode = "warm"
+    return _finish(result, mode, started, quiet, warning)
+
+
+def _finish(
+    result: WalkResult,
+    mode: str,
+    started: float,
+    quiet: bool,
+    warning: Optional[str],
+) -> WalkResult:
+    global _LAST_REPORT
+    report = WalkReport(
+        mode=mode,
+        directories=result.reused_dirs + result.rescanned_dirs,
+        reused=result.reused_dirs,
+        rescanned=result.rescanned_dirs,
+        files=len(result.paths),
+        elapsed_ms=(time.time() - started) * 1000.0,
+        warning=warning,
+    )
+    _LAST_REPORT = report
+    if not quiet:
+        progress.note(report.describe())
+    return result

--- a/src/neo/index/walk_cache.py
+++ b/src/neo/index/walk_cache.py
@@ -9,9 +9,10 @@ a repository that had not changed (#210).
 **The cost is the pattern matching, not the filesystem.** Measured on
 m365dotnet before this module existed:
 
-    raw directory listing, pruned     0.11 s   951 directories
-    should_ignore over the entries    6.7  s   11,219 calls
-    stat over the admitted files      0.10 s   9,378 files
+    full walk                              6.85 s   951 directories
+    the same traversal, per-file ignore
+      test removed                         0.80 s   the syscalls alone
+    stat over the admitted files           0.10 s   9,378 files
 
 A file's ignore verdict is a function of its NAME and the repository's pattern
 set. Neither changes when a file is edited. So the verdicts are what gets
@@ -33,7 +34,7 @@ parse-whole format would spend the warm budget deserializing postings nothing
 asked for. This cache is the opposite: every directory is validated on every
 call, so the whole file is read every time — the case JSON is for, and the
 case the semantic catalog next door already uses it for. On m365dotnet the
-file is ~340 KB and parses in ~10 ms.
+file is 507 KB and parses in ~10 ms.
 
 **A gitignore edit invalidates by content, not by timestamp.** The signature
 holds a hash of the effective pattern list — the shared defaults plus the
@@ -78,7 +79,7 @@ logger = logging.getLogger(__name__)
 #: than migrated: it is derived from the working tree, so rebuilding is always
 #: available and always correct, and migration code for a cache is liability
 #: with no upside.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 #: Bumped when the same path and the same patterns would produce a DIFFERENT
 #: verdict than they did before — a change to `should_ignore`, to
@@ -225,7 +226,13 @@ def _load(path: Path, expected: dict[str, str]) -> tuple[
         return None, "ignore rules or Neo version changed"
 
     directories = raw.get("directories")
-    if not isinstance(directories, dict):
+    if not isinstance(directories, dict) or not directories:
+        # An EMPTY map is rejected, not accepted as a cache of nothing. Every
+        # walk that reaches a readable root records at least the root itself,
+        # so an empty map can only come from a damaged file — and treating it
+        # as usable made every later call in that repository report
+        # `incremental` forever, which is exactly the signal `rebuilt` exists
+        # to preserve.
         return None, "cache holds no directory listings"
 
     listings: dict[str, DirectoryListing] = {}
@@ -233,6 +240,7 @@ def _load(path: Path, expected: dict[str, str]) -> tuple[
         for rel_dir, entry in directories.items():
             listings[rel_dir] = DirectoryListing(
                 mtime_ns=int(entry["mtime_ns"]),
+                ctime_ns=int(entry["ctime_ns"]),
                 scanned_at_ns=int(entry["scanned_at_ns"]),
                 subdirs=tuple(entry["subdirs"]),
                 files=tuple(entry["files"]),
@@ -260,6 +268,7 @@ def _save(path: Path, sig: dict[str, str], listings: dict[str, DirectoryListing]
         "directories": {
             rel_dir: {
                 "mtime_ns": listing.mtime_ns,
+                "ctime_ns": listing.ctime_ns,
                 "scanned_at_ns": listing.scanned_at_ns,
                 "subdirs": list(listing.subdirs),
                 "files": list(listing.files),
@@ -328,6 +337,7 @@ def cached_walk(
     policy: Optional[WalkPolicy] = None,
     *,
     quiet: bool = False,
+    record: bool = True,
 ) -> WalkResult:
     """`eligibility.walk`, accelerated by and refreshed into the on-disk cache.
 
@@ -335,6 +345,14 @@ def cached_walk(
     make a call cheaper, never different. Every failure mode — no cache, a
     corrupt one, one written under different rules, an unwritable `.neo/` —
     degrades to the full walk and says so.
+
+    `record=False` is for a SECONDARY walk — the architecture scan, the index
+    build — which uses the same cache but a narrower policy. Such a walk still
+    reads and refreshes the cache; it just does not become `last_report()`.
+    The report answers "what did the eligibility walk cost this call?" for the
+    operator reading `--dry-run`, and that is the corpus walk. A later
+    extension-filtered scan overwriting it would leave the reported file count
+    describing a subset nobody asked about.
     """
     started = time.time()
     policy = policy or WalkPolicy()
@@ -349,7 +367,7 @@ def cached_walk(
         # a future caller which does gets a correct answer rather than a fast
         # wrong one.
         result = walk(repo_root, policy)
-        return _finish(result, "bypassed", started, quiet, None)
+        return _finish(result, "bypassed", started, quiet, None, record)
 
     path = cache_path(repo_root)
     sig = signature(repo_root)
@@ -372,8 +390,14 @@ def cached_walk(
     result = walk(repo_root, policy, listings)
 
     warning = None
-    if listings is None or result.rescanned_dirs:
-        warning = _save(path, sig, result.listings or {})
+    if result.listings and (listings is None or result.rescanned_dirs):
+        # `result.listings` empty means the walk read no directory at all — a
+        # root that does not exist, or one it cannot enter. Saving then would
+        # be worse than useless: `_save` creates `.neo/`, so a mistyped
+        # `--cwd` silently minted a directory tree, and pointed at an
+        # unmounted mountpoint it would create a local directory that shadows
+        # the mount. Nothing was learned, so nothing is written.
+        warning = _save(path, sig, result.listings)
 
     if listings is None:
         mode = "rebuilt" if why_not else "cold"
@@ -381,7 +405,7 @@ def cached_walk(
         mode = "incremental"
     else:
         mode = "warm"
-    return _finish(result, mode, started, quiet, warning)
+    return _finish(result, mode, started, quiet, warning, record)
 
 
 def _finish(
@@ -390,6 +414,7 @@ def _finish(
     started: float,
     quiet: bool,
     warning: Optional[str],
+    record: bool = True,
 ) -> WalkResult:
     global _LAST_REPORT
     report = WalkReport(
@@ -401,7 +426,8 @@ def _finish(
         elapsed_ms=(time.time() - started) * 1000.0,
         warning=warning,
     )
-    _LAST_REPORT = report
+    if record:
+        _LAST_REPORT = report
     if not quiet:
         progress.note(report.describe())
     return result

--- a/tests/test_walk_cache.py
+++ b/tests/test_walk_cache.py
@@ -207,6 +207,27 @@ class TestParity:
 
         assert cache_path(root).read_text() == before
 
+    def test_a_symlinked_directory_is_listed_but_never_descended(self, tmp_path):
+        """The rule `os.walk(followlinks=False)` enforced, restated by hand.
+
+        This traversal recurses itself, so `followlinks=False` protects only
+        one directory read at a time. A link pointing at an ancestor is an
+        infinite descent and a link pointing at `/` walks the machine — this
+        test hangs rather than fails if the guard goes, which is the honest
+        shape of that defect.
+        """
+        root = _repo(tmp_path)
+        (root / "src" / "mirror").symlink_to(root / "docs", target_is_directory=True)
+        (root / "src" / "loop").symlink_to(root, target_is_directory=True)
+
+        found = _cached(root)
+
+        # The finite case fails fast and pins the same rule; the loop is what
+        # makes the consequence of losing it unbounded.
+        assert "docs/guide.md" in found
+        assert "src/mirror/guide.md" not in found
+        assert not any(name.startswith("src/loop/") for name in found)
+
     def test_a_symlink_is_still_a_policy_choice_on_a_warm_walk(self, tmp_path):
         root = _repo(tmp_path)
         (root / "src/link.py").symlink_to(root / "src/main.py")

--- a/tests/test_walk_cache.py
+++ b/tests/test_walk_cache.py
@@ -1,0 +1,492 @@
+"""Tests for the persistent eligibility walk.
+
+The cache exists to make the walk cheap. It must not make it different, and
+the failure it could produce is the quietest one in the system: a file that
+still exists but stops being offered, or a file that was deleted and keeps
+being offered, with no error anywhere and a plausible answer on screen.
+
+Four properties carry it, each a distinct way it could go wrong:
+
+1. **Parity.** `TestParity` runs the cached walk and the uncached walk over
+   the same tree, before and after every mutation shape that matters — add,
+   delete, rename, gitignore edit, a nested checkout appearing — and asserts
+   the two lists are equal. This is the test that would catch a wrong answer
+   regardless of which mechanism produced it.
+2. **The stamps stay live.** `TestStampsAreNeverCached` pins the one
+   cross-cache invariant: a reused directory listing must still yield the
+   file's CURRENT size and mtime, because the content index next door uses
+   them as its own freshness stamp. Remembering them would make an edited
+   file look unedited — this cache's staleness leaking into that one's.
+3. **Reporting.** `TestReport` asserts the mode a call reports is the work it
+   actually did. A cache that reports `warm` while re-listing everything, or
+   `cold` while a corrupt file is being discarded on every call, hides the
+   only signal an operator has.
+4. **Degradation.** `TestDegradation` corrupts, truncates, mangles and
+   write-protects the cache. Each must warn and return the right files.
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+from neo import eligibility
+from neo.eligibility import RACY_WINDOW_NS, WalkPolicy
+from neo.index import walk_cache
+from neo.index.walk_cache import cache_path, cached_walk
+
+REPO = {
+    "src/pkg/alpha.py": "def alpha():\n    return 1\n",
+    "src/pkg/beta.py": "def beta():\n    return 2\n",
+    "src/main.py": "from pkg import alpha\n",
+    "docs/guide.md": "# Guide\n",
+    "README.md": "# Project\n",
+    ".gitignore": "build/\n*.log\n",
+    "build/generated.py": "GENERATED = True\n",
+    "debug.log": "noise\n",
+}
+
+
+def _repo(tmp_path, files=REPO):
+    for rel, text in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return tmp_path
+
+
+def _age(root, seconds: float = 10.0) -> None:
+    """Move every directory's mtime back, out of the racy window.
+
+    A tree a test has just built is entirely inside `RACY_WINDOW_NS`, so a
+    cache of it is deliberately not trusted (see `eligibility.RACY_WINDOW_NS`)
+    and every call would report `incremental`. Ageing the directories is how a
+    test asks about steady state rather than about the guard — the guard has
+    its own tests below.
+    """
+    when = time.time() - seconds
+    for dirpath, dirnames, _ in os.walk(str(root)):
+        os.utime(dirpath, (when, when))
+        del dirnames  # walked for its directories only
+
+
+def _settle(root) -> None:
+    """Bring the cache to the state a repository is in between two calls.
+
+    Walk once so `.neo/` exists — writing the cache CREATES that directory,
+    which moves the repository root's own mtime, so a tree that is otherwise
+    unchanged still re-lists its root on the call after its very first. Then
+    age, so no directory sits inside `RACY_WINDOW_NS`, then walk again to
+    record the aged stamps. Ageing before the final walk rather than after is
+    the load-bearing order: the cache stores the mtime it saw, so ageing a
+    tree the cache was already written against makes every directory look
+    changed.
+    """
+    cached_walk(str(root), quiet=True)
+    _age(root)
+    cached_walk(str(root), quiet=True)
+
+
+def _names(result) -> list[str]:
+    return [entry.rel_path for entry in result.paths]
+
+
+def _uncached(root, policy=None) -> list[str]:
+    return _names(eligibility.walk(str(root), policy))
+
+
+def _cached(root, policy=None) -> list[str]:
+    return _names(cached_walk(str(root), policy, quiet=True))
+
+
+class TestParity:
+    """The cached walk answers exactly what the uncached walk answers."""
+
+    def test_a_cold_walk_matches_the_uncached_walk(self, tmp_path):
+        root = _repo(tmp_path)
+        assert _cached(root) == _uncached(root)
+
+    def test_a_warm_walk_matches_the_uncached_walk(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        assert _cached(root) == _uncached(root)
+
+    @pytest.mark.parametrize("mutation", ["add", "delete", "rename", "new_directory"])
+    def test_the_cache_survives_a_mutation(self, tmp_path, mutation):
+        root = _repo(tmp_path)
+        _settle(root)
+
+        if mutation == "add":
+            (root / "src/pkg/gamma.py").write_text("def gamma():\n    return 3\n")
+        elif mutation == "delete":
+            (root / "src/pkg/beta.py").unlink()
+        elif mutation == "rename":
+            (root / "src/pkg/beta.py").rename(root / "src/pkg/renamed.py")
+        else:
+            (root / "src/deep/nested").mkdir(parents=True)
+            (root / "src/deep/nested/leaf.py").write_text("LEAF = 1\n")
+
+        assert _cached(root) == _uncached(root)
+
+    def test_a_gitignore_edit_takes_effect_on_the_next_call(self, tmp_path):
+        """The case a directory mtime cannot see.
+
+        Editing `.gitignore` changes a file's CONTENT, so no directory's mtime
+        moves and every cached verdict looks current — while every one of them
+        may now be wrong. The signature hashes the effective pattern list for
+        exactly this.
+        """
+        root = _repo(tmp_path)
+        _settle(root)
+        assert "docs/guide.md" in _cached(root)
+
+        (root / ".gitignore").write_text("build/\n*.log\ndocs/\n")
+
+        assert "docs/guide.md" not in _cached(root)
+        assert _cached(root) == _uncached(root)
+
+    def test_a_nested_checkout_appearing_is_excluded(self, tmp_path):
+        """`.worktrees` is in the shared default list; the cache must not widen it."""
+        root = _repo(tmp_path)
+        _settle(root)
+
+        nested = root / ".worktrees" / "copy" / "src" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "alpha.py").write_text("def alpha():\n    return 1\n")
+
+        found = _cached(root)
+        assert not any(name.startswith(".worktrees/") for name in found)
+        assert found == _uncached(root)
+
+    def test_the_exclusion_counts_survive_a_warm_call(self, tmp_path):
+        """`--dry-run`'s G1 accounting must not depend on cache state."""
+        root = _repo(tmp_path)
+        _settle(root)
+        fresh = eligibility.walk(str(root))
+        warm = cached_walk(str(root), quiet=True)
+
+        assert warm.rescanned_dirs == 0
+        assert (warm.excluded_dirs, warm.excluded_files) == (
+            fresh.excluded_dirs,
+            fresh.excluded_files,
+        )
+        assert warm.excluded_dirs > 0 and warm.excluded_files > 0
+
+    def test_a_policy_filter_still_applies_to_a_warm_walk(self, tmp_path):
+        """The cache stores ignore verdicts; `exts` is a consumer policy on top."""
+        root = _repo(tmp_path)
+        _settle(root)
+
+        policy = WalkPolicy(exts=eligibility.normalize_exts(["py"]))
+        assert _cached(root, policy) == _uncached(root, policy)
+        assert all(name.endswith(".py") for name in _cached(root, policy))
+
+    def test_extra_ignores_are_never_served_from_a_cache(self, tmp_path):
+        """A caller's patterns are appended AFTER the repo's, and last match wins.
+
+        So a `!negation` in `extra_ignores` can re-include a path the stored
+        verdict excluded. The stored verdict is not a stale answer to this
+        question, it is an answer to a different one.
+        """
+        root = _repo(tmp_path)
+        _settle(root)
+
+        policy = WalkPolicy(extra_ignores=("docs/",))
+        result = cached_walk(str(root), policy, quiet=True)
+        assert "docs/guide.md" not in _names(result)
+        assert _names(result) == _uncached(root, policy)
+        assert walk_cache.last_report().mode == "bypassed"
+
+    def test_a_bypassed_call_does_not_overwrite_the_cache(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        before = cache_path(root).read_text()
+
+        cached_walk(str(root), WalkPolicy(extra_ignores=("docs/",)), quiet=True)
+
+        assert cache_path(root).read_text() == before
+
+    def test_a_symlink_is_still_a_policy_choice_on_a_warm_walk(self, tmp_path):
+        root = _repo(tmp_path)
+        (root / "src/link.py").symlink_to(root / "src/main.py")
+        _settle(root)
+
+        assert "src/link.py" not in _cached(root)
+        permissive = WalkPolicy(skip_symlinks=False)
+        assert "src/link.py" in _cached(root, permissive)
+        assert _cached(root, permissive) == _uncached(root, permissive)
+
+
+class TestStampsAreNeverCached:
+    """A reused listing must still report the file's CURRENT size and mtime.
+
+    This is the invariant that keeps one cache's staleness out of another's:
+    the content index decides what to re-tokenize from `EligiblePath.size` and
+    `EligiblePath.mtime_ns`, so a remembered stamp would make an edited file
+    look unedited and leave the index answering with text the file no longer
+    holds. Editing a file does not move its directory's mtime, so the listing
+    IS reused here — which is exactly the dangerous case.
+    """
+
+    def test_an_edit_is_visible_in_the_stamp_of_a_reused_listing(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+
+        target = root / "src/pkg/alpha.py"
+        before = {e.rel_path: e for e in cached_walk(str(root), quiet=True).paths}
+        assert walk_cache.last_report().mode == "warm"
+
+        target.write_text("def alpha():\n    return 1  # edited, and longer now\n")
+
+        result = cached_walk(str(root), quiet=True)
+        after = {e.rel_path: e for e in result.paths}
+        # The directory was NOT re-listed -- an edit does not move a directory's
+        # mtime -- and the stamp moved anyway.
+        assert result.rescanned_dirs == 0
+        assert after["src/pkg/alpha.py"].size != before["src/pkg/alpha.py"].size
+        assert (
+            after["src/pkg/alpha.py"].mtime_ns
+            != before["src/pkg/alpha.py"].mtime_ns
+        )
+        assert after["src/pkg/alpha.py"].mtime_ns == target.stat().st_mtime_ns
+
+    def test_a_size_ceiling_is_applied_to_the_current_size(self, tmp_path):
+        """A file that grew past the ceiling drops out without a re-listing."""
+        root = _repo(tmp_path)
+        policy = WalkPolicy(max_file_bytes=64)
+        _settle(root)
+        assert "src/pkg/alpha.py" in _cached(root, policy)
+
+        (root / "src/pkg/alpha.py").write_text("x = 1\n" * 100)
+
+        assert "src/pkg/alpha.py" not in _cached(root, policy)
+
+
+class TestReport:
+    """The mode reported is the work that was done."""
+
+    def test_a_first_call_is_cold(self, tmp_path):
+        root = _repo(tmp_path)
+        cached_walk(str(root), quiet=True)
+        report = walk_cache.last_report()
+        assert report.mode == "cold"
+        assert report.rescanned == report.directories > 0
+        assert report.reused == 0
+        assert report.files == len(_uncached(root))
+
+    def test_an_unchanged_repository_is_warm(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        cached_walk(str(root), quiet=True)
+
+        report = walk_cache.last_report()
+        assert report.mode == "warm"
+        assert report.rescanned == 0
+        assert report.reused == report.directories
+
+    def test_one_changed_directory_is_incremental(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        (root / "src/pkg/gamma.py").write_text("GAMMA = 3\n")
+
+        cached_walk(str(root), quiet=True)
+        report = walk_cache.last_report()
+        assert report.mode == "incremental"
+        assert report.rescanned == 1
+        assert report.reused == report.directories - 1
+
+    def test_a_discarded_cache_reports_rebuilt_not_cold(self, tmp_path):
+        """Distinct on purpose: only one of them means something went wrong."""
+        root = _repo(tmp_path)
+        cached_walk(str(root), quiet=True)
+        cache_path(root).write_text("{not json")
+
+        cached_walk(str(root), quiet=True)
+        assert walk_cache.last_report().mode == "rebuilt"
+
+    def test_the_summary_never_claims_work_it_did_not_do(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        cached_walk(str(root), quiet=True)
+
+        summary = walk_cache.last_report().describe()
+        assert "read warm" in summary
+        assert "re-listed" not in summary
+
+    def test_a_warm_call_does_not_rewrite_the_cache(self, tmp_path):
+        """A steady-state call must not open a write.
+
+        The content index next door learned this the expensive way: rewriting
+        an unchanged signature on every warm call put two ordinary overlapping
+        invocations into lock contention on the one path that should be free.
+        """
+        root = _repo(tmp_path)
+        _settle(root)
+        stamp = cache_path(root).stat().st_mtime_ns
+
+        time.sleep(0.01)
+        cached_walk(str(root), quiet=True)
+
+        assert cache_path(root).stat().st_mtime_ns == stamp
+
+
+class TestRacyDirectories:
+    """A directory modified in the same timestamp tick it was read is suspect.
+
+    Every test here pre-creates `.neo/` before the tree, and that is not
+    incidental. Writing the cache CREATES that directory, which moves the
+    repository ROOT's mtime, so the call after a first-ever call re-lists the
+    root no matter what this guard does — and a test that only asserted
+    "incremental" would pass with the guard deleted. Mutation-verified: with
+    `is_current` reduced to an mtime comparison, `rescanned == directories`
+    below fails and `rescanned >= 1` would not have.
+    """
+
+    def _tree(self, tmp_path):
+        (tmp_path / ".neo").mkdir(exist_ok=True)
+        return _repo(tmp_path)
+
+    def test_a_freshly_built_tree_is_not_trusted(self, tmp_path):
+        """Timestamp granularity is not always finer than the interval.
+
+        HFS+ stamps whole seconds. A directory listed at time E whose mtime is
+        M can be modified afterwards and land in the same bucket whenever
+        `E - M` is under one tick, so a cache of a tree built moments ago is
+        not trustworthy no matter how equal the two mtimes look.
+        """
+        root = self._tree(tmp_path)
+        cached_walk(str(root), quiet=True)
+
+        cached_walk(str(root), quiet=True)
+
+        report = walk_cache.last_report()
+        assert report.mode == "incremental"
+        # EVERY directory, not merely one: nothing but the guard re-lists a
+        # tree that has not been touched since it was read.
+        assert report.rescanned == report.directories > 1
+        assert report.reused == 0
+
+    def test_a_settled_tree_is_trusted(self, tmp_path):
+        root = self._tree(tmp_path)
+        cached_walk(str(root), quiet=True)
+        _age(root, seconds=RACY_WINDOW_NS / 1e9 + 1)
+        cached_walk(str(root), quiet=True)
+
+        cached_walk(str(root), quiet=True)
+
+        report = walk_cache.last_report()
+        assert report.mode == "warm"
+        assert report.reused == report.directories
+
+    def test_the_window_is_what_decides(self, tmp_path):
+        """The same tree, the same call, with only the timestamps moved.
+
+        Ageing by less than the window keeps every directory suspect; ageing
+        past it makes every one of them reusable. If both halves ever agree,
+        the two tests above have stopped measuring the guard.
+        """
+        root = self._tree(tmp_path)
+        cached_walk(str(root), quiet=True)
+        _age(root, seconds=RACY_WINDOW_NS / 1e9 / 2)
+        cached_walk(str(root), quiet=True)
+        cached_walk(str(root), quiet=True)
+        assert walk_cache.last_report().reused == 0
+
+        _age(root, seconds=RACY_WINDOW_NS / 1e9 + 1)
+        cached_walk(str(root), quiet=True)
+        cached_walk(str(root), quiet=True)
+        report = walk_cache.last_report()
+        assert report.reused == report.directories
+
+
+class TestDegradation:
+    """Every failure costs a warning and a full walk. None costs an answer."""
+
+    @pytest.mark.parametrize("damage", [
+        "{not json at all",
+        "",
+        "[]",
+        '{"signature": {}, "directories": {}}',
+        '{"signature": null, "directories": null}',
+    ])
+    def test_a_damaged_cache_still_returns_the_right_files(self, tmp_path, damage):
+        root = _repo(tmp_path)
+        expected = _cached(root)
+        cache_path(root).write_text(damage)
+
+        assert _cached(root) == expected
+
+    def test_a_malformed_entry_discards_the_whole_cache(self, tmp_path):
+        """Half a cache would be half a repository, silently."""
+        root = _repo(tmp_path)
+        expected = _cached(root)
+        raw = json.loads(cache_path(root).read_text())
+        raw["directories"]["src"] = {"mtime_ns": "not a number"}
+        cache_path(root).write_text(json.dumps(raw))
+
+        assert _cached(root) == expected
+        assert walk_cache.last_report().mode == "rebuilt"
+
+    def test_a_truncated_cache_is_discarded(self, tmp_path):
+        root = _repo(tmp_path)
+        expected = _cached(root)
+        text = cache_path(root).read_text()
+        cache_path(root).write_text(text[: len(text) // 2])
+
+        assert _cached(root) == expected
+
+    def test_a_signature_from_another_build_is_discarded(self, tmp_path):
+        root = _repo(tmp_path)
+        expected = _cached(root)
+        raw = json.loads(cache_path(root).read_text())
+        raw["signature"]["matcher_version"] = "999"
+        cache_path(root).write_text(json.dumps(raw))
+
+        assert _cached(root) == expected
+        assert walk_cache.last_report().mode == "rebuilt"
+
+    def test_an_unwritable_cache_costs_a_warning_not_a_run(self, tmp_path):
+        root = _repo(tmp_path)
+        neo_dir = root / ".neo"
+        neo_dir.mkdir(exist_ok=True)
+        neo_dir.chmod(0o500)
+        try:
+            result = cached_walk(str(root), quiet=True)
+        finally:
+            neo_dir.chmod(0o700)
+
+        assert _names(result) == _uncached(root)
+        report = walk_cache.last_report()
+        assert report.mode == "cold"
+        assert report.warning is not None
+
+    def test_a_repository_that_cannot_be_walked_yields_nothing(self, tmp_path):
+        """No cache, no crash: a missing root is an empty repository."""
+        result = cached_walk(str(tmp_path / "does-not-exist"), quiet=True)
+        assert result.paths == []
+
+    def test_an_abandoned_temp_file_is_swept(self, tmp_path):
+        root = _repo(tmp_path)
+        _cached(root)
+        stranded = root / ".neo" / (walk_cache.CACHE_FILENAME + ".abcd.tmp")
+        stranded.write_text("{}")
+        old = time.time() - walk_cache._TEMP_FILE_TTL_SECONDS - 60
+        os.utime(stranded, (old, old))
+
+        (root / "src/pkg/gamma.py").write_text("GAMMA = 3\n")
+        _cached(root)
+
+        assert not stranded.exists()
+
+    def test_a_recent_temp_file_is_left_alone(self, tmp_path):
+        """A slow concurrent write must never be the thing being deleted."""
+        root = _repo(tmp_path)
+        _cached(root)
+        peer = root / ".neo" / (walk_cache.CACHE_FILENAME + ".peer.tmp")
+        peer.write_text("{}")
+
+        (root / "src/pkg/gamma.py").write_text("GAMMA = 3\n")
+        _cached(root)
+
+        assert peer.exists()

--- a/tests/test_walk_cache.py
+++ b/tests/test_walk_cache.py
@@ -421,6 +421,75 @@ class TestRacyDirectories:
         assert report.reused == report.directories
 
 
+class TestForgedTimestamps:
+    """mtime is a value a tool can restore; the cache must not trust it alone.
+
+    `touch -r`, `tar -x`, `rsync -a` and every snapshot restore write a
+    directory's mtime back to a recorded value. A restore that adds or removes
+    a file can therefore land on exactly the mtime the cache holds, and the
+    walk would report `warm` while answering with a file list from before the
+    restore. The inode change time moves on any metadata change and no API
+    restores it — and it arrives in the same `stat`.
+    """
+
+    def test_a_restored_mtime_does_not_hide_an_added_file(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        target = root / "src" / "pkg"
+        saved = target.stat()
+
+        (target / "gamma.py").write_text("GAMMA = 3\n")
+        os.utime(target, ns=(saved.st_atime_ns, saved.st_mtime_ns))
+        assert target.stat().st_mtime_ns == saved.st_mtime_ns
+
+        found = _cached(root)
+        assert "src/pkg/gamma.py" in found
+        assert found == _uncached(root)
+
+    def test_a_restored_mtime_does_not_hide_a_deleted_file(self, tmp_path):
+        root = _repo(tmp_path)
+        _settle(root)
+        target = root / "src" / "pkg"
+        saved = target.stat()
+
+        (target / "beta.py").unlink()
+        os.utime(target, ns=(saved.st_atime_ns, saved.st_mtime_ns))
+
+        assert "src/pkg/beta.py" not in _cached(root)
+
+
+class TestTheWalkGuardsItselfToo:
+    """`eligibility.walk` re-states the `extra_ignores` rule its caller enforces.
+
+    `cached_walk` never hands listings to a policy carrying `extra_ignores`,
+    so this guard is unreachable through the front door — which is exactly why
+    it needs its own test: a direct `walk(root, policy, listings)` caller is
+    the case it exists for, and without this the guard is one of the few edits
+    the suite would not notice.
+    """
+
+    def test_a_negation_in_extra_ignores_is_not_answered_from_a_listing(self, tmp_path):
+        root = _repo(tmp_path)
+        # `docs/` is excluded by the repo's own rules in this fixture's second
+        # state, so the listing that records that verdict is the wrong answer
+        # to a call whose own patterns re-include it.
+        (root / ".gitignore").write_text("build/\n*.log\ndocs/\n")
+        # Out of the racy window BEFORE the listings are taken, or the guard
+        # under test never gets asked: a freshly-written tree is re-listed on
+        # the next call whatever `extra_ignores` says, and the assertion below
+        # would pass for that reason instead of this one.
+        _age(root)
+        first = eligibility.walk(str(root))
+        assert "docs/guide.md" not in _names(first)
+
+        policy = WalkPolicy(extra_ignores=("!docs/", "!docs/**"))
+        with_cache = eligibility.walk(str(root), policy, first.listings)
+        without = eligibility.walk(str(root), policy)
+
+        assert _names(with_cache) == _names(without)
+        assert "docs/guide.md" in _names(with_cache)
+
+
 class TestDegradation:
     """Every failure costs a warning and a full walk. None costs an answer."""
 
@@ -483,9 +552,35 @@ class TestDegradation:
         assert report.warning is not None
 
     def test_a_repository_that_cannot_be_walked_yields_nothing(self, tmp_path):
-        """No cache, no crash: a missing root is an empty repository."""
-        result = cached_walk(str(tmp_path / "does-not-exist"), quiet=True)
+        """No cache, no crash: a missing root is an empty repository.
+
+        And no directory either. `_save` creates `.neo/`, so writing a cache of
+        nothing turned a mistyped `--cwd` into a silent `mkdir -p` of a path
+        the operator never meant to exist — and pointed at an unmounted
+        mountpoint it would create a local directory shadowing the mount.
+        """
+        missing = tmp_path / "does-not-exist"
+        result = cached_walk(str(missing), quiet=True)
+
         assert result.paths == []
+        assert not missing.exists()
+
+    def test_an_empty_cache_is_discarded_rather_than_believed(self, tmp_path):
+        """A cache of no directories is damage, not a cache of an empty repo.
+
+        Every walk that reaches a readable root records at least the root, so
+        an empty map cannot be a true answer — and believing one made every
+        later call in that repository report `incremental` forever, which is
+        the signal `rebuilt` exists to preserve.
+        """
+        root = _repo(tmp_path)
+        expected = _cached(root)
+        raw = json.loads(cache_path(root).read_text())
+        raw["directories"] = {}
+        cache_path(root).write_text(json.dumps(raw))
+
+        assert _cached(root) == expected
+        assert walk_cache.last_report().mode == "rebuilt"
 
     def test_an_abandoned_temp_file_is_swept(self, tmp_path):
         root = _repo(tmp_path)


### PR DESCRIPTION
## Description

Persists the #208 eligibility walk beside #209's content index, in the repository's own
`.neo/`, so a warm invocation stops re-deriving which files exist and are eligible.
Closes #210. Goal 7 of `docs/unified-store-plan.md`.

Once #209 stopped the BM25 corpus rebuilding per call, the walk was the largest single
item left in a warm Neo call: **4.64 s on m365dotnet** to re-derive that 9,348 files
are eligible, on every invocation, in a repository that had not changed. It is now
**0.16 s**, and the canonical M2 battery went **15.63 s → 8.57 s** median with
byte-identical file selection.

**#209 merged while this was being measured**, so the branch is rebased onto `main`
and the diff is this goal's eight commits alone. The `base` arm in every table below is
`260e56c` (#209's pre-squash head); `git diff 260e56c origin/main` is empty, so it is
content-identical to the squashed `ebd29e0` now on `main` and the comparison stands
unchanged.

### What is cached, and what deliberately is not

- **`index/walk_cache.py`** — per-directory ignore VERDICTS (which subdirectories
  survive, which filenames survive, the exclusion counts), keyed on the directory's
  `mtime_ns` + `ctime_ns`, in `.neo/walk_cache.json`.
- **The design follows from one measurement**, taken before any of this existed. On
  m365dotnet the full walk is 6.85 s, the *same traversal with the per-file ignore test
  removed* is 0.80 s, and `stat`-ing all 9,378 admitted files is 0.10 s. **The walk's
  cost is the pattern matching, not the filesystem** — 6.05 s of 6.85 s is
  `should_ignore`. Caching directory listings would have saved almost nothing; caching
  verdicts saves almost everything.
- **Directory mtime is the right key for one reason**: it moves when an entry is
  created, deleted or renamed, and does NOT move when a file's content changes. An edit
  can change what a file SAYS; it can never change whether it is eligible.
- **File sizes and mtimes are never remembered.** They are read fresh from the `stat`
  the walk owes its callers anyway, because the content index next door uses them as
  ITS freshness stamp. A remembered mtime would make an edited file look unedited —
  one cache's staleness leaking into another's. `TestStampsAreNeverCached` pins it, and
  the M3 evidence below shows an edit landing (`changed=10`) *through* a fully reused
  set of directory listings.
- **A `.gitignore` edit invalidates by CONTENT.** No mtime moves when a pattern file is
  edited, so the signature hashes the effective pattern list (shared defaults + the
  repo's own `.gitignore`/`.ignore`), plus a `MATCHER_VERSION` for the case where the
  patterns are identical and `should_ignore` is not.
- **JSON, not SQLite — the opposite conclusion from the same question #209 asked.**
  Every directory is validated on every call, so the file is read whole every time.
  507 KB and ~10 ms on m365dotnet.
- **`--index` is still an optional warmer.** It goes through the same cache (as does
  `architecture_metrics.compute`, which runs on the outcome path of every real
  invocation), so it warms the walk as well as the catalog — but it is optional,
  because any invocation pays the cold cost once and every later one is warm. A first
  call announces itself before it starts.
- **`--dry-run` reports walk cache hit/miss** — cold / rebuilt / incremental (N of M
  directories) / warm / bypassed, in the selected-files block and in the `--json`
  payload's new `walk_cache` key.

### One defect found in existing behaviour, fixed here

`os.walk(followlinks=False)` had been doing work nobody had named. This traversal
recurses by hand, one directory at a time, so that flag protects only the single read
it is passed: a link to an ancestor was an infinite descent and a link to `/` walked
the machine. The refusal is now explicit, and is not gated by `skip_symlinks` (which is
about whether a symlinked FILE is delivered). The finite case in the same test
(`src/mirror -> docs`) fails in milliseconds rather than hanging.

## Type of Change

- [x] Performance improvement
- [x] New feature (non-breaking change which adds functionality)

## Related Issue

Fixes #210

---

## Evidence

Full tables, exact commands and repo HEADs:
**`docs/goal7-walk-cache-measurements-2026-08-13.md`**.
Arms: `main` = `9b0c16d63cfc` (post-#208, pre-#209) · `base` = `260e56c` (#209 head,
content-identical to today's `main` at `ebd29e0`) · `branch` = `0db7695fc003`, rebased
to `a7fa9c7`.

### M2 — warm call on m365dotnet (`tools/m2_battery.sh`, RUNS=3)

| id | shape | main | base (#209) | **branch** |
|---|---|---|---|---|
| P1 | file-named | 58.25 s | 15.91 s | **8.86 s** |
| P2 | file-named | 50.95 s | 15.63 s | **8.69 s** |
| P3 | concept-only | 49.58 s | 15.23 s | **8.07 s** |
| P4 | concept-only | 51.45 s | 15.53 s | **8.37 s** |
| P5 | mixed | 53.14 s | 15.60 s | **8.41 s** |
| P6 | symptom | 52.96 s | 16.17 s | **9.11 s** |
| **BATTERY** | | **52.20 s** | **15.63 s** | **8.57 s** |
| **peak RSS** | | 1893.0 MiB | 1386.8 MiB | 1387.2 MiB |

**Disclosed:** the `main` arm ran at `RUNS=1` (n=1 per prompt) — a 3-run `main` arm is
~16 minutes and this harness caps a foreground command at 10. It agrees with Goal 6's
independently measured 53.47 s for the same arm, which is why it is quoted rather than
dropped, but it is one sample. The machine is a shared laptop whose load varied (28 at
one point); the branch was measured at two shas, 9.47 s and 8.57 s, both published.

### M2 targets: 6× better, and the ≤ 5 s target is met excluding the memory system

Warm profile, m365dotnet, real CLI with timers wrapped around the stages (no profiler,
so the parts sum to a wall-clock a stopwatch would agree with):

```
T imports                                  1.24s
T eligibility walk                         0.16s  (1 call)   <- 4.64s in #209's profile
T content index refresh                    0.11s  (1 call)
T content index scores                     0.12s  (1 call)
T project index boost                      0.10s  (1 call)
T fact store history boost                 2.25s  (1 call)
T fact store retrieve (memory layer)       1.65s  (1 call)
T   of which fastembed model load          2.73s  (2 calls, inside the two above)
T WALL TOTAL                               7.67s   peak rss = 1385 MB
```

1. **The cost this goal owns is gone.** The walk is **0.16 s of a 7.67 s** warm call,
   down from 4.64 s.
2. **File selection is 0.49 s in total** — walk + content index + project index, on a
   9,348-file repository.
3. **Flagged exactly as #209 flagged it, and as the goal brief asks.** Excluding the
   memory system — `_history_boost` (2.25 s) and the engine's own fact retrieval
   (1.65 s), which between them carry both fastembed loads and all 1.26 GB of the RSS
   — the warm call is **3.77 s, under the ≤ 5 s target**. Including them it is 7.67 s.
   Neither is presented as the other. That is issue #211 and out of scope here.

### M3 — freshness cost AND staleness correctness, on the live repository

One script, three change shapes, each timing the full pipeline (walk + index refresh)
and then asserting the answer actually changed. A unique token is written into the
touched files and searched for through the index; the same search after the restore
must find nothing.

```
baseline (settled)     walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.10s [warm]                  TOTAL= 0.27s  files=9348
A: 10 files edited     walk= 0.15s [warm, 0/951 re-listed]  refresh= 0.69s [incremental, chg=10]   TOTAL= 0.84s  files=9348
   -> marker findable in 10 file(s)
A: restored            walk= 0.17s [warm, 0/951 re-listed]  refresh= 0.51s [incremental, chg=10]   TOTAL= 0.68s  files=9348
   -> marker findable in 0 file(s)
B: 10 files added      walk= 0.22s [incremental, 1/951]     refresh= 0.53s [incremental, add=10]   TOTAL= 0.75s  files=9358
   -> marker findable in 10 file(s): src/NeoGoal7Probe0.cs …
B: removed again       walk= 0.25s [incremental, 1/951]     refresh= 0.42s [incremental, rm=10]    TOTAL= 0.67s  files=9348
   -> marker findable in 0 file(s)
C: one file gitignored walk= 5.67s [rebuilt]   files=9347   still eligible: False
C: gitignore restored  walk= 5.30s [rebuilt]   files=9348   back: True

git status --porcelain identical before/after: True
```

That is the staleness evidence the goal asks for — **add a file, gitignore a file,
delete a file, each reflected on the next call** — and the three shapes exercise three
different mechanisms:

- **A: an edit moves no directory's mtime**, so the walk re-lists nothing and the
  index still sees the change, because the file's stamps were read fresh. Had the
  stamps been cached this line would read `warm, 0 changed` and the index would answer
  with text the file no longer holds.
- **B: an add or a delete moves exactly one directory's mtime** — 1 of 951 re-listed.
- **C: a `.gitignore` edit moves no mtime at all**, so the signature discards the cache
  and the walk runs in full once (5.67 s), then warm again.

**Both M3 shapes are met: 0.84 s and 0.75 s against ≤ 5 s.** The live tree was restored
byte-for-byte.

### M1 — retrieval quality: identical, on all three flagships

| repo | arm | cases | MRR | R@1 | R@3 | R@10 | H@10 |
|---|---|---|---|---|---|---|---|
| neo | main | 50 | 0.712 | 0.307 | 0.502 | 0.708 | 0.980 |
| neo | **branch** | 50 | **0.712** | **0.307** | **0.502** | **0.708** | **0.980** |
| aieweb | main | 50 | 0.728 | 0.487 | 0.654 | 0.778 | 0.880 |
| aieweb | **branch** | 50 | **0.728** | **0.487** | **0.654** | **0.778** | **0.880** |
| m365dotnet | main | 8 | 0.906 | 0.583 | 0.729 | 0.958 | 1.000 |
| m365dotnet | **branch** | 8 | **0.906** | **0.583** | **0.729** | **0.958** | **1.000** |

Byte-identical in every cell. **Disclosed:** m365dotnet ran 8 cases, not 50 — its
`main` arm costs ~52 s per case, so 50 cases is ~40 minutes against a 10-minute
foreground cap. Only the two arms of the same 8 cases are comparable with each other,
which is all this table claims; the absolute is not comparable with Goal 6's 50-case
0.669. The branch arms ran at `cc7d98c`, two commits before HEAD — what carries them
to HEAD is the battery re-run at HEAD selecting **byte-identically** to both `cc7d98c`
and `base`.

**Stronger than the MRR table:** all six canonical battery prompts selected the same
files in the same rank order on **all three arms and at both branch shas** — 24
comparisons, no output.

### G1-inv — a cache of the walker's verdicts cannot widen them

| label | distinct | `git check-ignore` excludes | duplicate content | inside `.worktrees/` | unresolvable |
|---|---|---|---|---|---|
| **BATTERY UNION**, main | 111 | 0 | 0 | 0 | 0 |
| **BATTERY UNION**, base | 111 | 0 | 0 | 0 | 0 |
| **BATTERY UNION**, branch | **111** | **0** | **0** | **0** | **0** |

The three union files are byte-identical.

### Cold cost — what a fresh clone pays, once

| repo | files | dirs | uncached walk | first call | second call | cache on disk |
|---|---|---|---|---|---|---|
| neo | 285 | 43 | 0.41 s | 0.36 s | **0.01 s** | 15 KB |
| aieweb | 902 | 221 | 1.05 s | 0.96 s | **0.06 s** | 64 KB |
| m365dotnet | 9,348 | 951 | 6.85 s | 5.3 s | **0.16 s** | 507 KB |

### A fresh non-author verification pass found two real defects

The routing protocol requires a fresh non-author Claude to verify; it did, and it ran a
differential fuzzer (60 random repos × 8 mutation steps × 5 policies), a base-branch A/B
over ten adversarial filesystem shapes plus three real repositories, a five-process
concurrency stress, and twelve source mutations. It found **no input where the cached
walk returned a different file list, order, exclusion count or file stamp** — and two
defects, both fixed in `0db7695`, each with a mutation-verified test:

1. **MEDIUM — `mtime` alone is forgeable.** `touch -r`, `tar -x`, `rsync -a` and every
   snapshot restore write a directory's mtime back to a recorded value, so a restore
   that adds or deletes a file can land on exactly the cached mtime and be reported
   `warm`. Reproduced with two lines of `os.utime`. `st_ctime_ns` moves on any metadata
   change, no userland API restores it, and it arrives in the same `stat` — so the
   defence costs nothing. On Windows `st_ctime` is a creation time and hence constant,
   which makes the extra comparison a no-op there rather than a false invalidation.
   Schema bumped to 2 so existing caches are discarded rather than misread.
2. **LOW/MEDIUM — `cached_walk` on a path that does not exist created it.** The save
   (which `mkdir -p`s `.neo/`) ran even when the walk had read no directory at all, so
   a mistyped `--cwd` silently minted a directory tree — and pointed at an unmounted
   mountpoint it would create a local directory shadowing the mount. Nothing is written
   when nothing was learned, and an empty stored listing map is now rejected on load
   too (believing one made every later call report `incremental` forever).

Also from that pass: secondary walks (`--index`, the arch scan) no longer overwrite the
process-global report the operator's `--dry-run` line describes; and three comments
quoting a *derived* 0.11 s for the directory listing now quote the *measured* 0.80 s
arm, which the measurements doc in the same commit series had contradicted.

## How Has This Been Tested?

- [x] `tests/test_walk_cache.py` — 41 new tests in six groups. **Parity**: the cached
      and uncached walks compared over add / delete / rename / new directory /
      gitignore edit / nested checkout appearing / symlinked directory / policy
      filters. **Live stamps**: an edit is visible through a fully reused listing.
      **Reporting**: every mode is the work actually done. **Racy directories**:
      pre-creating `.neo/` so the guard is what the test measures. **Forged
      timestamps**: `os.utime` restoring an mtime does not hide an add or a delete.
      **Degradation**: corrupt, truncated, empty, malformed-entry, foreign-signature,
      unwritable, missing root, stranded temp files.
- [x] **Seven source mutations, all caught**: constant signature → the gitignore test
      fails; cached file stamps → the stamp test fails; racy-window removed → the racy
      tests fail; descend into symlinked dirs → the symlink test fails; drop the ctime
      key → the forged-timestamp test fails; save a cache of nothing → the missing-root
      test fails; the walk-side `extra_ignores` guard removed → its own test fails. The
      first cut of the racy tests and of the `extra_ignores` test each passed under
      their mutant for an unrelated reason, and both are fixed and re-verified.
- [x] The #208 differential suite against `git check-ignore`
      (`tests/test_eligibility_differential.py`) and the single-source guards
      (`tests/test_eligibility_single_source.py`) pass **untouched** — no change to
      either file.
- [x] Full suite: **2566 passed, 29 skipped, 1 failed**. The failure is
      `test_consolidation_performance_with_all_boosts`, a wall-clock assertion inside a
      correctness test, and it **fails identically on the base branch** (255.6 ms there,
      267.9 ms here, against a 100 ms bound) on this machine. It is the class of failure
      CLAUDE.md documents as advisory-not-correctness.
- [x] `ruff check src/ tests/ tools/` clean.
- [x] End-to-end through the real CLI on m365dotnet (9,348 files), aieweb and neo —
      cold, incremental, warm and gitignore-invalidated, in both `--dry-run` output
      modes.

**Test Configuration**: Python 3.13.7 · macOS (darwin 25.5.0) · neo 0.45.0 at
`0db7695`, rebased onto `main` as `a7fa9c7` with no conflicts and re-verified there

## Checklist

- [x] Code follows the project's style
- [x] Self-review performed, plus an independent fresh-verifier pass
- [x] Commented, particularly the load-bearing decisions (why verdicts and not
      listings, why mtime is the right key, why mtime alone is not enough, why the
      stamps are never cached, why JSON here and SQLite next door)
- [x] Docs updated — `CLAUDE.md` and a datestamped measurements doc
- [x] No new warnings
- [x] Tests added that prove the change works and that it did not re-rank
- [x] New and existing tests pass (see the one pre-existing failure above)

## Additional Notes

**Two clones of one repository do not share a cache.** It lives in each working tree's
own `.neo/`, because it is keyed on that tree's directory stamps.

**A `.gitignore` edit costs one full walk** (5.67 s on m365dotnet), then warm again.
Deriving which directories a pattern edit could have affected is a large amount of
machinery guarding a cost paid when someone edits a `.gitignore`.

**What would still fool it:** a directory whose mtime AND ctime are both restored — not
reachable from normal userland, but a filesystem image edited offline could do it.

Opened as **DRAFT** per the plan's option-3 governance: the shepherd verifies this
evidence and flips it ready; the car-pr-review daemon is the independent gate after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
