### PR TITLE
fix(learning): restore the reinforcement link and bound the confidence ratchet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,21 @@
   and the way to undo it is one `failures.extend(performance_notes)` —
   `test_no_latency_text_leaks_into_acceptance_failures` exists for exactly that edit,
   since the two obvious tests either side of it stay green when it happens (#183).
+  **The gate came back once already, as a TEST rather than a threshold.**
+  `test_within_budget_run_reports_clean` called `run_learning_evaluation` against
+  the REAL 500ms budget and asserted `performance_within_budget is True` — i.e. it
+  asserted the ambient machine is fast, which is the identical coin-flip one level
+  up. It failed CI at **534.80ms** on a commit measured at ~50ms locally (three runs
+  each on branch and main, pinned `PYTHONPATH`, ≤1ms apart — so not the change under
+  review), with `accepted=True`, `acceptance_failures=[]`, all twelve scenarios
+  passing and every safety rate 0.0. A correctness PR was red for a reason that had
+  nothing to do with correctness, which is the whole defect #183 named. Every OTHER
+  test in that class is deterministic because `_over_budget` forces
+  `latency_ms_max = 0.001`, something no machine can meet; the clean-report case now
+  goes through `_within_budget` (1e6 ms), something no machine can exceed. **Rule:
+  no test in this class may depend on how fast the machine running it is** — pin the
+  budget in whichever direction the case needs, and never mock the clock (a patched
+  timer tests the patch).
 - A2UI memory inspector (`neo.a2ui`): a per-project A2UI v0.9 surface
   (`neo-<project_id8>`) registered with the running `car-server` daemon so any
   conformant renderer (CarHost.app, future webviews) can inspect neo's state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,84 @@
   when no link is found; UNVERIFIED never creates a REVIEW. INDEPENDENT writes a
   REVIEW at confidence 0.2. **Footgun**: if you add a new `OutcomeType`, update
   both `outcomes.py` and `store.detect_implicit_feedback`.
+- **"The linked original fact" means the DURABLE fact the suggestion re-applied,
+  and the link nearly died in silence.** `suggestion_fact_ids` (file_path →
+  fact_id) is the only input to the ACCEPTED reinforcement branch and to
+  `replay_linked_feedback`. It is built by `engine._build_suggestion_fact_ids`
+  from the fact `_store_reasoning` returns — and when episodes replaced
+  immediate fact-writing (`412a174`, 2026-07-18) that function started
+  returning `None` on **every** path (all three `return`s; the legacy branch
+  too). The builder returns `{}` for a `None` fact, so the map was
+  unconditionally empty from that commit on. Nothing raised: the ACCEPTED
+  branch just fell through to the candidate path, `reinforce_legacy_fact`
+  became unreachable, and `neo memory replay-feedback` — documented right here
+  as the repair command for a broken memory loop — became a no-op that reports
+  success. Measured on a live install: 51 sessions through 2026-06-19 carried
+  one link per suggestion, then 9 consecutive sessions from 2026-07-19 carried
+  zero, and **no fact's `success_count` moved again in 90 days** (`learning-stats`
+  reinforcements = 0). Across 6,613 valid facts in every project, **zero have
+  ever reached `success_count >= 3`**, so `find_contributable` has never once
+  returned a fact and `neo contribute` has never been reachable.
+  The fix does NOT restore per-suggestion fact minting — that is the unverified
+  flood `412a174` existed to stop. It resolves the link through the episode
+  candidate instead: `find_durable_fact_for_candidate(subject)` matches the
+  candidate's `_episode_signature` against the FROZEN `canonical_signature`,
+  which is written **only** by the two promotion paths, so a hit means "this
+  exact lesson is already durable" and this suggestion is an application of it.
+  A candidate with no durable fact yet contributes no link — its early
+  acceptances are evidence toward promotion, which the candidate path already
+  owns. **Footgun**: match the frozen field, never a recomputed signature, and
+  never let an empty target match the empty default — every unpromoted fact
+  would answer for every candidate.
+- **A re-accepted durable pattern is reinforced in place, not re-minted.**
+  `_promote_repeatedly_supported_candidate` looks for an existing valid PROJECT
+  fact at the target signature before calling `add_fact`, and on a hit folds in
+  the new supporting episodes, raises `success_count` to the support count and
+  adds `REACCEPTANCE_BOOST` (0.05). `add_fact`'s pre-write dedup cannot catch
+  this: its signature includes the BODY, which is one episode's run-varying LM
+  prose, so a third acceptance worded differently wrote a SECOND durable fact
+  for the same lesson. `collapse_duplicate_signature_facts` heals that after
+  the fact but keeps the richest by supporting-episode count — the NEW fact, at
+  its freshly capped mint confidence — silently discarding whatever the
+  original had earned. This is also the only way past the mint cap: promotion
+  mints at `min(0.75, 0.4 + 0.1·n)`, so without an in-place boost a
+  repeatedly-verified pattern could never reach the 0.8 contribution bar no
+  matter how many acceptances it collected.
+- **`durable` is a terminal candidate status.** `detect_implicit_feedback`
+  calls `_record_attributed_episode_outcome` a SECOND time right after a
+  successful promotion, to record the mutation. That method used to assign the
+  ACCEPTED status unconditionally, so it immediately walked the just-written
+  `durable` back to `supported_once` — leaving every promoted candidate reading
+  `supported_once` beside a populated `promoted_fact_id`, and `learning-stats`
+  under-reporting the one number it exists to report. Promotion is not the only
+  writer of that field, so the guard lives in the status loop, not the caller.
+- **The protection boost is bounded by evidence, because it runs per PROCESS
+  START.** `demote_unhelpful_facts` (cold-start chain) adds `PROTECTION_BOOST`
+  to any fact with `success_count > 0` and hit rate ≥ `PROTECTION_HIT_RATE`.
+  Unbounded, that compounds once per neo invocation, so confidence measured how
+  often the process started rather than how often the fact was right — measured
+  on a live store, the 93 facts with any success at all averaged **0.968**
+  confidence and 57 sat at exactly **1.00**, several of them throwaway drill
+  prompts holding a single success against 40-odd accesses. The boost now stops
+  at `min(PROTECTION_CEILING_MAX, PROTECTION_CEILING_BASE +
+  PROTECTION_CEILING_PER_SUCCESS · success_count)`. Verified outcomes may still
+  carry a fact above that line; the comparison is strictly `>` so protection can
+  never claw back confidence it did not grant. **This is why the contribution
+  banner had it backwards**: confidence was the half satisfied almost
+  accidentally, and successes the half nothing could move.
+- Community contribution gates are single-sourced in `store.py`
+  (`CONTRIBUTION_MIN_CONFIDENCE` / `CONTRIBUTION_MIN_SUCCESSES` /
+  `CONTRIBUTION_EXCLUDED_TAGS`), and eligibility is split in two:
+  `is_contribution_candidate` holds the PERMANENT disqualifiers (kind is
+  CONSTRAINT, or provenance is a seed/community/history feed), while the two
+  numeric thresholds are the only part a fact can grow out of. The split exists
+  so a caller reporting *why* a fact is not contributable can name only the gate
+  that binds — `subcommands._describe_contribution_gap`. The status banner used
+  to print a fixed "need 0.8 confidence + 3 successes" at facts already sitting
+  at 1.00, which is this repo's own rule about never blaming a cap for an
+  absence it did not cause, broken in the one line a user reads most. It also
+  filtered `near` differently from `find_contributable`, so it could advertise
+  facts that were never contributable at all.
 - Retrieval: `rank_score = recall_decay(sim)·confidence + success_bonus·effectiveness_f
   + provenance_bonus`. `memory.models.rank_score` is the single source of truth — if you
   change the formula, audit `ContextAssembler._score_facts` too. Cosine is batched via

--- a/src/neo/engine.py
+++ b/src/neo/engine.py
@@ -1405,8 +1405,10 @@ class NeoEngine:
             )
         simulation_facts = []
         if self.fact_store is not None and learning_allowed:
-            ids = self._build_suggestion_fact_ids(fact, code_suggestions)
             episode = self.current_learning_episode
+            # After `_store_reasoning`, so the episode already carries this
+            # run's candidates — that is what the linkage is resolved against.
+            ids = self._build_suggestion_fact_ids(fact, code_suggestions, episode)
             candidates = {
                 candidate.suggestion_id: {
                     "candidate_id": candidate.candidate_id,
@@ -3541,20 +3543,71 @@ RULES:
         # Combine template with facts
         return f"{template}\n\n({facts})"
 
-    @staticmethod
     def _build_suggestion_fact_ids(
-        fact, code_suggestions: list[CodeSuggestion]
+        self, fact, code_suggestions: list[CodeSuggestion], episode=None
     ) -> dict[str, str]:
-        """Build file_path -> fact_id mapping for outcome linkage."""
-        if fact is None:
-            logger.debug("_build_suggestion_fact_ids: fact is None, no linkage possible")
-            return {}
+        """Build file_path -> fact_id mapping for outcome linkage.
+
+        This map is how a later git-verified acceptance finds the knowledge its
+        suggestion came from — `detect_implicit_feedback` reinforces the linked
+        fact, and `replay_linked_feedback` (the documented repair command for a
+        broken memory loop) does nothing else.
+
+        `fact` is the suggestion-time fact, and on the FactStore backend there
+        ISN'T one: episodes replaced immediate fact-writing, so `_store_reasoning`
+        returns None on every path. That left this map permanently empty and
+        silently killed both reinforcement paths — measured on a live install,
+        every session from the changeover onward carried zero links, and no
+        fact's success_count moved again.
+
+        The successor link is the episode candidate: when a candidate's lesson
+        has ALREADY been promoted to a durable fact, that fact is exactly what
+        this suggestion is an application of, and an acceptance of it is
+        genuine re-verification. A candidate with no durable fact yet
+        contributes no link — its first acceptances are evidence toward
+        promotion, which the candidate path handles.
+        """
         ids: dict[str, str] = {}
-        for s in code_suggestions:
-            fp = getattr(s, "file_path", "")
-            if fp and fp not in ("/", "N/A"):
-                ids[fp] = fact.id
-        logger.debug(f"_build_suggestion_fact_ids: linked {len(ids)} suggestions to fact {fact.id}")
+
+        def _targets() -> list[str]:
+            return [
+                fp for s in code_suggestions
+                if (fp := getattr(s, "file_path", "")) and fp not in ("/", "N/A")
+            ]
+
+        if fact is not None:
+            # A backend that still mints a fact per suggestion links directly.
+            ids = {fp: fact.id for fp in _targets()}
+            logger.debug(
+                "_build_suggestion_fact_ids: linked %d suggestion(s) to fact %s",
+                len(ids), fact.id,
+            )
+            return ids
+
+        if episode is None or self.fact_store is None:
+            logger.debug(
+                "_build_suggestion_fact_ids: no fact and no episode, no linkage possible"
+            )
+            return ids
+
+        subjects = {
+            candidate.suggestion_id: candidate.subject
+            for candidate in episode.memory_candidates
+        }
+        for suggestion in code_suggestions:
+            file_path = getattr(suggestion, "file_path", "")
+            if not file_path or file_path in ("/", "N/A"):
+                continue
+            subject = subjects.get(getattr(suggestion, "suggestion_id", ""), "")
+            if not subject:
+                continue
+            durable = self.fact_store.find_durable_fact_for_candidate(subject)
+            if durable is not None:
+                ids[file_path] = durable.id
+        logger.debug(
+            "_build_suggestion_fact_ids: linked %d of %d suggestion(s) to durable facts",
+            len(ids), len(code_suggestions),
+        )
         return ids
 
     def _store_reasoning(

--- a/src/neo/memory/store.py
+++ b/src/neo/memory/store.py
@@ -58,6 +58,16 @@ EMBEDDING_CACHE_MAX_SIZE = 500
 MAX_TEXT_LENGTH = 32000
 SUPERSESSION_THRESHOLD = 0.85  # Cosine similarity threshold for supersession
 
+# Community contribution gates. Single-sourced because the status banner has to
+# report which of them is short, and a banner that quotes its own copy of the
+# numbers will eventually quote the wrong ones.
+CONTRIBUTION_MIN_CONFIDENCE = 0.8
+CONTRIBUTION_MIN_SUCCESSES = 3
+# Provenance that permanently disqualifies a fact from being contributed.
+CONTRIBUTION_EXCLUDED_TAGS = frozenset(
+    {"seed", "community", "constraint", "history", "git-commit"}
+)
+
 # How strong each outcome is as evidence, for deciding which one an episode
 # reports as its final_outcome when a single invocation produced several.
 # Same VALUES as the priority map in `OutcomeTracker._dedup_outcomes` (asserted
@@ -92,6 +102,26 @@ DEMOTION_CONFIDENCE_PENALTY = 0.1  # Confidence reduction per demotion
 DEMOTION_CONFIDENCE_FLOOR = 0.1    # Never demote below this
 PROTECTION_HIT_RATE = 0.3      # Success/access ratio for protection boost
 PROTECTION_BOOST = 0.05        # Confidence boost for consistently helpful facts
+
+# Ceiling on what the protection boost alone may buy, as a function of the
+# EVIDENCE behind a fact. `demote_unhelpful_facts` runs on every cold start, so
+# an unbounded `confidence + PROTECTION_BOOST` makes confidence a function of
+# how often the process restarted rather than of how often the fact was right.
+# Measured on a live store: of 6,613 valid facts the 93 with any success at all
+# averaged 0.968 confidence and 57 sat at exactly 1.00, several of them
+# throwaway drill prompts with a single success against 43 accesses. Verified
+# outcomes may still carry a fact above this line — only the restart-driven
+# ratchet is bounded.
+PROTECTION_CEILING_BASE = 0.6        # Confidence one success alone can justify...
+PROTECTION_CEILING_PER_SUCCESS = 0.1  # ...plus this per additional success
+PROTECTION_CEILING_MAX = 0.9         # Protection alone never certifies a fact
+
+# Confidence gained when an ALREADY-durable pattern is independently re-accepted.
+# Deliberately smaller than the +0.2 a linked suggestion earns: that one fact is
+# being re-verified, not newly established, and the mint cap
+# (`min(0.75, ...)`) means this is the only way a repeatedly-proven pattern ever
+# reaches the contribution bar.
+REACCEPTANCE_BOOST = 0.05
 
 # Independent outcome limits (second layer — outcomes.py caps at 5/session)
 MAX_INDEPENDENT_FACTS = 50     # Cap per project to prevent bloat from active repos
@@ -1205,7 +1235,16 @@ class FactStore:
                     if deterministic_failure:
                         candidate.status = "rejected_by_verification"
                     else:
-                        candidate.status = "supported_once"
+                        # "durable" is terminal and must not be walked back.
+                        # `detect_implicit_feedback` calls this method a SECOND
+                        # time right after a successful promotion (to record the
+                        # mutation), and an unconditional assignment here reset
+                        # the status the promotion had just written — leaving
+                        # every promoted candidate reading "supported_once"
+                        # beside a populated promoted_fact_id, and
+                        # `learning-stats` under-reporting durable promotions.
+                        if candidate.status != "durable":
+                            candidate.status = "supported_once"
                         # Invariant: promoted_fact_id is written ONLY by the
                         # promotion path (_promote_repeatedly_supported_candidate).
                         # Setting it here to the outcome's mutation-target fact_id
@@ -1310,6 +1349,44 @@ class FactStore:
         if not base:
             return ""
         return f"{base}{FactStore._SIG_SEP}{fingerprint}"
+
+    def _find_valid_fact_by_signature(
+        self, target_signature: str, scope: Optional[FactScope] = None
+    ) -> Optional[Fact]:
+        """The live fact already minted for an episode correlation signature.
+
+        Matches the FROZEN ``canonical_signature`` only, never a recomputed
+        one — that field is written exclusively by the two promotion paths, so
+        a hit means "this exact lesson has already been promoted" and can
+        never collide with the separate pre-write dedup signature (which adds
+        kind+scope and the body, and is never stored on the fact).
+        """
+        if not target_signature:
+            return None
+        for fact in self._facts:
+            if not fact.is_valid:
+                continue
+            if scope is not None and fact.scope != scope:
+                continue
+            if fact.canonical_signature == target_signature:
+                return fact
+        return None
+
+    def find_durable_fact_for_candidate(self, candidate_subject: str) -> Optional[Fact]:
+        """The durable PROJECT fact this candidate's lesson was promoted to.
+
+        This is what re-links a suggestion to the knowledge it came from. The
+        engine stopped minting a fact per suggestion when episodes replaced
+        immediate fact-writing, which left ``suggestion_fact_ids`` empty on
+        every run and silently killed every downstream reinforcement path. A
+        candidate whose lesson is ALREADY durable has a legitimate fact to
+        point at, and pointing at it is what lets a re-acceptance count.
+        """
+        if not candidate_subject:
+            return None
+        return self._find_valid_fact_by_signature(
+            self._episode_signature(candidate_subject), scope=FactScope.PROJECT
+        )
 
     @staticmethod
     def _global_signature(subject: str) -> str:
@@ -1645,6 +1722,46 @@ class FactStore:
                     )
                     return None
 
+            # Already promoted: reinforce the fact we have rather than mint a
+            # near-twin. `add_fact`'s pre-write dedup can't catch this — its
+            # signature includes the BODY, which is one episode's run-varying
+            # LM prose, so a third acceptance worded differently writes a
+            # SECOND durable fact for the same lesson. `collapse_duplicate_
+            # signature_facts` heals that afterwards, but it keeps the richest
+            # by supporting-episode count, which is the NEW fact at its freshly
+            # capped mint confidence — discarding whatever the original had
+            # earned. Reinforcing in place keeps the accumulated evidence and
+            # is what lets a repeatedly re-verified pattern climb past the mint
+            # ceiling at all.
+            existing_fact = self._find_valid_fact_by_signature(
+                target_signature, scope=FactScope.PROJECT
+            )
+            if existing_fact is not None:
+                existing_fact.supporting_episode_ids = list(dict.fromkeys(
+                    existing_fact.supporting_episode_ids + supporting_ids
+                ))
+                existing_fact.metadata.success_count = max(
+                    existing_fact.metadata.success_count,
+                    len(existing_fact.supporting_episode_ids),
+                )
+                existing_fact.metadata.confidence = min(
+                    1.0, existing_fact.metadata.confidence + REACCEPTANCE_BOOST
+                )
+                update_effectiveness(existing_fact, outcome="better")
+                existing_fact.metadata.last_accessed = time.time()
+                self.save()
+                logger.info(
+                    "Reinforced already-promoted pattern %s "
+                    "(success_count=%d, confidence=%.2f)",
+                    existing_fact.id,
+                    existing_fact.metadata.success_count,
+                    existing_fact.metadata.confidence,
+                )
+                self._mark_candidates_promoted(
+                    episode_store, supporting_ids, target_signature, existing_fact.id
+                )
+                return existing_fact
+
             fact = self.add_fact(
                 # Strip the [fp:<hash>] correlation qualifier from the stored
                 # subject — it's a key ingredient, not user-facing text. The
@@ -1676,23 +1793,40 @@ class FactStore:
             fact.canonical_signature = target_signature  # frozen for rollback-resolve
             self.save()
 
-            for episode_id in supporting_ids:
-                episode = episode_store.load(episode_id)
-                if episode is None:
-                    continue
-                changed = False
-                for candidate in episode.memory_candidates:
-                    signature = self._episode_signature(candidate.subject)
-                    if signature == target_signature:
-                        candidate.status = "durable"
-                        candidate.promoted_fact_id = fact.id
-                        changed = True
-                if changed:
-                    episode_store.save(episode)
+            self._mark_candidates_promoted(
+                episode_store, supporting_ids, target_signature, fact.id
+            )
             return fact
         except Exception as exc:
             logger.warning("Episode candidate promotion failed: %s", exc)
             return None
+
+    def _mark_candidates_promoted(
+        self,
+        episode_store,
+        supporting_ids: list[str],
+        target_signature: str,
+        fact_id: str,
+    ) -> None:
+        """Point every supporting candidate at the fact carrying their lesson.
+
+        Shared by the first promotion and by reinforcement of an
+        already-promoted signature, so a re-verified candidate records the
+        same `promoted_fact_id` as the episodes that minted it. Without that,
+        a later contradiction could not resolve back to the right fact.
+        """
+        for episode_id in supporting_ids:
+            episode = episode_store.load(episode_id)
+            if episode is None:
+                continue
+            changed = False
+            for candidate in episode.memory_candidates:
+                if self._episode_signature(candidate.subject) == target_signature:
+                    candidate.status = "durable"
+                    candidate.promoted_fact_id = fact_id
+                    changed = True
+            if changed:
+                episode_store.save(episode)
 
     def _cross_project_evidence(self, target_signature: str, episodes_root: "Path"):
         """Collect (supporting, project_ids, episode_ids) for one canonical
@@ -2465,28 +2599,41 @@ class FactStore:
         """Backward-compatible access to all facts."""
         return self._facts
 
-    def find_contributable(self, min_confidence: float = 0.8,
-                           min_successes: int = 3) -> list[Fact]:
+    @staticmethod
+    def is_contribution_candidate(fact: Fact) -> bool:
+        """Whether a fact could ever be contributed, ignoring the quality gates.
+
+        Kind and provenance are permanent disqualifiers: a constraint is
+        project-specific and a seed/community fact came FROM the feed. The
+        confidence/success thresholds are the only part a fact can grow out
+        of, so they are asked separately — callers reporting *why* a fact is
+        not contributable must not name a gate that no amount of learning
+        would clear.
+        """
+        if not fact.is_valid:
+            return False
+        if fact.kind == FactKind.CONSTRAINT:
+            return False
+        if CONTRIBUTION_EXCLUDED_TAGS & set(fact.tags):
+            return False
+        return True
+
+    def find_contributable(
+        self,
+        min_confidence: float = CONTRIBUTION_MIN_CONFIDENCE,
+        min_successes: int = CONTRIBUTION_MIN_SUCCESSES,
+    ) -> list[Fact]:
         """Find high-quality facts worth contributing to the community feed.
 
         Criteria: high confidence, real success validation, not already
         from seed/community feeds, not constraints (project-specific).
         """
-        auto_tags = {"seed", "community", "constraint", "history", "git-commit"}
-        results = []
-        for f in self._facts:
-            if not f.is_valid:
-                continue
-            if f.kind == FactKind.CONSTRAINT:
-                continue
-            if f.metadata.confidence < min_confidence:
-                continue
-            if f.metadata.success_count < min_successes:
-                continue
-            if auto_tags & set(f.tags):
-                continue
-            results.append(f)
-        return results
+        return [
+            f for f in self._facts
+            if self.is_contribution_candidate(f)
+            and f.metadata.confidence >= min_confidence
+            and f.metadata.success_count >= min_successes
+        ]
 
     # ------------------------------------------------------------------ #
     # Scope capacity enforcement
@@ -2897,7 +3044,10 @@ class FactStore:
         - access_count 5-9, success 0: reduce confidence by 0.1 (floor 0.1)
         - access_count >= 10, success 0: mark invalid (actively unhelpful)
 
-        Facts with hit rate > 30% get a small confidence boost (protection).
+        Facts with hit rate > 30% get a small confidence boost (protection),
+        bounded by an evidence-derived ceiling — this runs on every cold start,
+        so an unbounded boost would compound per process start rather than per
+        verified success.
 
         Returns the total number of facts affected (demoted + pruned + boosted).
         """
@@ -2934,9 +3084,20 @@ class FactStore:
                     )
                     affected += 1
             elif success > 0 and (success / access) >= PROTECTION_HIT_RATE:
-                # Protect consistently helpful facts
-                new_conf = min(1.0, fact.metadata.confidence + PROTECTION_BOOST)
-                if new_conf != fact.metadata.confidence:
+                # Protect consistently helpful facts, but only up to what the
+                # evidence supports. This runs on every cold start, so an
+                # unbounded boost compounds per PROCESS START — a fact with one
+                # success reached 1.00 confidence purely by being loaded often
+                # enough, and the store is full of them. The ceiling makes the
+                # boost converge on a value justified by success_count instead.
+                ceiling = min(
+                    PROTECTION_CEILING_MAX,
+                    PROTECTION_CEILING_BASE + PROTECTION_CEILING_PER_SUCCESS * success,
+                )
+                new_conf = min(1.0, ceiling, fact.metadata.confidence + PROTECTION_BOOST)
+                # Strictly greater: a fact already above its ceiling was carried
+                # there by verified outcomes, which protection must never undo.
+                if new_conf > fact.metadata.confidence:
                     fact.metadata.confidence = new_conf
                     affected += 1
 

--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -36,6 +36,46 @@ MIN_EMBEDDING_SUCCESS_RATE = 0.8  # Require 80% success to prevent mass data cor
 VALID_EMBEDDING_DIMENSIONS = {384, 768, 1536}  # BGE-small, Jina-v2, OpenAI
 
 
+def _describe_contribution_gap(facts: list) -> str:
+    """Name the contribution gate(s) that actually hold these facts back.
+
+    Every caller has already established that none of `facts` is
+    contributable, so at least one gate is short and the result is never
+    empty. Only the short ones are named: quoting "need 0.8 confidence + 3
+    successes" at a fact sitting at 1.00 confidence points the operator at a
+    threshold no amount of learning would change, when the successes counter
+    is the only thing that has stalled.
+    """
+    from neo.memory.store import (
+        CONTRIBUTION_MIN_CONFIDENCE,
+        CONTRIBUTION_MIN_SUCCESSES,
+    )
+
+    conf_short = [f for f in facts
+                  if f.metadata.confidence < CONTRIBUTION_MIN_CONFIDENCE]
+    succ_short = [f for f in facts
+                  if f.metadata.success_count < CONTRIBUTION_MIN_SUCCESSES]
+
+    parts = []
+    if conf_short:
+        best = max(f.metadata.confidence for f in conf_short)
+        parts.append(
+            f"{len(conf_short)} short on confidence "
+            f"(best {best:.2f} of {CONTRIBUTION_MIN_CONFIDENCE})"
+        )
+    if succ_short:
+        best = max(f.metadata.success_count for f in succ_short)
+        parts.append(
+            f"{len(succ_short)} short on successes "
+            f"(best {best} of {CONTRIBUTION_MIN_SUCCESSES})"
+        )
+    if not parts:
+        # Unreachable via the status banner, but a caller that passes an
+        # already-contributable fact should not get a dangling clause.
+        return "no gate short"
+    return "; ".join(parts)
+
+
 def show_version(codebase_root: Optional[str] = None):
     """Show Neo's current state and journey progress."""
     from neo.config import NeoConfig
@@ -134,18 +174,24 @@ def show_version(codebase_root: Optional[str] = None):
             print(f"\n\u2728 {len(contributable)} pattern(s) ready to share with the community")
             print("   Run: neo contribute")
         else:
-            # Show progress toward contribution
-            valid = [f for f in entries if getattr(f, 'is_valid', True)]
-            near = [f for f in valid
-                    if hasattr(f, 'metadata')
-                    and f.metadata.confidence >= 0.6
+            # Show progress toward contribution. Report only the gate that is
+            # actually short: naming a threshold a fact already clears sends the
+            # operator to a knob that would change nothing.
+            valid = [f for f in entries
+                     if getattr(f, 'is_valid', True) and hasattr(f, 'metadata')]
+            candidates = [f for f in valid if memory.is_contribution_candidate(f)]
+            near = [f for f in candidates
+                    if f.metadata.confidence >= 0.6
                     and f.metadata.success_count >= 1]
             if near:
-                print(f"\n\u26a1 {len(near)} pattern(s) approaching contribution (need 0.8 confidence + 3 successes)")
+                print(f"\n\u26a1 {len(near)} pattern(s) approaching contribution: "
+                      f"{_describe_contribution_gap(near)}")
+            elif candidates:
+                print(f"\n\u26a1 {len(candidates)} pattern(s), none yet contributable: "
+                      f"{_describe_contribution_gap(candidates)}")
             elif valid:
-                best_conf = max((f.metadata.confidence for f in valid if hasattr(f, 'metadata')), default=0)
-                best_succ = max((f.metadata.success_count for f in valid if hasattr(f, 'metadata')), default=0)
-                print(f"\n\u26a1 {len(valid)} pattern(s), none yet contributable (best: {best_conf:.0%} confidence, {best_succ} successes — need 0.8 + 3)")
+                print(f"\n\u26a1 {len(valid)} pattern(s), none eligible to contribute "
+                      "(all are constraints, or came from the seed/community feeds)")
             else:
                 print("\n\u26a1 No patterns yet. Use neo to build patterns — validated ones can be shared via: neo contribute")
     print()
@@ -154,7 +200,11 @@ def show_version(codebase_root: Optional[str] = None):
 def handle_contribute(args):
     """Export high-quality patterns and open a GitHub PR draft."""
     from neo.config import NeoConfig
-    from neo.memory.store import FactStore
+    from neo.memory.store import (
+        CONTRIBUTION_MIN_CONFIDENCE,
+        CONTRIBUTION_MIN_SUCCESSES,
+        FactStore,
+    )
 
     codebase_root = getattr(args, 'cwd', None) or os.getcwd()
     config = NeoConfig.load()
@@ -163,7 +213,14 @@ def handle_contribute(args):
     contributable = memory.find_contributable()
     if not contributable:
         print("No patterns ready to contribute yet.")
-        print("Patterns qualify when they reach high confidence (>0.8) with 3+ successes.")
+        print(
+            f"Patterns qualify at {CONTRIBUTION_MIN_CONFIDENCE} confidence "
+            f"with {CONTRIBUTION_MIN_SUCCESSES}+ successes."
+        )
+        candidates = [f for f in memory.entries
+                      if memory.is_contribution_candidate(f)]
+        if candidates:
+            print(_describe_contribution_gap(candidates))
         return
 
     print(f"Found {len(contributable)} pattern(s) ready to contribute:\n")

--- a/tests/test_fact_store.py
+++ b/tests/test_fact_store.py
@@ -1112,6 +1112,92 @@ class TestOutcomeLinkage:
             store.detect_implicit_feedback({"prompt": "next"}, [])
         return episode_store
 
+    def test_third_acceptance_reinforces_instead_of_minting_a_twin(self, store):
+        """A re-verified lesson must grow the fact it already has.
+
+        `add_fact`'s pre-write dedup keys on subject+body, and the body is one
+        episode's run-varying LM prose — so a third acceptance worded
+        differently used to write a SECOND durable fact for the same lesson.
+        `collapse_duplicate_signature_facts` heals that afterwards but keeps
+        the richest by supporting-episode count, i.e. the NEW fact at its
+        freshly capped mint confidence, discarding what the original earned.
+        """
+        subject = "algorithm: dedupe a list preserving order [util.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "grow-0", subject, "Reasoning: use a seen set.")
+        self._accept_episode(store, "grow-1", subject, "Reasoning: track membership.")
+
+        promoted = [f for f in store.entries if "episode-derived" in f.tags]
+        assert len(promoted) == 1
+        fact = promoted[0]
+        minted_confidence = fact.metadata.confidence
+        assert fact.metadata.success_count == 2
+
+        self._accept_episode(store, "grow-2", subject, "Reasoning: worded a third way.")
+
+        still = [f for f in store.entries if "episode-derived" in f.tags and f.is_valid]
+        assert len(still) == 1, "a re-acceptance must not mint a near-twin"
+        assert still[0] is fact
+        assert fact.metadata.success_count == 3
+        assert fact.metadata.confidence > minted_confidence, (
+            "re-verification is the only way past the mint cap"
+        )
+
+    def test_promotion_status_is_not_walked_back_by_its_own_bookkeeping(self, store):
+        """`durable` must survive the record call that follows promotion.
+
+        `detect_implicit_feedback` records the mutation by calling
+        `_record_attributed_episode_outcome` a second time, and that method
+        assigns the ACCEPTED status unconditionally — so every promoted
+        candidate read `supported_once` beside a populated `promoted_fact_id`,
+        and `learning-stats` under-counted durable promotions.
+        """
+        from neo.memory.episodes import LearningEpisodeStore
+
+        subject = "algorithm: dedupe a list preserving order [util.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "term-0", subject, "Reasoning: a.")
+        self._accept_episode(store, "term-1", subject, "Reasoning: b.")
+
+        fact = [f for f in store.entries if "episode-derived" in f.tags][0]
+        episode_store = LearningEpisodeStore(store.project_id)
+        for ep_id in ("term-0", "term-1"):
+            candidate = episode_store.load(ep_id).memory_candidates[0]
+            assert candidate.status == "durable", (
+                f"{ep_id} reverted to {candidate.status} after promotion"
+            )
+            assert candidate.promoted_fact_id == fact.id
+
+    def test_reinforced_fact_records_the_new_supporting_episode(self, store):
+        """The third episode's candidate must point at the same fact."""
+        from neo.memory.episodes import LearningEpisodeStore
+
+        subject = "algorithm: dedupe a list preserving order [util.py] [fp:deadbeef1234]"
+        for i in range(3):
+            self._accept_episode(store, f"link-{i}", subject, f"Reasoning: v{i}.")
+
+        fact = [f for f in store.entries
+                if "episode-derived" in f.tags and f.is_valid][0]
+        assert set(fact.supporting_episode_ids) == {"link-0", "link-1", "link-2"}
+
+        episode_store = LearningEpisodeStore(store.project_id)
+        candidate = episode_store.load("link-2").memory_candidates[0]
+        assert candidate.status == "durable"
+        assert candidate.promoted_fact_id == fact.id
+
+    def test_reinforcement_cannot_resurrect_a_rolled_back_lesson(self, store):
+        """The rollback guard runs before the reuse branch, not after."""
+        subject = "algorithm: dedupe a list preserving order [util.py] [fp:deadbeef1234]"
+        self._accept_episode(store, "roll-0", subject, "Reasoning: a.")
+        self._accept_episode(store, "roll-1", subject, "Reasoning: b.")
+
+        fact = [f for f in store.entries if "episode-derived" in f.tags][0]
+        fact.is_valid = False
+        fact.invalidation_reason = "repeated_attributed_contradiction"
+
+        self._accept_episode(store, "roll-2", subject, "Reasoning: c.")
+
+        assert [f for f in store.entries
+                if "episode-derived" in f.tags and f.is_valid] == []
+
     def test_body_drift_with_matching_fingerprint_promotes(self, store):
         """The live-drill regression: two independent accepted episodes of the
         SAME task whose bodies differ (run-varying LM prose) but whose subject +
@@ -3283,3 +3369,155 @@ class TestCrashEvidenceSupersession:
         for stale in ("error_type", "error_message", "traceback"):
             assert stale not in saved.outcome_details, (
                 f"{stale} outlived the crash it described")
+
+
+class TestProtectionCeiling:
+    """The protection boost must track evidence, not process restarts.
+
+    `demote_unhelpful_facts` runs on every cold start. An unbounded
+    `confidence + PROTECTION_BOOST` therefore compounds once per invocation of
+    neo, which is how a live store ended up with 57 facts at exactly 1.00
+    confidence — several of them throwaway drill prompts holding a single
+    success against 40-odd accesses.
+    """
+
+    @staticmethod
+    def _fact(confidence, success, access):
+        return Fact(
+            subject="helpful",
+            body="a fact that has paid off",
+            kind=FactKind.PATTERN,
+            scope=FactScope.PROJECT,
+            metadata=FactMetadata(
+                confidence=confidence,
+                access_count=access,
+                success_count=success,
+                created_at=time.time() - 10 * 86400,
+            ),
+        )
+
+    def test_boost_converges_instead_of_ratcheting_to_one(self, store):
+        """Repeated cold starts must not walk a one-success fact up to 1.00."""
+        fact = self._fact(confidence=0.5, success=2, access=5)
+        store._facts.append(fact)
+
+        for _ in range(50):  # 50 cold starts
+            store.demote_unhelpful_facts(save=False)
+
+        # Ceiling for 2 successes: 0.6 + 2 * 0.1 = 0.8
+        assert fact.metadata.confidence == pytest.approx(0.8)
+
+    def test_ceiling_rises_with_evidence(self, store):
+        """More verified successes justify a higher protected confidence."""
+        low = self._fact(confidence=0.5, success=2, access=5)
+        high = self._fact(confidence=0.5, success=6, access=10)
+        store._facts.extend([low, high])
+
+        for _ in range(50):
+            store.demote_unhelpful_facts(save=False)
+
+        assert low.metadata.confidence == pytest.approx(0.8)
+        assert high.metadata.confidence == pytest.approx(0.9)  # PROTECTION_CEILING_MAX
+        assert high.metadata.confidence > low.metadata.confidence
+
+    def test_never_lowers_a_fact_already_above_its_ceiling(self, store):
+        """Confidence earned by verified outcomes is not clawed back.
+
+        success/access must clear PROTECTION_HIT_RATE so this actually enters
+        the protection branch — at a lower hit rate the fact falls through
+        both branches untouched and the assertion would hold vacuously.
+        """
+        fact = self._fact(confidence=0.95, success=3, access=5)  # hit rate 0.6
+        store._facts.append(fact)
+
+        affected = store.demote_unhelpful_facts(save=False)
+
+        # Ceiling for 3 successes is 0.9, and the fact is already past it.
+        assert fact.metadata.confidence == pytest.approx(0.95)
+        assert affected == 0, "a no-op boost must not be reported as a change"
+
+    def test_boost_still_applies_below_the_ceiling(self, store):
+        """The ceiling bounds the ratchet; it does not disable protection."""
+        fact = self._fact(confidence=0.5, success=2, access=5)
+        store._facts.append(fact)
+
+        assert store.demote_unhelpful_facts(save=False) == 1
+        assert fact.metadata.confidence == pytest.approx(0.55)
+
+
+class TestDurableFactLinkage:
+    """A suggestion applying an already-learned lesson must link to its fact.
+
+    `engine._store_reasoning` stopped minting a fact per suggestion when
+    episodes replaced immediate fact-writing, which left `suggestion_fact_ids`
+    permanently empty and killed every path that reinforces a fact on a
+    verified acceptance.
+    """
+
+    @staticmethod
+    def _durable(store, candidate_subject):
+        """Mint a fact the way `_promote_repeatedly_supported_candidate` does.
+
+        The stored subject is fingerprint-STRIPPED while the frozen signature
+        is computed from the full candidate subject — so lookup cannot work by
+        comparing subjects, only by the frozen signature.
+        """
+        fact = Fact(
+            subject=store._split_fingerprint(candidate_subject)[0].strip(),
+            body="the learned lesson",
+            kind=FactKind.PATTERN,
+            scope=FactScope.PROJECT,
+            metadata=FactMetadata(confidence=0.7, success_count=2),
+            tags=["episode-derived", "durable"],
+        )
+        fact.canonical_signature = store._episode_signature(candidate_subject)
+        store._facts.append(fact)
+        return fact
+
+    def test_finds_the_fact_a_candidate_was_promoted_to(self, store):
+        subject = "bugfix: guard the empty path [a.py] [fp:abc123]"
+        fact = self._durable(store, subject)
+
+        assert fact.subject != subject, "fixture must exercise the stripped subject"
+        assert store.find_durable_fact_for_candidate(subject) is fact
+
+    def test_a_different_diff_shape_is_a_different_lesson(self, store):
+        """Same prompt prefix, different fingerprint — must not link."""
+        self._durable(store, "bugfix: guard the empty path [a.py] [fp:abc123]")
+
+        assert store.find_durable_fact_for_candidate(
+            "bugfix: guard the empty path [a.py] [fp:def456]"
+        ) is None
+
+    def test_no_link_before_the_lesson_is_durable(self, store):
+        """A candidate with no promoted fact contributes no link."""
+        self._durable(store, "bugfix: guard the empty path [a.py] [fp:abc123]")
+
+        assert store.find_durable_fact_for_candidate(
+            "bugfix: something else entirely [z.py] [fp:999999]"
+        ) is None
+        assert store.find_durable_fact_for_candidate("") is None
+
+    def test_tombstoned_fact_is_not_linked(self, store):
+        """A rolled-back lesson must not be re-linked as if still believed."""
+        subject = "bugfix: guard the empty path [a.py] [fp:abc123]"
+        fact = self._durable(store, subject)
+        fact.is_valid = False
+
+        assert store.find_durable_fact_for_candidate(subject) is None
+
+    def test_ignores_facts_carrying_no_frozen_signature(self, store):
+        """canonical_signature is written only by the promotion paths.
+
+        An ordinary fact leaves it "", and an empty target must never match
+        that empty field — every unpromoted fact would answer for every
+        candidate.
+        """
+        ordinary = Fact(
+            subject="unrelated", body="b", kind=FactKind.PATTERN,
+            scope=FactScope.PROJECT, metadata=FactMetadata(confidence=0.7),
+        )
+        store._facts.append(ordinary)
+
+        assert store._find_valid_fact_by_signature("") is None
+        assert store.find_durable_fact_for_candidate("   ") is None

--- a/tests/test_learning_evaluation.py
+++ b/tests/test_learning_evaluation.py
@@ -100,8 +100,24 @@ class TestLatencyIsNotACorrectnessGate:
 
         assert not any("latency" in failure for failure in report.acceptance_failures)
 
+    def _within_budget(self, tmp_path, name):
+        """Run against a budget no machine can exceed.
+
+        Mirrors `_over_budget` in the other direction and for the same reason.
+        Asserting that the AMBIENT machine comes in under the real 500ms budget
+        is the coin-flip this class exists to document: CI measured 534.80ms on
+        a commit that runs at ~50ms locally, with all twelve scenarios passing
+        and every safety rate at zero. That is the same 11x shared-runner
+        spread that moved latency out of `accepted` in the first place —
+        reappearing one level up, as a flaky test that fails a correctness PR
+        for a reason that has nothing to do with correctness.
+        """
+        corpus = load_corpus()
+        corpus["performance_budget"]["latency_ms_max"] = 1_000_000.0
+        return LearningLoopEvaluator(corpus, workspace=tmp_path / name).run()
+
     def test_within_budget_run_reports_clean(self, tmp_path):
-        report = run_learning_evaluation(workspace=tmp_path / "fast")
+        report = self._within_budget(tmp_path, "fast")
 
         assert report.performance_within_budget is True
         assert report.performance_notes == []

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -30,6 +30,10 @@ def test_show_version_does_not_eager_initialize_fact_store(capsys):
         def find_contributable(self):
             return []
 
+        @staticmethod
+        def is_contribution_candidate(fact):
+            return True
+
     with patch.object(NeoConfig, "load", return_value=NeoConfig()), \
          patch("neo.memory.store.FactStore", FakeFactStore), \
          patch("neo.car_discovery.discover_car", side_effect=RuntimeError("skip car")):
@@ -37,6 +41,39 @@ def test_show_version_does_not_eager_initialize_fact_store(capsys):
 
     assert calls["eager_init"] is False
     assert "neo " in capsys.readouterr().out
+
+
+def test_contribution_gap_names_only_the_gate_that_binds():
+    """A fact already at full confidence must not be told to raise confidence.
+
+    The status banner used to print a fixed "need 0.8 confidence + 3
+    successes" for every stalled fact, which points the operator at a
+    threshold that is already cleared — the same defect this repo bans for
+    file-selection caps ("never blame a cap for an absence it did not
+    cause").
+    """
+    from neo.memory.models import Fact, FactMetadata, FactKind, FactScope
+    from neo.subcommands import _describe_contribution_gap
+
+    def fact(confidence, successes):
+        return Fact(
+            subject="s", body="b", kind=FactKind.PATTERN, scope=FactScope.PROJECT,
+            metadata=FactMetadata(confidence=confidence, success_count=successes),
+        )
+
+    successes_only = _describe_contribution_gap([fact(1.0, 2), fact(1.0, 1)])
+    assert "confidence" not in successes_only
+    assert "2 short on successes (best 2 of 3)" == successes_only
+
+    confidence_only = _describe_contribution_gap([fact(0.7, 5)])
+    assert "success" not in confidence_only
+    assert "1 short on confidence (best 0.70 of 0.8)" == confidence_only
+
+    both = _describe_contribution_gap([fact(0.7, 5), fact(1.0, 1)])
+    assert "short on confidence" in both and "short on successes" in both
+
+    # Never emits a dangling clause for a fact that clears both gates.
+    assert _describe_contribution_gap([fact(1.0, 9)]) == "no gate short"
 
 
 def test_citation_stats_aggregates_per_signal(capsys):

--- a/tests/test_suggestion_fact_linkage.py
+++ b/tests/test_suggestion_fact_linkage.py
@@ -1,0 +1,126 @@
+"""The linkage that lets a verified acceptance reinforce the fact it came from.
+
+`suggestion_fact_ids` maps each suggested file path to the fact the suggestion
+applied. `detect_implicit_feedback` reinforces the linked fact on a git-verified
+acceptance, and `neo memory replay-feedback` — the documented repair command for
+a broken memory loop — reads nothing else.
+
+It went permanently empty when episodes replaced immediate fact-writing:
+`engine._store_reasoning` returns None on every path, and the old builder
+returned `{}` for a None fact. Measured on a live install, every session after
+the changeover carried zero links and no fact's success_count ever moved again.
+"""
+
+from types import SimpleNamespace
+
+from neo.engine import NeoEngine
+
+
+def _suggestion(suggestion_id, file_path):
+    return SimpleNamespace(suggestion_id=suggestion_id, file_path=file_path)
+
+
+def _episode(*candidates):
+    return SimpleNamespace(memory_candidates=[
+        SimpleNamespace(suggestion_id=sid, subject=subject)
+        for sid, subject in candidates
+    ])
+
+
+class _Store:
+    """Stands in for FactStore.find_durable_fact_for_candidate."""
+
+    def __init__(self, durable_by_subject):
+        self._durable = durable_by_subject
+        self.asked = []
+
+    def find_durable_fact_for_candidate(self, subject):
+        self.asked.append(subject)
+        fact_id = self._durable.get(subject)
+        return SimpleNamespace(id=fact_id) if fact_id else None
+
+
+def _build(fact, suggestions, episode, store):
+    engine = NeoEngine.__new__(NeoEngine)
+    engine.fact_store = store
+    return NeoEngine._build_suggestion_fact_ids(engine, fact, suggestions, episode)
+
+
+def test_links_a_suggestion_to_the_durable_fact_it_applies():
+    """The whole point: a re-applied lesson has a fact to credit."""
+    subject = "bugfix: guard empty path [a.py] [fp:abc]"
+    store = _Store({subject: "fact-1"})
+
+    ids = _build(None, [_suggestion("s1", "src/a.py")], _episode(("s1", subject)), store)
+
+    assert ids == {"src/a.py": "fact-1"}
+
+
+def test_no_link_before_the_lesson_is_durable():
+    """First acceptances are evidence toward promotion, not reinforcement."""
+    subject = "bugfix: guard empty path [a.py] [fp:abc]"
+    store = _Store({})
+
+    ids = _build(None, [_suggestion("s1", "src/a.py")], _episode(("s1", subject)), store)
+
+    assert ids == {}
+    assert store.asked == [subject], "the candidate must still be consulted"
+
+
+def test_each_suggestion_resolves_against_its_own_candidate():
+    """A multi-suggestion run must not credit one fact for another's path."""
+    first = "bugfix: guard empty path [a.py] [fp:abc]"
+    second = "algorithm: batch the scan [b.py] [fp:def]"
+    store = _Store({first: "fact-1", second: "fact-2"})
+
+    ids = _build(
+        None,
+        [_suggestion("s1", "src/a.py"), _suggestion("s2", "src/b.py")],
+        _episode(("s1", first), ("s2", second)),
+        store,
+    )
+
+    assert ids == {"src/a.py": "fact-1", "src/b.py": "fact-2"}
+
+
+def test_unattributable_paths_are_never_linked():
+    """A path a git diff could never name must not carry a link."""
+    subject = "explanation: what does x do [/] [fp:abc]"
+    store = _Store({subject: "fact-1"})
+
+    for bad_path in ("/", "N/A", ""):
+        ids = _build(
+            None, [_suggestion("s1", bad_path)], _episode(("s1", subject)), store
+        )
+        assert ids == {}, f"{bad_path!r} must not be linked"
+
+
+def test_suggestion_without_a_candidate_is_skipped():
+    """No candidate means no signature to resolve; it must not guess."""
+    store = _Store({"anything": "fact-1"})
+
+    ids = _build(None, [_suggestion("s-unknown", "src/a.py")], _episode(), store)
+
+    assert ids == {}
+    assert store.asked == []
+
+
+def test_a_backend_that_still_mints_a_fact_links_directly():
+    """The legacy path stays intact and does not consult the episode."""
+    store = _Store({})
+
+    ids = _build(
+        SimpleNamespace(id="legacy-fact"),
+        [_suggestion("s1", "src/a.py"), _suggestion("s2", "src/b.py")],
+        _episode(),
+        store,
+    )
+
+    assert ids == {"src/a.py": "legacy-fact", "src/b.py": "legacy-fact"}
+    assert store.asked == []
+
+
+def test_no_episode_and_no_fact_yields_no_links():
+    """Degrades quietly rather than raising on a store with no episode."""
+    assert _build(None, [_suggestion("s1", "src/a.py")], None, _Store({})) == {}
+    assert _build(None, [_suggestion("s1", "src/a.py")], _episode(), None) == {}


### PR DESCRIPTION
## Description

`suggestion_fact_ids` — the map from a suggested file path to the fact the suggestion came from — has been **unconditionally empty since 412a174** (2026-07-18). That commit moved the FactStore path of `engine._store_reasoning` from minting a fact per suggestion to appending an episode candidate, so all three of its `return`s now yield `None`, and `_build_suggestion_fact_ids` returns `{}` for a `None` fact.

Nothing raised. The ACCEPTED branch simply fell through to the candidate path, `reinforce_legacy_fact` became unreachable, and `neo memory replay-feedback` — documented in `CLAUDE.md` as the repair command for a broken memory loop — became a no-op that reports success.

This PR restores the reinforcement link through the episode candidate (not by resurrecting per-suggestion fact minting), stops a re-accepted pattern from minting a near-twin, bounds a confidence ratchet that was driven by process restarts rather than evidence, keeps `durable` terminal, and makes the contribution banner name only the gate that actually binds.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

No tracking issue — found by tracing a stuck status-banner line (`⚡ 6 pattern(s) approaching contribution`) that had not moved in months.

## Motivation and Context

Measured on a live install before the fix:

| Signal | Value |
|---|---|
| Sessions through 2026-06-19 carrying a link per suggestion | 51 |
| Consecutive sessions from 2026-07-19 carrying **zero** links | 9 (100%) |
| `learning-stats` reinforcements, 90 days | **0** |
| Valid facts across all projects | 6,613 |
| Facts that have **ever** reached `success_count >= 3` | **0** |

So `find_contributable` has never once returned a fact and `neo contribute` has never been reachable.

The confidence half of that same gate was the mirror image. Enumerating every confidence mutation in `src/`, the only live *increase* path left was the protection boost in `demote_unhelpful_facts` — which runs on **every cold start**, so it compounded per process start rather than per verified success:

| Fact population | n | mean confidence | at exactly 1.00 |
|---|---|---|---|
| `success_count > 0` | 93 | **0.968** | 57 |
| `success_count = 0` | 6,520 | 0.719 | 2,425 |

Several of those 1.00 facts are throwaway drill prompts holding a single success against 40-odd accesses. The banner had it exactly backwards: confidence was the half satisfied almost accidentally, successes the half nothing could move.

### What changed

**1. Reinforcement link, via the candidate.** `find_durable_fact_for_candidate` matches a candidate's `_episode_signature` against the **frozen** `canonical_signature`, which only the two promotion paths ever write — so a hit means "this lesson is already durable and this suggestion re-applies it." A candidate with no durable fact contributes no link; its early acceptances stay evidence toward promotion, which the candidate path already owns. This deliberately does **not** restore per-suggestion fact minting — that is the unverified flood 412a174 existed to stop.

**2. Re-acceptance reinforces in place.** `add_fact`'s pre-write dedup cannot catch a re-promotion: its signature includes the body, which is one episode's run-varying LM prose, so a third acceptance worded differently wrote a *second* durable fact for the same lesson. `collapse_duplicate_signature_facts` heals that afterwards but keeps the richest by supporting-episode count — the **new** fact at its freshly capped mint confidence — silently discarding what the original earned. In-place reinforcement is also the only route past the `min(0.75, ...)` mint cap to the 0.8 contribution bar.

**3. Protection boost bounded by evidence.** Now stops at `min(0.9, 0.6 + 0.1 · success_count)`, compared strictly `>` so it can never claw back confidence verified outcomes granted. Existing data is untouched — facts already at 1.00 stay there, they just cannot climb there by restart count.

**4. `durable` is terminal.** `detect_implicit_feedback` calls `_record_attributed_episode_outcome` a second time right after a successful promotion to record the mutation, and that method assigned the ACCEPTED status unconditionally — immediately walking the just-written `durable` back to `supported_once`. Found while testing (2); it means **the promotion count in `learning-stats` has been a floor, not a count.**

**5. Banner names only the binding gate.** It printed a fixed `need 0.8 confidence + 3 successes` at facts already sitting at 1.00 — this repo's own rule about never blaming a cap for an absence it did not cause, broken in the line a user reads most. It also filtered `near` differently from `find_contributable`, so it could advertise facts that were never contributable at all. Gates are single-sourced; eligibility is split into permanent disqualifiers vs. the two numeric thresholds a fact can grow out of.

## How Has This Been Tested?

- [x] Full suite: **2721 passed, 29 skipped, 0 failures** (up from 2701 — all 20 new tests collected)
- [x] `ruff check src/ tests/ tools/` clean under the pinned 0.16.2
- [x] Pre-commit gate (lint + full suite) passed on the commit itself
- [x] **Mutation-verified**: 3 of the 4 protection-ceiling tests fail against the old unbounded boost; the fourth is the "does not disable protection" guard and is correctly green both ways
- [x] Banner confirmed live against the real store: `⚡ 6 pattern(s) approaching contribution: 6 short on successes (best 2 of 3)`

New coverage: `tests/test_suggestion_fact_linkage.py` (7), `TestProtectionCeiling` (4), `TestDurableFactLinkage` (5), plus 3 promotion/reinforcement tests and 1 banner test.

Two of my own tests were caught passing vacuously during review and rewritten: one used a hit rate below `PROTECTION_HIT_RATE` so it never entered the branch it claimed to test, and one asserted signature-matching using an identical subject string. The fixture now mints facts the way the promotion path does — stripped subject, frozen signature — so lookup cannot succeed by comparing subjects.

**Test Configuration**:
- Python version: 3.12.13
- OS: macOS 26.6 (darwin)
- Neo version: 0.46.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**This repairs the machinery, not the starvation.** The loop can move now; whether it *does* depends on real git-verified acceptances, of which this install sees roughly two a quarter. Expect the banner to read "short on successes" for a while yet. `learning-stats` reports 63% of recorded suggestions as advisory against 15% verifiable — that ratio, not this code, is the binding constraint on how fast anything is learned.

**Re-read `neo memory learning-stats` after this lands.** Because of (4), the promotion count it has been reporting is a floor.

`CLAUDE.md` gains five entries covering all of the above with the measurements behind them.
