### PR TITLE
fix(adapters): recover when the SDK removes a parameter, not just the API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.21.0"]
+# Upper-capped at the next major. 1.0.0 REMOVED `temperature` from
+# `Messages.create()`, so every call raised a client-side TypeError before
+# reaching the network — the adapter now recovers from that (see
+# `_sdk_rejects_keyword`), but the cap is what stops the NEXT major from
+# retiring a parameter we have not learned to drop yet. Caught by the release
+# gate rather than by 2769 tests, because every adapter test mocks the SDK and
+# a mock accepts any keyword.
+anthropic = ["anthropic>=0.21.0,<2.0"]
 openai = ["openai>=1.0.0"]
 google = ["google-genai>=0.2.0"]
 ollama = ["requests>=2.31.0"]
@@ -100,7 +107,7 @@ car = [
     "psutil>=5.9.0",
 ]
 all = [
-    "anthropic>=0.21.0",
+    "anthropic>=0.21.0,<2.0",
     "openai>=1.0.0",
     "google-genai>=0.2.0",
     "requests>=2.31.0",

--- a/src/neo/adapters.py
+++ b/src/neo/adapters.py
@@ -41,6 +41,28 @@ logger = logging.getLogger(__name__)
 
 # Adaptation flags recorded per model.
 _ADAPT_DROP_TEMPERATURE = "drop_temperature"
+
+
+def _sdk_rejects_keyword(exc: TypeError, param: str) -> bool:
+    """True when `exc` is the SDK refusing `param` at the call signature.
+
+    A provider can retire a sampling parameter in two distinct ways, and only
+    one of them is an HTTP error. `anthropic` 1.0.0 removed `temperature` from
+    `Messages.create()` outright, so the call raises a **client-side
+    TypeError** before any request is made — `BadRequestError` handling never
+    sees it, and every Anthropic call failed with
+    `ProcessingError: Messages.create() got an unexpected keyword argument
+    'temperature'`. Caught by the release gate, not by any test.
+
+    Matching is deliberately narrow: CPython's message for this case is
+    `<callable>() got an unexpected keyword argument '<name>'`, so both the
+    phrase and the quoted parameter must be present. A TypeError from inside
+    the SDK for any other reason re-raises untouched, which matters because
+    this runs on the inference path and swallowing a real bug here would
+    silently degrade every call.
+    """
+    message = str(exc)
+    return "unexpected keyword argument" in message and f"'{param}'" in message
 _ADAPT_RENAME_MAX_TOKENS = "rename_max_tokens"
 
 
@@ -181,6 +203,20 @@ def _chat_completion_resilient(client, kwargs: dict, provider: str):
     while True:
         try:
             return client.chat.completions.create(**kwargs)
+        except TypeError as e:
+            # The SDK refusing the keyword at the signature, not the API
+            # refusing it over HTTP. `anthropic` 1.0.0 did exactly this with
+            # `temperature`; the same hole existed here and is closed at the
+            # same time rather than waiting for the openai SDK to do it too.
+            if "temperature" not in kwargs or not _sdk_rejects_keyword(e, "temperature"):
+                raise
+            _PARAM_COMPAT.learn(provider, model, _ADAPT_DROP_TEMPERATURE)
+            kwargs.pop("temperature", None)
+            logger.debug(
+                "%s SDK does not accept `temperature` for model %s; dropped it "
+                "and retrying", provider, model,
+            )
+            continue
         except openai.BadRequestError as e:
             msg = str(e).lower()
             # NOTE: we can't distinguish "temperature is deprecated/unsupported"
@@ -468,6 +504,20 @@ class AnthropicAdapter(LMAdapter):
                 logger.debug(
                     "Anthropic model %s rejected `temperature`; dropped it "
                     "and retrying", self.model,
+                )
+                response = self.client.messages.create(**kwargs)
+            except TypeError as e:
+                # The SDK, not the API: `anthropic` 1.0.0 dropped `temperature`
+                # from the signature, so this raises before any request. Same
+                # remedy, same persistent learning — but it can never be a 400,
+                # so the branch above cannot reach it.
+                if "temperature" not in kwargs or not _sdk_rejects_keyword(e, "temperature"):
+                    raise
+                _PARAM_COMPAT.learn("anthropic", self.model, _ADAPT_DROP_TEMPERATURE)
+                kwargs.pop("temperature", None)
+                logger.debug(
+                    "Anthropic SDK does not accept `temperature` for model %s; "
+                    "dropped it and retrying", self.model,
                 )
                 response = self.client.messages.create(**kwargs)
             self._emit_usage_metric(response)

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -116,3 +116,77 @@ def test_unrelated_400_reraises(_fake_anthropic):
 
     assert adapter.client.messages.create.call_count == 1
     assert not adapters._PARAM_COMPAT.has("anthropic", "claude-opus-4-8", "drop_temperature")
+
+
+# ------------------------------------------------- the SDK dropping the keyword
+
+
+class TestSdkKeywordRemoval:
+    """A provider can retire a sampling parameter in two ways, and only one of
+    them is an HTTP error.
+
+    `anthropic` 1.0.0 removed `temperature` from `Messages.create()` outright,
+    so the call raises a **client-side TypeError** before any request is made.
+    The `BadRequestError` recovery above never saw it, and every Anthropic call
+    failed with `ProcessingError: Messages.create() got an unexpected keyword
+    argument 'temperature'`. `pyproject.toml` declared `anthropic>=0.21.0` with
+    no upper bound, so CI resolved into the major bump on its own.
+
+    It was caught by the release gate — one real LLM round trip per language —
+    and by nothing else in 2769 tests, because every test here mocks the SDK
+    and a mock accepts any keyword.
+    """
+
+    def test_recognises_the_sdk_refusing_a_keyword(self):
+        exc = TypeError("Messages.create() got an unexpected keyword argument 'temperature'")
+        assert adapters._sdk_rejects_keyword(exc, "temperature")
+
+    @pytest.mark.parametrize("message", [
+        "unsupported operand type(s) for +: 'int' and 'str'",
+        "Messages.create() got an unexpected keyword argument 'top_p'",
+        "Messages.create() missing 1 required positional argument: 'model'",
+        "'NoneType' object is not subscriptable",
+    ])
+    def test_unrelated_type_errors_are_not_swallowed(self, message):
+        """This sits on the inference path. Treating an unrelated TypeError as
+        a parameter rejection would silently degrade every call."""
+        assert not adapters._sdk_rejects_keyword(TypeError(message), "temperature")
+
+    def test_drops_temperature_and_retries_on_sdk_type_error(self, _fake_anthropic):
+        """One refusal, one retry without the parameter, a successful answer —
+        the behaviour the release gate demanded."""
+        adapter = _fake_anthropic(model="claude-sonnet-4-5-20250929", api_key="k")
+        adapter.client = MagicMock()
+        adapter.client.messages.create.side_effect = [
+            TypeError("Messages.create() got an unexpected keyword argument 'temperature'"),
+            _ok_response(),
+        ]
+
+        assert adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7) == "ok"
+
+        assert adapter.client.messages.create.call_count == 2
+        assert "temperature" in adapter.client.messages.create.call_args_list[0].kwargs
+        assert "temperature" not in adapter.client.messages.create.call_args_list[1].kwargs
+
+    def test_the_rejection_is_remembered_so_the_next_call_omits_it(self, _fake_anthropic):
+        """Otherwise every call pays a wasted round of argument binding."""
+        adapter = _fake_anthropic(model="claude-sonnet-4-5-20250929", api_key="k")
+        adapter.client = MagicMock()
+        adapter.client.messages.create.side_effect = [
+            TypeError("Messages.create() got an unexpected keyword argument 'temperature'"),
+            _ok_response(),
+            _ok_response(),
+        ]
+        adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)
+        adapter.generate([{"role": "user", "content": "again"}], temperature=0.7)
+
+        assert "temperature" not in adapter.client.messages.create.call_args_list[-1].kwargs
+
+    def test_an_unrelated_type_error_still_propagates(self, _fake_anthropic):
+        adapter = _fake_anthropic(model="claude-sonnet-4-5-20250929", api_key="k")
+        adapter.client = MagicMock()
+        adapter.client.messages.create.side_effect = TypeError(
+            "'NoneType' object is not subscriptable"
+        )
+        with pytest.raises(TypeError, match="NoneType"):
+            adapter.generate([{"role": "user", "content": "hi"}], temperature=0.7)


### PR DESCRIPTION
## Description

`anthropic` 1.0.0 removed `temperature` from `Messages.create()`. Every
Anthropic call now fails before reaching the network:

```
ProcessingError: Messages.create() got an unexpected keyword argument 'temperature'
```

`pyproject.toml` declared `anthropic>=0.21.0` with **no upper bound**, so the
major bump arrived on its own. Not a CI artifact — anyone installing
`neo-reasoner[anthropic]` today hits it on every run.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Blocks the v0.47.0 release: `language-roundtrip` failed on this, so `build`,
`publish-pypi` and `publish-testpypi` were all skipped and nothing reached PyPI.

## Motivation and Context

A provider can retire a sampling parameter in two ways, and **only one of them
is an HTTP error**. `adapters.py` already recovered from the 400 — catch it,
drop the param, retry, remember. It had no handling for the SDK dropping the
keyword from the signature, which raises a client-side `TypeError` before any
request exists to return a status code.

`_sdk_rejects_keyword` closes that, in the Anthropic adapter **and** in the
shared OpenAI-family path. The OpenAI half had the identical hole; fixing only
the copy that bit would leave a known defect in one half of a duplicated rule.

Matching is deliberately narrow — CPython's `unexpected keyword argument`
phrase *and* the quoted parameter name. This sits on the inference path, and
swallowing an unrelated `TypeError` would silently degrade every call.

Capped at `<2.0`: the recovery handles a parameter we know to drop, the cap
stops the next major retiring one we do not.

## How Has This Been Tested?

- [x] Full suite: **2777 passed, 29 skipped** (+8 new)
- [x] `ruff check src/ tests/ tools/` clean
- [x] **Verified against the real `anthropic` 1.0.0, not a mock.** Constructing
      the adapter with a throwaway key and calling `generate(temperature=0.7)`
      now clears the signature and reaches `AuthenticationError` — the expected
      end of the road without real credentials. Costs nothing: the `TypeError`
      fired before any network call.
- [x] Unrelated `TypeError`s still propagate (pinned, parametrized)
- [x] The rejection is remembered, so the next call omits the parameter up front

**Test Configuration**:
- Python version: 3.12.13 (CI covers 3.10–3.13)
- OS: macOS 26 (Darwin 25.6.0), Apple Silicon
- anthropic: 1.0.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**The durable lesson is about the gate, not the parameter.** This was found by
`language-roundtrip` — one real LLM round trip per language — and by nothing
else in 2769 tests. Every adapter test mocks the SDK, and **a mock accepts any
keyword**, so a mocked boundary cannot detect the boundary changing shape. The
gate is the only thing standing between an SDK major bump and a published
release that cannot make a single inference call.

It also validates the release-gate design decision recorded in
`docs/release-gate.md`: the job **fails rather than skips** without
`ANTHROPIC_API_KEY`, because an absent credential is a red gate, not a green
one. Had it skipped, 0.47.0 would have shipped to PyPI broken for every
Anthropic user.
