### PR TITLE
Release v0.46.0 — the unified store release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.46.0] - 2026-08-13
+
+The unified store release, and the close of the ten-goal climb that built it. Neo used to retrieve down two independent lanes that walked the repository separately, disagreed about what was eligible, and answered to two different front doors — so a fix applied to one was silently absent from the other. There is now **one walker, one persistent content index, and one retrieval front door**. The largest flagship repository moved from **MRR 0.051 to 0.738** and recall@10 from **0.097 to 0.883** across the climb; the eligibility walk itself went from 4.6–6.9 s to **0.12 s** warm, and file selection is now 0.37 s of a warm call.
+
+This release cuts nothing new. It is the retirement: the two-lane vocabulary is gone from the code, the tests and every document a user reads, and `tests/test_lane_retirement.py` fails if it returns.
+
+### Changed
+
+- **`neo --index` is documented as what it is — an optional cache-warmer.** Auto-freshness has been the default reality since the eligibility walk began persisting itself, so the docs, the CLI help and the plugin surfaces no longer describe an index you must remember to build.
+- **`--semantic` is documented as a weight hint**, not a lane selector. It stopped selecting a pipeline when the second front door was deleted; the documentation now says so rather than describing a fork that no longer exists.
+- The two-lane mental model is removed from README, QUICKSTART, the CLI help text and the `.claude-plugin/` agent and command docs. Dated evidence and measurement records keep their historical references on purpose — they are the record of what was measured, not instructions to a user.
+
+### Removed
+
+- Every remaining reference to the deleted lane functions across `src/`, the plugin manifests and user-facing docs. The structural proof is re-run as a test: one eligibility implementation, one gather path, zero references to the retired functions.
+
+### Documentation
+
+- [`docs/unified-store-plan.md`](docs/unified-store-plan.md) gains its **completion ledger** — the per-goal PR table, the final M1/M2 readings side by side with the Goal 1 trailhead baselines, an honest reading of which targets closed and which did not, and the exits left open on purpose.
+- **Two of the three north stars closed.** M1 closed decisively. M2 closed on the half this plan owns — file selection — and did **not** close on the absolute number, because the FactStore history boost accounts for 3.43 s and 1.26 GB of every invocation. That is [#211](https://github.com/Parslee-ai/neo/issues/211), scoped out from the trailhead and still open; it is the natural successor plan. [#213](https://github.com/Parslee-ai/neo/issues/213) and [#217](https://github.com/Parslee-ai/neo/issues/217) are the other recorded exits.
+
 ## [0.45.0] - 2026-08-12
 
 Neo picked the files it showed the model without ever opening them, and the tool built for checking that never showed you the answer. This release closes both. File selection now ranks on content, which moves retrieval quality on the largest flagship repository from **MRR 0.051 to 0.738** and recall@10 from 0.097 to 0.883 — a change of kind, not of degree. `--dry-run` now prints the messages Neo actually hands the adapter, having previously exited before the engine was built, and before that could bill you for a full multi-agent panel under a flag whose entire promise is that it makes no call. Ruby and PHP get the graph edges they have never had. And the release itself now runs one real LLM round trip per language, so a language cannot silently stop working for eight months again.

--- a/docs/unified-store-plan.md
+++ b/docs/unified-store-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-11
 **Owner:** Keenan Keeling (dispatching via goalpool; Kai shepherds)
-**Status:** **Goals 1-8 and 10 merged; Goal 9 (this ledger) is open as a draft PR and v0.46.0 is uncut.** See [Completion ledger](#completion-ledger-2026-08-13).
+**Status:** **All ten goals merged ([#216](https://github.com/Parslee-ai/neo/pull/216) closed the climb, 2026-08-13 17:01Z); v0.46.0 is the closing release.** See [Completion ledger](#completion-ledger-2026-08-13).
 **Origin:** 2026-08-11 forensic review of Neo file selection (issues #158/#159/#176/#186/#193–#199) + the 2026-08-10 Keenan/Matt sync.
 
 ## Intent
@@ -70,11 +70,12 @@ Already done inline (2026-08-11): #192 (eval harness), #186 (gitignore implement
 
 ## Completion ledger (2026-08-13)
 
-**Written at Goal 9, the plan's own closing goal, while Goal 9 itself is still an
-open draft PR.** Nine of the ten goals are merged; this one and the v0.46.0 release
-are not, and the tense below is deliberate — a plan that declares itself complete
-before its last PR merges is the same category of claim as an index that prints
-"Built index" and exits 0.
+**Written at Goal 9, the plan's own closing goal, while Goal 9 was still an open
+draft PR — and updated here, in the v0.46.0 release PR, once it merged.** That
+ordering was deliberate: a plan that declares itself complete before its last PR
+merges is the same category of claim as an index that prints "Built index" and
+exits 0. All ten goals are now merged ([#216](https://github.com/Parslee-ai/neo/pull/216),
+2026-08-13 17:01Z) and this release is the last step.
 
 2026-08-11 → 2026-08-13: ten goals, thirteen merged PRs plus one governance PR,
 seven issues closed (#193, #195, #196, #197, #198, #199, #210). This section is the
@@ -93,7 +94,7 @@ open.
 | **6. Persistent content index** | [#209](https://github.com/Parslee-ai/neo/pull/209) | closes #195 — BM25 moves into the on-disk store |
 | **7. Auto-freshness** | [#212](https://github.com/Parslee-ai/neo/pull/212) | closes #210 — the eligibility walk persists; `--index` becomes optional |
 | **8. One front door** | [#214](https://github.com/Parslee-ai/neo/pull/214) | one pipeline, four stages; the `cli.py` gather fork and the second gather function deleted |
-| **9. Lane retirement** | *this PR — open, draft* | the two-lane vocabulary retired from code and docs; `tests/test_lane_retirement.py` guards it. **v0.46.0 is cut after it merges, not in it** |
+| **9. Lane retirement** | [#216](https://github.com/Parslee-ai/neo/pull/216) | the two-lane vocabulary retired from code and docs; `tests/test_lane_retirement.py` guards it. **v0.46.0 is cut after it merged, not in it** |
 | **10. Release gate** | [#202](https://github.com/Parslee-ai/neo/pull/202) | G5-inv — per-language LLM round trip gates the release, invariant battery gates every PR |
 
 Governance PR [#203](https://github.com/Parslee-ai/neo/pull/203) added the draft-flow

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.45.0"
+version = "0.46.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Cuts **v0.46.0 — the unified store release**, the closing release of the ten-goal climb in [`docs/unified-store-plan.md`](https://github.com/Parslee-ai/neo/blob/main/docs/unified-store-plan.md). Goal 9 (#216) merged at 2026-08-13 17:01Z; this is the release that follows it, per the plan's own ruling that **v0.46.0 is cut after Goal 9 merges, not in it**.

Version bumped in `pyproject.toml` alone; `make sync-version` propagated it to the other three files. `python tools/sync_version.py --check` reports `version 0.46.0: all files in sync`.

| File | 0.45.0 → 0.46.0 |
|---|---|
| `pyproject.toml` | hand edit (the only one) |
| `src/neo/__init__.py` | via `make sync-version` |
| `.claude-plugin/plugin.json` | via `make sync-version` |
| `plugins/neo/.codex-plugin/plugin.json` | via `make sync-version` — the one that gets forgotten |

## Type of Change

- [x] Documentation update
- [x] Code cleanup/refactoring (release chore: version bump + changelog)

## Related Issue

No issue. This is the release step of the unified-store plan; the exits it leaves open are recorded in the plan ledger as #211, #213 and #217.

## Motivation and Context

The climb is merged and `main` is telling two lies until this lands:

1. **The plan's status line said Goal 9 was "open as a draft PR and v0.46.0 is uncut."** That was true when written and false the moment #216 merged. The status line, the Goal 9 row in the per-goal PR table, and the ledger's opening tense note are updated to point at #216 and record that all ten goals are merged. The tense note is *edited rather than deleted* — the reason it was written in the future tense is the point, and it now says so explicitly.
2. **The package still said 0.45.0**, so the retirement work shipped in #216 had no released version carrying it.

The CHANGELOG entry tells the story briefly, as the goal brief asked: one walker, one persistent content index, one front door; MRR 0.051 → 0.738 and R@10 0.097 → 0.883 on the gate repo; the eligibility walk 4.6–6.9 s → 0.12 s warm. It also states plainly which target did **not** close (M2's absolute wall/RSS, owned by the FactStore, #211) rather than reporting only the wins.

## How Has This Been Tested?

- [x] `python tools/sync_version.py --check` → `version 0.46.0: all files in sync` (all four files, including the Codex manifest)
- [x] No source changes — the diff is one version string per file plus CHANGELOG and plan prose, so no behavioural surface is touched
- [x] CI matrix (3.10/3.11/3.12/3.13) + guard-invariant battery on this branch
- [x] `tests/test_host_adapter_parity.py` pins the manifests against `pyproject.toml`; a missed manifest fails it rather than drifting silently

**The release gate runs after this merges**, not here: creating the GitHub Release triggers `publish.yml`, where `language-roundtrip` (one real LLM round trip each for C#, TypeScript and Python) must be green before `build`, and nothing reaches PyPI if a language is red. See [`docs/release-gate.md`](https://github.com/Parslee-ai/neo/blob/main/docs/release-gate.md).

**Test Configuration**:
- Python version: 3.10–3.13 (CI matrix)
- OS: ubuntu-latest (CI), darwin (local)
- Neo version: 0.46.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#216 merged 2026-08-13 17:01Z)
- [ ] I have added tests that prove my fix is effective — n/a, no behaviour changes; the version invariant is already pinned by `test_host_adapter_parity.py`

## Additional Notes

Release steps remaining after merge, in order: tag `v0.46.0` on merged `main`, create the GitHub Release (triggers `publish.yml` → the per-language round-trip gate → `build` → `publish-pypi`), then verify the registry actually serves 0.46.0.

Branch is named `release/v0.46.0-g_msrhuemt_78c44a` rather than the plain `release/v0.46.0` the ship-release doc shows, because the dispatching protocol requires the goal id in the branch name. Nothing keys on the branch name — publication is triggered by the GitHub Release.
