### PR TITLE
fix(front-door): pins cannot starve the scan; each budget cap owns its own count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1003,6 +1003,27 @@
   on the same terms `--include` uses. The boost STAYS on the ranking: a file can
   only be pinned if the walk found it, so the boost covers the candidates the
   pin pool never held (an `--exts`-narrowed list).
+  **The pin block cannot spend the whole ceiling** (`PIN_BUDGET_SHARE` = 0.5).
+  Ruling 1 is "the named files AND keep scanning", and funding pins to the last
+  byte satisfies the first clause by deleting the second. Measured on the M2
+  battery after #214 merged: the prompt naming
+  `src/Parslee.M365.Api/Program.cs` (442,867 bytes) pinned it, spent 299,959 of
+  the 300,000-byte default, and delivered **one file** — the whole context was
+  that file — where pre-#214 main delivered 22 and the fix delivers 30. The
+  reserve binds only when pins would take more than half; with nothing else
+  eligible it would fund nothing, so it does not apply and the pin arrives
+  whole. The held-back cut is marked and announced, which the ruling permits
+  ("whole, or with an explicit marker").
+  **Each budget cap is charged for what IT removed.** `dropped_by_file_cap` is
+  counted before the byte cap cuts and `dropped_by_byte_cap` after, and both are
+  reported when both bind. Deriving the file cap's verdict from the full
+  candidate list made the run print `pinned files filled the file budget
+  (--max-files=30)` with 29 of 30 slots free and the BYTE ceiling holding the
+  count at one — raising the named knob provably changed nothing, which is this
+  repo's own rule about never blaming a cap for an absence it did not cause,
+  broken inside the goal whose subject is selection truthfulness. In the
+  scan-delivered-nothing branch the byte cap is tested FIRST, because it is
+  applied second and therefore holds the margin.
   **Delivery is one entry per file, read whole from disk.** Chunking survives
   only as a RANKING internal — it chooses WHICH region of an over-budget file
   arrives, never how many entries a file contributes. `--max-bytes` is

--- a/docs/goal8-front-door-measurements-2026-08-13.md
+++ b/docs/goal8-front-door-measurements-2026-08-13.md
@@ -198,6 +198,41 @@ P1 and P5 are slower and P2, P3, P4, P6 faster; every one of those differences i
 smaller than the spread within a single prompt's own three runs. Read the battery
 median, not a row.
 
+### Correction (2026-08-13, post-merge): P1 delivered ONE file, and this doc did not say so
+
+The table above reports P1's wall-clock and RSS and nothing else, and the
+selection table below reports only aggregates. Both concealed the single largest
+behavioural change on the battery, which a fresh non-author verifier found in
+this branch's own committed artifact:
+
+| | pre-#214 main | #214 as merged | with `PIN_BUDGET_SHARE` |
+|---|---|---|---|
+| P1 entries / distinct files | 30 / 22 | **1 / 1** | 30 / 30 |
+| P1 context bytes | 240,525 | 299,959 | 284,406 |
+
+P1 names `src/Parslee.M365.Api/Program.cs` (442,867 bytes). Stage 1 pinned it,
+the pin took 299,959 of the 300,000-byte default ceiling, `remaining_bytes` fell
+to 41, and the scan contributed **nothing** — the entire context was one file.
+The aggregate "sum of per-prompt distinct files 135 → 151" nets a −21 on P1
+against gains elsewhere, and "entries == distinct files on all six prompts" is
+true for P1 only as `1 == 1`.
+
+Two things were wrong and both are fixed in the follow-up:
+
+1. **Ruling 1 has two clauses.** "The named files AND keep scanning" was
+   satisfied by deleting the second. `PIN_BUDGET_SHARE` holds the pin block to
+   half of `--max-bytes` while the scan still has candidates of its own; the cut
+   is marked and announced, which the ruling explicitly permits.
+2. **The warning named the wrong knob.** The run printed `pinned files filled
+   the file budget (--max-files=30)` with 29 of 30 slots free — the byte ceiling
+   was the binder, and raising `--max-files` would have changed nothing.
+
+**Consequence for the M2 medians above:** the branch's P1 did roughly 1/30th of
+main's delivery work and was still the slowest branch prompt (10.50 s vs
+9.37 s), so the battery median comparison is confounded. The confound runs
+against the branch, so "within noise" survives — but P1 is not like-for-like and
+the median should not be read as one.
+
 ### Selection, on the same battery
 
 | | main | branch |

--- a/src/neo/context_gatherer.py
+++ b/src/neo/context_gatherer.py
@@ -160,6 +160,12 @@ SEMANTIC_HINT_WEIGHT = CONTENT_WEIGHT
 #: the keyword stage never scored at all.
 SEMANTIC_HINT_DEPTH = 3
 
+#: Largest share of `--max-bytes` the pin block may take while the scan still
+#: has candidates of its own. Ruling 1 is "the named files AND keep scanning";
+#: an unbounded pin block satisfies the first clause by deleting the second.
+#: See the call site in `gather_context` for the measurement that forced it.
+PIN_BUDGET_SHARE = 0.5
+
 #: Floor on a scan file's share of `--max-bytes`. Below this a file arrives as
 #: little more than its own truncation marker, which costs a delivery slot and
 #: answers nothing — so the file count is reduced to what the ceiling can
@@ -1381,27 +1387,30 @@ def _budget_notes(
     config: GatherConfig,
     adaptive_limit: int,
     *,
-    file_cap_rejected: bool,
-    bytes_cap_rejected: bool,
-    dropped: int,
+    dropped_by_file_cap: int,
+    dropped_by_byte_cap: int,
 ) -> None:
-    """Name the cap that actually reduced the selection, and only that one.
+    """Name each cap that reduced the selection, charged for what IT removed.
 
     G3-inv: no silent caps. The scan used to stop mid-loop and say nothing —
     the operator saw twelve files and no indication that a thirteenth had lost
     to a ceiling rather than to the ranking. Those are different facts with
     different remedies and they looked identical.
 
-    The file cap is reported before the byte cap because it is applied first
-    and is therefore the one that bound: with 40 candidates, 25 slots and a
-    ceiling that could fund 30, it is `--max-files` that turned away the other
-    15 and raising `--max-bytes` changes nothing. Reporting both would send the
-    operator to a knob that cannot move the number, which is this repo's own
-    rule about never blaming a cap for an absence it did not cause.
+    **Both caps can bind at once and then both are named, with their own
+    counts.** The first version took one boolean per cap, derived the file
+    cap's from the full candidate list before the byte cap had cut anything,
+    and reported the file cap alone whenever both were true. Reproduced: 41
+    candidates, 3 delivered, "38 lower-ranked file(s) not delivered: the file
+    budget was reached" — where the file cap accounted for 16 and the byte cap
+    for 22, and raising `--max-files` moved nothing. A count attributed to the
+    wrong knob is worse than no count, because the operator acts on it.
+
+    The two are charged in application order: the file cap sees every
+    candidate, the byte cap sees only what survived it. So the numbers sum to
+    the real loss and neither is double-counted.
     """
-    if not dropped:
-        return
-    if file_cap_rejected:
+    if dropped_by_file_cap:
         # The limit that bound is the ADAPTIVE one, and printing it as
         # `--max-files=25` names a number the operator never typed — worse,
         # below specificity 10 `calculate_adaptive_limit` returns a fixed
@@ -1414,11 +1423,11 @@ def _budget_notes(
             else f"--max-files={config.max_files}"
         )
         progress.note(
-            f"{dropped} lower-ranked file(s) not delivered: the file budget "
-            f"({knob}) was reached")
-    elif bytes_cap_rejected:
+            f"{dropped_by_file_cap} lower-ranked file(s) not delivered: the "
+            f"file budget ({knob}) was reached")
+    if dropped_by_byte_cap:
         progress.note(
-            f"{dropped} lower-ranked file(s) not delivered: "
+            f"{dropped_by_byte_cap} lower-ranked file(s) not delivered: "
             f"--max-bytes={config.max_bytes:,} cannot fund them above "
             f"{MIN_FILE_SHARE_BYTES} bytes each")
 
@@ -1526,10 +1535,39 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
             pin_origins[entry[1]] = origin
             pin_entries.append(entry)
 
-    pin_report = pin_included_files(pin_entries, config.max_bytes, pin_origins)
+    # **The pin block cannot spend the whole ceiling while anything else is
+    # eligible.** Standing ruling 1 has two clauses — the named files, AND the
+    # scan keeps running — and funding pins to the last byte honours the first
+    # by deleting the second. Measured on the M2 battery: the prompt naming
+    # `src/Parslee.M365.Api/Program.cs` (442,867 bytes) pinned it, spent 299,959
+    # of the 300,000-byte default, left 41 bytes, and delivered **one file**
+    # where main delivered 22. The ruling permits a marked cut ("whole, or with
+    # an explicit marker"); it does not permit the scan contributing nothing
+    # because one named file was large.
+    #
+    # Half, and symmetric, because neither side has a claim to more of the
+    # other's budget than that: "the files you named" and "everything else
+    # useful" are the two things the caller asked for. It binds only when pins
+    # would otherwise take more than half, which on every prompt in the M2
+    # battery except P1 is never — pins are typically a few KB against 300,000.
+    # With nothing else eligible the reserve would fund nothing, so the pins
+    # take the whole ceiling and arrive whole.
+    scan_pool_exists = any(rel not in pin_origins for _a, rel, _s in candidates)
+    pin_budget = (
+        max(int(config.max_bytes * PIN_BUDGET_SHARE), 1)
+        if scan_pool_exists and pin_entries
+        else config.max_bytes
+    )
+    pin_report = pin_included_files(pin_entries, pin_budget, pin_origins)
     pinned = pin_report.files
     pinned_rels = {f.rel_path for f in pinned}
-    _pin_notes(pin_report, config.max_bytes, include_misses, include_refused)
+    _pin_notes(pin_report, pin_budget, include_misses, include_refused)
+    if pin_budget != config.max_bytes and pin_report.truncated_rels:
+        progress.note(
+            f"The pinned block is held to {pin_budget:,} bytes "
+            f"({PIN_BUDGET_SHARE:.0%} of --max-bytes={config.max_bytes:,}) so "
+            "the scan still has a budget to run in; raise --max-bytes to give "
+            "both more room")
 
     if explicit_paths and not explicit_matches:
         # A named path that matched nothing is the single highest-value
@@ -1721,8 +1759,7 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # have changed anything.
     eligible_scan = [c for c in scored if c[1] not in pinned_rels]
     scan_slots = max(adaptive_limit - len(selected), 0)
-    file_cap_rejected = len(eligible_scan) > scan_slots
-    scan_candidates = eligible_scan[:scan_slots]
+    after_file_cap = eligible_scan[:scan_slots]
 
     # The byte ceiling reduces the file COUNT rather than truncating the tail
     # of the ranking mid-loop, so what it costs is one number the operator can
@@ -1730,9 +1767,20 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
     # nothing but the file's own truncation marker.
     remaining_bytes = max(config.max_bytes - pinned_bytes, 0)
     affordable = remaining_bytes // MIN_FILE_SHARE_BYTES
-    bytes_cap_rejected = len(scan_candidates) > affordable
-    if bytes_cap_rejected:
-        scan_candidates = scan_candidates[:affordable]
+    scan_candidates = after_file_cap[:affordable]
+
+    # **Each cap is charged for what IT removed, and the two are counted
+    # separately.** The first version set `file_cap_rejected` from the full
+    # candidate list and then let the byte cap cut further, so whenever both
+    # bound the file cap was named and the byte cap was never mentioned —
+    # reproduced live at `--max-files=30`, where the message read "pinned files
+    # filled the file budget (--max-files=30)" for a run with 29 of 30 slots
+    # free and the BYTE ceiling holding the count at one. Raising the knob the
+    # run named provably changed nothing, which is this repo's own rule about
+    # never blaming a cap for an absence it did not cause, broken inside the
+    # goal whose subject is selection truthfulness.
+    dropped_by_file_cap = len(eligible_scan) - len(after_file_cap)
+    dropped_by_byte_cap = len(after_file_cap) - len(scan_candidates)
 
     # Apportion on the walk's own size, not on a pre-pass that reads every
     # candidate: the walk already stat'd them, and reading files the ceiling
@@ -1791,9 +1839,8 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
         _budget_notes(
             config,
             adaptive_limit,
-            file_cap_rejected=file_cap_rejected,
-            bytes_cap_rejected=bytes_cap_rejected,
-            dropped=len(eligible_scan) - len(scan_candidates),
+            dropped_by_file_cap=dropped_by_file_cap,
+            dropped_by_byte_cap=dropped_by_byte_cap,
         )
 
     if scan_delivered_nothing:
@@ -1807,7 +1854,17 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
         # settings that would change nothing. That is this repo's own rule
         # about never blaming a cap for an absence it did not cause, broken
         # inside the goal whose subject is selection truthfulness.
-        if file_cap_rejected:
+        # Which cap to name is decided by which one REMOVED candidates, in the
+        # same accounting `_budget_notes` uses — and the BYTE cap is tested
+        # first here, because it is applied second and is therefore the one
+        # holding the margin when both bound. The reverse order named
+        # `--max-files=30` on a run with 29 slots free.
+        if dropped_by_byte_cap:
+            progress.note(
+                f"Warning: pinned files filled the byte budget "
+                f"(--max-bytes={config.max_bytes:,}); the scan contributed "
+                "nothing")
+        elif dropped_by_file_cap:
             # The limit that bound is the ADAPTIVE one, and printing it as
             # `--max-files=25` names a number the operator never typed — worse,
             # below specificity 10 `calculate_adaptive_limit` returns a fixed
@@ -1822,11 +1879,6 @@ def gather_context(config: GatherConfig) -> list[ContextFile]:
             progress.note(
                 f"Warning: pinned files filled the file budget ({knob}); "
                 "the scan contributed nothing")
-        elif bytes_cap_rejected:
-            progress.note(
-                f"Warning: pinned files filled the byte budget "
-                f"(--max-bytes={config.max_bytes:,}); the scan contributed "
-                "nothing")
         else:
             # No cap bound. The scan simply found nothing else eligible, which
             # no setting changes — so it gets a bare statement and no remedy.

--- a/tests/test_front_door.py
+++ b/tests/test_front_door.py
@@ -39,6 +39,12 @@ PROMPT_NAMING = (
     "is busy"
 )
 PROMPT_PLAIN = "Fix the connection pool timeout when the database is busy"
+# Three named paths against a one-file cap. Boosting cannot put three files
+# through one slot; only a pin can, which is what makes the cap test bite.
+PROMPT_NAMING_THREE = (
+    "Fix the connection pool timeout across src/app/pool.py, "
+    "src/app/client.py and src/app/config.py"
+)
 
 _BULK = "\n".join(
     f"    # database pool connection timeout retry line {i}" for i in range(400)
@@ -59,6 +65,16 @@ def repo(tmp_path):
     (tmp_path / "src" / "app" / "pool.py").write_text(
         "def connection_pool_timeout():\n"
         "    '''Database connection pool timeout handling.'''\n"
+        f"{_BULK}\n",
+        encoding="utf-8",
+    )
+    # See the matching note in tests/test_include_guarantee.py: a single big
+    # file cannot separate pinned from unpinned at one ceiling, because any
+    # ceiling that leaves the pin block room also leaves the scan's fair share
+    # room. `PIN_BUDGET_SHARE` holds the pin block to half.
+    (tmp_path / "src" / "app" / "worker.py").write_text(
+        "def connection_pool_worker():\n"
+        "    '''Database connection pool worker loop.'''\n"
         f"{_BULK}\n",
         encoding="utf-8",
     )
@@ -108,30 +124,39 @@ class TestStageOneIsAPin:
 
         assert named.pinned is True
 
-    def test_a_named_path_survives_a_file_cap_of_one(self, repo):
+    def test_every_named_path_survives_a_file_cap_of_one(self, repo):
         """The claim `EXPLICIT_PATH_BOOST` could not make.
 
-        +10.0 clears every organic signal combined, so the file did rank
-        first — and a prompt naming more files than the limit admits still
-        lost the ones past the cut, because ranking first is not presence.
+        The prompt names THREE files against a one-file cap, and that is the
+        whole point: with one named file the boost alone still delivers it,
+        so a single-file version of this test passes with stage 1 deleted and
+        proves nothing. A verifier reverted the pin and watched exactly that
+        happen. Boosting cannot put three files through one slot; pinning can,
+        because a pin is not competing for the slot.
         """
-        gathered = _gather(repo, prompt=PROMPT_NAMING, max_files=1)
+        gathered = _gather(repo, prompt=PROMPT_NAMING_THREE, max_files=1)
+        rels = _rels(gathered)
 
-        assert "src/app/pool.py" in _rels(gathered)
+        for named in (
+            "src/app/pool.py", "src/app/client.py", "src/app/config.py"
+        ):
+            assert named in rels, f"{named} was named and did not arrive: {rels}"
 
-    def test_the_control_run_really_does_lose_it(self, repo):
-        """Guards the guard: at `--max-files=1` the pool file must NOT arrive
-        when nothing names it, or the assertion above proves nothing."""
+    def test_the_control_run_really_does_lose_them(self, repo):
+        """Guards the guard: at `--max-files=1` exactly one file arrives when
+        nothing names them, or the assertion above proves nothing."""
         gathered = _gather(repo, prompt=PROMPT_PLAIN, max_files=1)
+
         assert len(gathered) == 1
-        # It may or may not be the top-ranked file; what must be true is that
-        # a single slot is decided by the ranking, not by a guarantee.
         assert all(not g.pinned for g in gathered)
 
     def test_a_named_path_arrives_whole_at_a_ceiling_that_would_cut_it(self, repo):
         """Same ceiling in both arms; only the naming differs."""
         source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
-        ceiling = len(source.encode("utf-8"))
+        # TWICE the file: the pin block is held to half of `--max-bytes` while
+        # anything else is eligible, so half seats the pin exactly while the
+        # scan must split the same ceiling with `worker.py`.
+        ceiling = 2 * len(source.encode("utf-8"))
 
         control = _gather(repo, prompt=PROMPT_PLAIN, max_bytes=ceiling)
         control_pool = next(
@@ -192,6 +217,11 @@ class TestStageOrder:
         gathered = _gather(repo, prompt=PROMPT_NAMING)
         pinned_positions = [i for i, g in enumerate(gathered) if g.pinned]
 
+        # Non-empty FIRST. `[] == list(range(0))` is True, so without this the
+        # assertion below passes on a run with no pins at all — which is
+        # exactly the state a reverted stage 1 leaves it in.
+        assert pinned_positions, "nothing was pinned; the assertion is vacuous"
+        assert len(gathered) > len(pinned_positions), "the scan added nothing"
         assert pinned_positions == list(range(len(pinned_positions)))
 
 
@@ -258,19 +288,40 @@ class TestTheBudgetIsApportionedNotSpent:
         small ones are funded in full and the pool file pays."""
         source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
         gathered = _gather(repo, max_bytes=len(source.encode("utf-8")))
-        rels = _rels(gathered)
+        by_rel = {g.rel_path: g for g in gathered}
 
-        assert "src/app/pool.py" in rels
-        assert "src/app/client.py" in rels
-        assert "src/app/config.py" in rels
+        for rel in ("src/app/pool.py", "src/app/client.py", "src/app/config.py"):
+            assert rel in by_rel, f"{rel} did not arrive: {sorted(by_rel)}"
+
+        # PRESENT IS NOT ENOUGH. Under a greedy spend the small files still
+        # "arrive" — as marker-only entries with a zero allowance — so an
+        # `in rels` assertion passes with apportionment reverted. A verifier
+        # swapped `apportion` for a greedy fill and watched this test stay
+        # green. What apportionment buys is that the small files arrive
+        # INTACT, so that is what is asserted.
+        for rel in ("src/app/client.py", "src/app/config.py"):
+            on_disk = (repo / rel).read_text(encoding="utf-8")
+            assert (by_rel[rel].content or "") == on_disk, (
+                f"{rel} arrived cut; the big file took its budget"
+            )
 
     def test_the_small_files_are_not_the_ones_that_pay(self, repo):
+        """Max-min fair means the LARGE files pay and the small ones do not.
+
+        `pool.py` and `worker.py` are both ~21 KB and both legitimately pay at
+        this ceiling; the assertion is about the three small files, which a
+        greedy fill in rank order would have starved entirely.
+        """
         source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
         gathered = _gather(repo, max_bytes=len(source.encode("utf-8")))
+        big = {"src/app/pool.py", "src/app/worker.py"}
 
-        for g in gathered:
-            if g.rel_path != "src/app/pool.py":
-                assert g.truncated is False, f"{g.rel_path} paid for the big file"
+        small = [g for g in gathered if g.rel_path not in big]
+        assert small, "fixture stopped delivering any small file"
+        for g in small:
+            assert g.truncated is False, f"{g.rel_path} paid for the big files"
+            on_disk = (repo / g.rel_path).read_text(encoding="utf-8")
+            assert (g.content or "") == on_disk
 
     def test_the_ceiling_is_honoured(self, repo):
         source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
@@ -278,6 +329,178 @@ class TestTheBudgetIsApportionedNotSpent:
         gathered = _gather(repo, max_bytes=ceiling)
 
         assert sum(g.bytes for g in gathered) <= ceiling
+
+
+class TestThePinBlockCannotStarveTheScan:
+    """Ruling 1 has two clauses, and funding pins to the last byte deletes one.
+
+    Measured on the M2 battery before `PIN_BUDGET_SHARE` existed: the prompt
+    naming `src/Parslee.M365.Api/Program.cs` (442,867 bytes) pinned it, spent
+    299,959 of the 300,000-byte default ceiling, and delivered **one file**
+    where main delivered 22. "The named files AND keep scanning" was satisfied
+    by deleting the second half.
+    """
+
+    def test_the_scan_still_runs_when_a_named_file_would_eat_the_ceiling(
+        self, repo
+    ):
+        source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
+        # Just over the named file's own size: without the reserve the pin
+        # takes all but a few hundred bytes and `affordable` falls to zero.
+        ceiling = len(source.encode("utf-8")) + 500
+
+        gathered = _gather(repo, prompt=PROMPT_NAMING, max_bytes=ceiling)
+        rels = _rels(gathered)
+
+        assert "src/app/pool.py" in rels
+        scan = [g for g in gathered if not g.pinned]
+        assert scan, (
+            "the pin block took the whole ceiling and the scan contributed "
+            f"nothing: {rels}"
+        )
+
+    def test_the_reserve_is_what_makes_that_true(self, repo):
+        """Guards the guard: prove the ceiling really is tight enough that an
+        unreserved pin block would have consumed it.
+
+        Without this the test above passes on any ceiling roomy enough for
+        both, which is most of them.
+        """
+        from neo.context_gatherer import MIN_FILE_SHARE_BYTES, PIN_BUDGET_SHARE
+
+        source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
+        pin_bytes = len(source.encode("utf-8"))
+        ceiling = pin_bytes + 500
+
+        # What the scan would have been left with, unreserved.
+        assert (ceiling - pin_bytes) // MIN_FILE_SHARE_BYTES == 0
+        # And what it is left with under the reserve.
+        assert (
+            ceiling - int(ceiling * PIN_BUDGET_SHARE)
+        ) // MIN_FILE_SHARE_BYTES >= 1
+
+    def test_the_held_back_pin_is_cut_marked_and_announced(self, repo, capsys):
+        source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
+        ceiling = len(source.encode("utf-8")) + 500
+
+        gathered = _gather(repo, prompt=PROMPT_NAMING, max_bytes=ceiling)
+        err = capsys.readouterr().err
+        pool = next(g for g in gathered if g.rel_path == "src/app/pool.py")
+
+        assert pool.truncated is True
+        assert MARKER_PREFIX in (pool.content or "")
+        assert "the pinned block is held to" in err.lower()
+
+    def test_a_pin_that_fits_is_not_held_back(self, repo, capsys):
+        """The reserve must not be background noise: at the default ceiling a
+        pin of this size is nowhere near half, and nothing is said."""
+        gathered = _gather(repo, prompt=PROMPT_NAMING)
+        err = capsys.readouterr().err
+        pool = next(g for g in gathered if g.rel_path == "src/app/pool.py")
+
+        assert pool.truncated is False
+        assert "held to" not in err
+
+    def test_pins_take_the_whole_ceiling_when_nothing_else_is_eligible(
+        self, tmp_path
+    ):
+        """The reserve funds a scan that can run. With no other candidate it
+        would fund nothing, so it does not apply and the pin arrives whole."""
+        (tmp_path / "only.py").write_text(
+            "def connection_pool_timeout():\n" + "    # pool timeout\n" * 200,
+            encoding="utf-8",
+        )
+        source = (tmp_path / "only.py").read_text(encoding="utf-8")
+
+        gathered = _gather(
+            tmp_path,
+            prompt="Fix the timeout in only.py",
+            max_bytes=len(source.encode("utf-8")),
+        )
+
+        assert len(gathered) == 1
+        assert gathered[0].pinned is True
+        assert gathered[0].truncated is False
+        assert gathered[0].content == source
+
+
+class TestEachCapIsChargedForWhatItRemoved:
+    """The repo's own rule: never blame a cap for an absence it did not cause.
+
+    The first version derived the file cap's verdict from the FULL candidate
+    list and then let the byte cap cut further, so whenever both bound only the
+    file cap was named. Reproduced live at `--max-files=30`: "pinned files
+    filled the file budget (--max-files=30)" on a run with 29 of 30 slots free
+    and the byte ceiling holding the count at one.
+    """
+
+    @staticmethod
+    def _many(tmp_path, n=40):
+        for i in range(n):
+            (tmp_path / f"pool_{i:02d}.py").write_text(
+                f"def connection_pool_timeout_{i}():\n"
+                + f"    # database pool connection timeout retry {i}\n" * 4,
+                encoding="utf-8",
+            )
+        return tmp_path
+
+    def test_the_byte_cap_is_named_when_it_is_the_one_holding_the_count(
+        self, tmp_path, capsys
+    ):
+        from neo.context_gatherer import MIN_FILE_SHARE_BYTES
+
+        self._many(tmp_path)
+        # Room for two files by bytes, and far more than two file slots.
+        gathered = _gather(
+            tmp_path, max_files=200, max_bytes=MIN_FILE_SHARE_BYTES * 2 + 100
+        )
+        err = capsys.readouterr().err
+
+        assert len(gathered) == 2
+        assert "--max-bytes" in err
+        assert "file budget" not in err
+
+    def test_raising_the_named_knob_actually_moves_the_number(self, tmp_path):
+        """The property a mis-attributed warning breaks. If the run names
+        `--max-bytes`, raising `--max-bytes` must change the outcome."""
+        from neo.context_gatherer import MIN_FILE_SHARE_BYTES
+
+        self._many(tmp_path)
+        tight = _gather(
+            tmp_path, max_files=200, max_bytes=MIN_FILE_SHARE_BYTES * 2 + 100
+        )
+        roomier = _gather(
+            tmp_path, max_files=200, max_bytes=MIN_FILE_SHARE_BYTES * 20 + 100
+        )
+
+        assert len(roomier) > len(tight)
+
+    def test_both_caps_are_reported_with_their_own_counts(
+        self, tmp_path, capsys
+    ):
+        """Both can bind at once, and then both are named. Reporting one
+        understates the loss and points at a knob that only half explains it."""
+        from neo.context_gatherer import MIN_FILE_SHARE_BYTES
+
+        self._many(tmp_path)
+        gathered = _gather(
+            tmp_path, max_files=10, max_bytes=MIN_FILE_SHARE_BYTES * 3 + 100
+        )
+        err = capsys.readouterr().err
+
+        assert len(gathered) == 3
+        assert "file budget" in err
+        assert "--max-bytes" in err
+
+    def test_only_the_file_cap_is_named_when_bytes_are_plentiful(
+        self, tmp_path, capsys
+    ):
+        self._many(tmp_path)
+        _gather(tmp_path, max_files=5, max_bytes=1_000_000)
+        err = capsys.readouterr().err
+
+        assert "file budget" in err
+        assert "cannot fund them above" not in err
 
 
 class _FakeChunk:

--- a/tests/test_include_guarantee.py
+++ b/tests/test_include_guarantee.py
@@ -67,6 +67,18 @@ def repo(tmp_path):
         f"{_BULK}\n",
         encoding="utf-8",
     )
+    # A SECOND file of the same order of size. Without it the pinned/unpinned
+    # A/B cannot be run at ONE ceiling: with a single big file, any ceiling
+    # that leaves the pin block enough room also leaves the scan's max-min
+    # fair share enough room, so the control stops excerpting and the
+    # comparison proves nothing. Two big files make the scan split what the
+    # pin block gets to itself.
+    (tmp_path / "src" / "app" / "worker.py").write_text(
+        "def connection_pool_worker():\n"
+        "    '''Database connection pool worker loop.'''\n"
+        f"{_BULK}\n",
+        encoding="utf-8",
+    )
     (tmp_path / "src" / "app" / "client.py").write_text(
         "def database_client():\n    '''Database client, uses the pool.'''\n"
         "    return connection_pool_timeout()\n",
@@ -197,7 +209,11 @@ class TestIncludedFilesAreGuaranteed:
         evidence the guarantee did anything.
         """
         source = (repo / "src" / "app" / "pool.py").read_text(encoding="utf-8")
-        ceiling = len(source.encode("utf-8"))
+        # TWICE the file, because the pin block is held to half of
+        # `--max-bytes` while anything else is eligible (`PIN_BUDGET_SHARE`).
+        # Half of this seats the pin exactly, while the scan has to split the
+        # same ceiling with `worker.py` and cannot.
+        ceiling = 2 * len(source.encode("utf-8"))
 
         control = _gather(repo, max_bytes=ceiling)
         control_pool = [g for g in control if g.rel_path == "src/app/pool.py"]
@@ -246,7 +262,8 @@ class TestIncludedFilesAreGuaranteed:
         pinned = [g.rel_path for g in _gather(repo, includes=["src/app/*.py"])
                   if g.pinned]
         assert set(pinned) == {
-            "src/app/pool.py", "src/app/client.py", "src/app/config.py"
+            "src/app/pool.py", "src/app/worker.py",
+            "src/app/client.py", "src/app/config.py",
         }
         assert len(rels) == len(set(rels))
 


### PR DESCRIPTION
## Description

Follow-up to #214 (unified-store Goal 8). Two defects that #214 introduced and shipped, both found by a fresh non-author verifier reading **#214's own committed evidence** after it merged. Neither is a new feature; both restore properties #214 claimed and broke.

### 1. The pin block could spend the whole byte ceiling, and the scan got nothing

Standing ruling 1 is *"guarantee the named files … AND keep scanning for anything else useful"*. Funding pins to the last byte satisfies the first clause by deleting the second.

Reproduced on `main` at `5c0ce5d`, using the canonical M2 battery's own P1 prompt — it names `src/Parslee.M365.Api/Program.cs` (442,867 bytes):

| | pre-#214 (`d5adcbc`) | **#214 as merged (`5c0ce5d`)** | this PR |
|---|---|---|---|
| entries / distinct files | 30 / 22 | **1 / 1** | 30 / 30 |
| context bytes | 240,525 | 299,959 | 284,406 |

The pin took 299,959 of the 300,000-byte default, `remaining_bytes` fell to 41, `affordable` to 0, and **the entire context was one file**. Mentioning a large file in your prompt deleted the rest of your context.

`PIN_BUDGET_SHARE` (0.5) holds the pin block to half of `--max-bytes` **while the scan still has candidates of its own**. The held-back cut is marked inline and announced — which the ruling explicitly permits ("whole, or with an explicit marker"). With nothing else eligible the reserve would fund nothing, so it does not apply and the pin arrives whole; `test_pins_take_the_whole_ceiling_when_nothing_else_is_eligible` pins that.

Half, and symmetric, because neither of "the files you named" and "everything else useful" has a claim to more of the other's budget. It binds on exactly one of the six battery prompts.

### 2. Both budget caps could bind and only the file cap was named

`file_cap_rejected` was derived from the full candidate list *before* the byte cap had cut anything, so whenever both bound the file cap was reported and the byte cap was never mentioned. On the same P1 run, merged main prints:

```
Warning: pinned files filled the file budget (--max-files=30); the scan contributed nothing
```

— with **29 of 30 file slots free** and the byte ceiling holding the count at one. Raising the knob the run named provably changes nothing.

Each cap is now charged for what IT removed, in application order (`dropped_by_file_cap` counted before the byte cap cuts, `dropped_by_byte_cap` after), and **both are reported when both bind** with their own counts. In the scan-delivered-nothing branch the byte cap is tested first, because it is applied second and therefore holds the margin.

This is the repo's own `never blame a cap for an absence it did not cause` rule, broken inside the goal whose subject is selection truthfulness.

### 3. Three of #214's new tests did not bite

Verified by mutation, not by reading:

- `test_a_named_path_survives_a_file_cap_of_one` passed with **stage 1 deleted** — the fixture named ONE file, and `EXPLICIT_PATH_BOOST` alone still delivers one file into one slot. It now names THREE paths against a one-file cap, which boosting cannot satisfy.
- `test_pins_come_before_the_scan` passed **vacuously** with zero pins: `[] == list(range(0))`. It now asserts the pin list is non-empty and that the scan also contributed.
- `test_every_ranked_file_arrives_despite_one_large_one` passed with `apportion` replaced by a greedy fill, because a zero-allowance file still "arrives" as a marker-only entry. It now asserts the small files arrive **byte-identical to disk**.

Both fixtures gain a second large file: with only one, no single ceiling can separate pinned from unpinned, because any ceiling that leaves the pin block room also leaves the scan's fair share room.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issue

Follows up #214. Plan of record: `docs/unified-store-plan.md`, Goal 8.

## Motivation and Context

#214 was measured, reviewed and merged, and still shipped a case where naming a file in your prompt reduced your context to that one file. It was visible the whole time in `evidence/m2_branch/P1_run1.files` — one line, `entries=1` — and the measurements doc reported P1's wall-clock and RSS and nothing else. The doc is corrected in place rather than rewritten, including the confound this puts on the M2 median: the branch's P1 did ~1/30th of main's delivery work and was still the slowest branch prompt, so that median is not like-for-like.

## How Has This Been Tested?

- [x] **Both defects reproduced on merged `main` and shown fixed**, side by side, via `neo --dry-run` on the P1 prompt against `m365dotnet` — see the table above. Selection counts, not timings, so the result is contention-free and deterministic.
- [x] **`tests/test_front_door.py` — 9 new tests** in two classes (`TestThePinBlockCannotStarveTheScan`, `TestEachCapIsChargedForWhatItRemoved`), including `test_raising_the_named_knob_actually_moves_the_number`, which is the property a mis-attributed warning breaks.
- [x] **Mutation-verified, both fixes.** `PIN_BUDGET_SHARE = 1.0` → 3 failures. Reinstating the old cap attribution → 2 failures. A fix whose test stays green when the fix is reverted is what produced defect 3.
- [x] `pytest tests/test_front_door.py tests/test_include_guarantee.py` → **99 passed**
- [x] `pytest -m invariants` → **100 passed, 1 skipped**
- [x] `ruff check src/ tests/ tools/` clean

**Test Configuration**: Python 3.13.7 · macOS 26.5.2 (Apple M4 Max) · base `origin/main` = `5c0ce5d`

### M1 is not re-run, deliberately

`PIN_BUDGET_SHARE` binds only when the pin block would exceed half the ceiling, and exactly 1 of the 150 git-mined M1 cases names a path at all (it names three small markdown files). The unified-store **Goal 9** session independently re-ran M1 at the post-#214 base and reproduced #214's branch arm byte-for-byte on all three flagships — neo 0.712 / 0.708, aieweb 0.728 / 0.778, m365dotnet 0.669 / 0.771, 0 failed cases. Different session, different base, same numbers; cited rather than re-spent, and credited to that run.

M2 wall-clock is **not** re-measured here: another goal's battery had the laptop, and a contended timing number would be worse than none. This PR's claim is about selection, which is deterministic.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Opened as **DRAFT** per `docs/unified-store-plan.md`'s option-3 governance for runtime-touching changes: the shepherd verifies the evidence and flips it ready; the car-pr-review daemon is the gate after that.
