### PR TITLE
Release v0.47.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.47.1] - 2026-08-23
+
+Every Anthropic call in 0.47.0 fails before it reaches the network. `anthropic` 1.0.0 removed `temperature` from `Messages.create()`, and `pyproject.toml` declared `anthropic>=0.21.0` with no upper bound, so the major bump arrived on its own. 0.47.0 never reached PyPI — the release gate caught this and stopped the publish — but its GitHub release artifacts carry the defect; use 0.47.1.
+
+### Fixed
+
+- **A provider can retire a sampling parameter in two ways, and only one of them is an HTTP error.** `adapters.py` already recovered from the 400 — catch it, drop the param, retry, remember the model. It had no handling for the SDK dropping the keyword from the *signature*, which raises a client-side `TypeError` before any request exists to carry a status code:
+
+  ```
+  ProcessingError: Messages.create() got an unexpected keyword argument 'temperature'
+  ```
+
+  `_sdk_rejects_keyword` closes it, in the Anthropic adapter **and** in the shared OpenAI-family path — the hole was identical, and fixing only the copy that bit would leave a known defect in half of a duplicated rule. Matching is deliberately narrow (CPython's `unexpected keyword argument` phrase *and* the quoted parameter name) because this sits on the inference path, where swallowing an unrelated `TypeError` would silently degrade every call. Verified against the real `anthropic` 1.0.0 rather than a mock.
+
+  `anthropic` is now capped at `<2.0`. The recovery handles a parameter we know to drop; the cap is what stops the next major retiring one we do not. ([#223](https://github.com/Parslee-ai/neo/pull/223))
+
+  **The durable lesson is about the gate, not the parameter.** This was found by `language-roundtrip` — one real LLM round trip per language — and by nothing else in 2,769 tests, because every adapter test mocks the SDK and **a mock accepts any keyword**. A mocked boundary cannot detect the boundary changing shape. It also vindicates the gate's design decision in [`docs/release-gate.md`](docs/release-gate.md): the job **fails rather than skips** when `ANTHROPIC_API_KEY` is absent, because an absent credential is a red gate, not a green one. Had it skipped, 0.47.0 would have shipped to PyPI unable to make a single inference call.
+
 ## [0.47.0] - 2026-08-22
 
 Two halves of the same loop. [#219](https://github.com/Parslee-ai/neo/pull/219) restored the link that lets a verified acceptance reinforce the fact it re-applied; this release adds the input that never existed — a `PostToolUse` hook that records which files Claude Code actually edited, so acceptance can be **observed** rather than inferred from a repo-wide git diff on some later invocation. And the Claude Code plugin, which had never loaded a single component, now loads.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.47.0"
+version = "0.47.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.47.0"
+__version__ = "0.47.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release **v0.47.1** — version bump and changelog only. The fix landed in #223.

`tools/sync_version.py --check` reports all four version files in sync.

## Type of Change

- [x] Documentation update

## Related Issue

Releases [#223](https://github.com/Parslee-ai/neo/pull/223). Supersedes v0.47.0,
which was tagged but **never published to PyPI** — the release gate caught the
Anthropic defect and stopped the chain at `build`.

## Motivation and Context

`anthropic` 1.0.0 removed `temperature` from `Messages.create()`, so every
Anthropic call in 0.47.0 raises a client-side `TypeError` before reaching the
network. `pyproject.toml` had no upper bound on the dependency, so the major
bump arrived unannounced.

## How Has This Been Tested?

- [x] Full suite: **2777 passed, 29 skipped**
- [x] `ruff check src/ tests/ tools/` clean
- [x] `tools/sync_version.py --check` — all four in sync
- [x] **0.47.1 wheel smoke-tested from a clean install against the real
      `anthropic` 1.0.0**: `generate(temperature=0.7)` clears the signature and
      reaches `AuthenticationError`, the expected end without credentials. This
      is the exact check that would have caught the 0.47.0 defect.
- [x] `neo hook record` from the same wheel returns exit 0

**Test Configuration**:
- Python version: 3.12.13 (CI covers 3.10–3.13)
- OS: macOS 26, Apple Silicon
- anthropic: 1.0.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

v0.47.0's GitHub release remains, with wheels attached that carry the defect.
Nothing consumed them — PyPI never received that version — but they are
downloadable. Worth marking that release superseded if anyone might reach it.