### PR TITLE
docs(observer): the autostart opt-out belongs in .zshenv, not .zshrc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,16 @@
   never see. **Not opt-in**: `maybe_autostart_observer()`
   (called from `cli.main`) auto-registers it whenever `car-server` is reachable;
   opt out with `NEO_OBSERVER_AUTOSTART=0`. No CAR → one-time hint, then silent.
+  **Footgun — that export belongs in `~/.zshenv`, never `~/.zshrc`.** The gate is
+  a plain `os.getenv` (`observer.py`), read by whichever process runs `neo`, and
+  most of those are NOT interactive shells: an editor plugin, a CI step, a git
+  hook, an agent tool call. zsh sources `.zshrc` for interactive shells only, so
+  an export there leaves every programmatic invocation autostarting the observer
+  while the terminal prints `0` and looks correct. Measured directly: with it in
+  `.zshrc`, `zsh -c`, `zsh -lc` and a non-interactive tool call all read empty;
+  only `zsh -ic` read `0`. **Verify without `-i`** — that flag forces the single
+  mode that works, so the obvious check passes for the wrong reason and confirms
+  nothing.
   Projects are discovered from `~/.claude/projects/*` (decoded roots), minus
   **container roots** (`observer._is_container_root`): a decoded root that holds
   another discovered root and is not itself a repo. Claude Code mints a

--- a/README.md
+++ b/README.md
@@ -904,7 +904,17 @@ neo memory observer kick     # force a cycle now (maps to CAR agents_restart)
 
 It **autostarts** whenever `car-server` is reachable — opt out with
 `NEO_OBSERVER_AUTOSTART=0`. With no CAR present it prints a one-time hint and
-stays silent. Requires the `[car]` extra and a running `car-server`
+stays silent.
+
+> **Put that export in `~/.zshenv`, not `~/.zshrc`** (or `~/.bash_profile`'s
+> non-interactive equivalent). The gate is a plain `os.getenv` read by whichever
+> process runs `neo`, and most of them are **not** interactive shells — an editor
+> plugin, a CI step, a git hook, an agent tool call. zsh sources `.zshrc` only for
+> interactive shells, so an export placed there leaves every programmatic
+> invocation autostarting the observer while `echo $NEO_OBSERVER_AUTOSTART` in
+> your terminal cheerfully prints `0`. Verify with `zsh -c 'echo
+> $NEO_OBSERVER_AUTOSTART'` — **without** `-i`, which forces the one mode that
+> works and makes the check pass for the wrong reason. Requires the `[car]` extra and a running `car-server`
 (car-runtime ≥ 0.18.0). Logs land in
 `~/.car/logs/neo-observer.{stdout,stderr}.log`. Tunables:
 `NEO_OBSERVER_INTERVAL_SECONDS` (default 300), `NEO_OBSERVER_COOLDOWN`
@@ -1318,7 +1328,7 @@ export NEO_ALLOW_PLAINTEXT_API_KEY=1              # permit storing api_key in co
 **Background observer**
 
 ```bash
-export NEO_OBSERVER_AUTOSTART=0                   # do not autostart the observer
+export NEO_OBSERVER_AUTOSTART=0                   # do not autostart the observer (put in ~/.zshenv, not ~/.zshrc)
 export NEO_OBSERVER_INTERVAL_SECONDS=300          # sweep interval
 export NEO_OBSERVER_COOLDOWN=60                   # per-process cooldown between cycles
 export NEO_OBSERVER_RECYCLE_CYCLES=48             # re-exec after N cycles to bound RSS (0 disables)


### PR DESCRIPTION
## Description

`NEO_OBSERVER_AUTOSTART=0` is documented in README (twice) and CLAUDE.md, and
none of them says **where** to set it. Placed in `~/.zshrc` it is inert for
every caller that matters.

## Type of Change

- [x] Documentation update

## Motivation and Context

zsh sources `.zshrc` for **interactive shells only**. The gate is a plain
`os.getenv` in `observer.py`, read by whichever process runs `neo` — an editor
plugin, a CI step, a git hook, an agent tool call. None of those is interactive.

So the export sits in `.zshrc` looking right, the terminal prints `0`, and every
programmatic invocation still autostarts a process that sweeps every project
under `~/.claude/projects` on a 300s cycle making LM calls.

Measured while configuring a real machine, export in `.zshrc`:

| invocation | value |
|---|---|
| `zsh -c` (non-interactive) | *empty* |
| `zsh -lc` (login, non-interactive) | *empty* |
| non-interactive tool call | *empty* |
| `zsh -ic` (interactive) | `0` |

Moved to `~/.zshenv`, which zsh sources for every shell: all four read `0`.

**The verification trap is the half worth documenting.** The obvious check is
`zsh -lic 'echo $NEO_OBSERVER_AUTOSTART'` — and it passes, because `-i` forces
the one mode where `.zshrc` is read. It reported success over a setting that was
doing nothing. Both notes now say to verify *without* `-i`.

## How Has This Been Tested?

- [x] Documentation only; no code paths touched
- [x] `pytest tests/test_host_adapter_parity.py` — 68 passed
- [x] `ruff check src/ tests/ tools/` clean
- [x] Behaviour verified on a real machine in all four shell modes, before and
      after moving the export

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings