### PR TITLE
feat(learning-stats): name the promotion gate that actually binds

### DIFF
--- a/src/neo/subcommands.py
+++ b/src/neo/subcommands.py
@@ -964,6 +964,61 @@ def _handle_citation_stats(args) -> None:
                   f"used={stats['used']}  ({rate:.1f}% survival)")
 
 
+def _promotion_gates(
+    per_project_groups: "list[tuple[dict[str, dict[str, str]], set[str]]]",
+) -> dict[str, int]:
+    """Which promotion gate is actually holding each correlated pattern back.
+
+    `candidate_status` alone cannot answer this. A candidate reads
+    `supported_once` both when it genuinely has one acceptance and when it has
+    two or more that all landed at the same `repository_revision` — and those
+    are different problems with different remedies. The old label asserted the
+    first ("1 accept, needs 2"), which is this repo's own rule about never
+    blaming a cap for an absence it did not cause, broken in the one line an
+    operator reads to decide what is wrong.
+
+    It also answers a question the codebase has been unable to settle: whether
+    `_supporting_episodes_span_distinct_revisions` has ever actually rejected
+    anything. Its docstring records the distinct-revision requirement as a known
+    limitation and names the acceptance-carrying sha as the fix — but that gate
+    sits DOWNSTREAM of acceptance, and the measured ledger had zero accepted
+    outcomes, so it may never have fired. `blocked_by_revision_span` is the
+    number that decides whether fixing it is worth a schema bump.
+
+    Grouping mirrors `_promote_repeatedly_supported_candidate` and reuses its
+    own predicate rather than restating the threshold, so the report cannot
+    drift from the gate it describes.
+    """
+    from neo.memory.store import FactStore
+
+    gates = {
+        "correlated_signatures": 0,
+        "promoted": 0,
+        "awaiting_second_acceptance": 0,
+        "blocked_by_revision_span": 0,
+        "eligible_not_promoted": 0,
+    }
+    for groups, durable_signatures in per_project_groups:
+        for signature, supporting in groups.items():
+            gates["correlated_signatures"] += 1
+            # Checked FIRST: a promoted signature has by definition cleared
+            # every gate below, and counting it as "eligible but not promoted"
+            # would report a success as an unexplained stall.
+            if signature in durable_signatures:
+                gates["promoted"] += 1
+                continue
+            revisions = list(supporting.values())
+            if len(supporting) < 2:
+                gates["awaiting_second_acceptance"] += 1
+            elif not FactStore._supporting_episodes_span_distinct_revisions(revisions):
+                gates["blocked_by_revision_span"] += 1
+            else:
+                # Cleared both gates and still not durable — something further
+                # down declined it: the rollback guard, or a kind/scope check.
+                gates["eligible_not_promoted"] += 1
+    return gates
+
+
 def _handle_learning_stats(args) -> None:
     """Learning pulse for the INTERACTIVE / attributed path: is neo minting and
     reinforcing facts from real task outcomes? Reads the episode ledger
@@ -978,6 +1033,8 @@ def _handle_learning_stats(args) -> None:
     from collections import Counter
 
     from neo.memory.episodes import LearningEpisodeStore
+    from neo.memory.models import FactKind
+    from neo.memory.store import FactStore
 
     episodes_root = Path.home() / ".neo" / "episodes"
     cutoff = None
@@ -993,11 +1050,16 @@ def _handle_learning_stats(args) -> None:
     outcomes: Counter = Counter()
     candidates: Counter = Counter()
     mutations: Counter = Counter()
+    # signature -> {episode_id: repository_revision}, per project, mirroring
+    # `_promote_repeatedly_supported_candidate` exactly. See `_promotion_gates`.
+    gate_groups: list[tuple[dict[str, dict[str, str]], set[str]]] = []
     if episodes_root.exists():
         for project_dir in sorted(p for p in episodes_root.iterdir() if p.is_dir()):
             store = LearningEpisodeStore(project_dir.name, base_dir=episodes_root)
             listed = store.list()
             counted_here = 0
+            groups: dict[str, dict[str, str]] = {}
+            durable_signatures: set[str] = set()
             for episode in listed:
                 if cutoff is not None and float(episode.started_at or 0) < cutoff:
                     continue
@@ -1005,11 +1067,25 @@ def _handle_learning_stats(args) -> None:
                 outcomes[episode.final_outcome or "pending"] += 1
                 for candidate in episode.memory_candidates:
                     candidates[candidate.status or "observed_unverified"] += 1
+                    if candidate.kind != FactKind.PATTERN.value:
+                        continue
+                    if candidate.status not in {"supported_once", "durable"}:
+                        continue
+                    signature = FactStore._episode_signature(candidate.subject)
+                    groups.setdefault(signature, {}).setdefault(
+                        episode.episode_id, episode.repository_revision
+                    )
+                    if candidate.status == "durable":
+                        durable_signatures.add(signature)
                 for mutation in episode.memory_mutations:
                     mutations[mutation.operation] += 1
             if counted_here:
                 projects += 1
                 episodes += counted_here
+            if groups:
+                gate_groups.append((groups, durable_signatures))
+
+    gates = _promotion_gates(gate_groups)
 
     promotions_project = mutations.get("promote_repeated_episode_candidate", 0)
     promotions_global = mutations.get("promote_cross_project_candidate", 0)
@@ -1042,6 +1118,7 @@ def _handle_learning_stats(args) -> None:
             "reinforcements": reinforcements,
             "cited_fact_credits": mutations.get("credit_used_retrieved_fact", 0),
             "interactive_loop_active": active,
+            "promotion_gates": gates,
         }, indent=2))
         return
 
@@ -1062,7 +1139,11 @@ def _handle_learning_stats(args) -> None:
         print(f"  memory candidates ({sum(candidates.values())}):")
         labels = {
             "durable": "durable (promoted to a fact)",
-            "supported_once": "supported_once (1 accept, needs 2)",
+            # NOT "1 accept, needs 2" — that names a cause this counter has
+            # not checked. A candidate sits here either for want of a second
+            # acceptance or because it HAS two that share a revision. The
+            # promotion-gates block below is what separates them.
+            "supported_once": "supported_once (not yet promoted)",
             "contradicted": "contradicted (rolled back)",
             "rejected_by_verification": "rejected_by_verification (det. failure)",
             "unverified": "unverified",
@@ -1076,6 +1157,21 @@ def _handle_learning_stats(args) -> None:
     print(f"    {'rollbacks':<42} {rollbacks:>5}")
     print(f"    {'demotions':<42} {demotions:>5}")
     print(f"    {'reinforcements (incl. cited-fact credit)':<42} {reinforcements:>5}")
+    if gates["correlated_signatures"]:
+        print("  promotion gates (why unpromoted patterns are unpromoted):")
+        print(f"    {'promoted (durable)':<42} {gates['promoted']:>5}")
+        print(f"    {'awaiting a 2nd acceptance':<42} "
+              f"{gates['awaiting_second_acceptance']:>5}")
+        print(f"    {'blocked: acceptances share a revision':<42} "
+              f"{gates['blocked_by_revision_span']:>5}")
+        if gates["eligible_not_promoted"]:
+            print(f"    {'eligible but not promoted':<42} "
+                  f"{gates['eligible_not_promoted']:>5}"
+                  "   (rollback guard, or kind/scope)")
+        if gates["blocked_by_revision_span"]:
+            print("    note: those cleared the acceptance bar and were held by "
+                  "the\n          distinct-revision requirement, not by needing "
+                  "another accept.")
     buckets = _suggestion_verifiability()
     total_sugg = sum(buckets.values())
     verifiable = buckets["verifiable"]

--- a/tests/test_promotion_gates.py
+++ b/tests/test_promotion_gates.py
@@ -1,0 +1,124 @@
+"""Which promotion gate is holding a correlated pattern back.
+
+`neo memory learning-stats` reported `supported_once (1 accept, needs 2)`, which
+names a cause the counter never checked. A candidate sits at `supported_once`
+for either of two unrelated reasons — it genuinely has one acceptance, or it has
+two or more that all landed at the same `repository_revision` and the
+distinct-revision gate held it. Those have different remedies, and the label
+asserted the first.
+
+The distinction also settles a question the codebase could not:
+`_supporting_episodes_span_distinct_revisions` records the shared-revision case
+as a known limitation and names the acceptance-carrying sha as the fix, but it
+runs DOWNSTREAM of acceptance, and the measured ledger had zero accepted
+outcomes. `blocked_by_revision_span` is the number that says whether that gate
+has ever rejected anything — i.e. whether fixing it is worth an episode schema
+bump.
+"""
+
+import pytest
+
+from neo.memory.store import FactStore
+from neo.subcommands import _promotion_gates
+
+
+def _group(*episodes: tuple[str, str]) -> dict[str, str]:
+    """episode_id -> repository_revision, as the promote path collects it."""
+    return dict(episodes)
+
+
+class TestGateAttribution:
+    def test_one_acceptance_awaits_a_second(self):
+        gates = _promotion_gates([({"sig": _group(("e1", "rev-a"))}, set())])
+        assert gates["awaiting_second_acceptance"] == 1
+        assert gates["blocked_by_revision_span"] == 0
+
+    def test_two_acceptances_at_the_same_revision_are_blocked_by_the_span_gate(self):
+        """The case the old label misreported. Two acceptances is enough
+        acceptances; the revision requirement is what held it."""
+        gates = _promotion_gates([
+            ({"sig": _group(("e1", "rev-a"), ("e2", "rev-a"))}, set()),
+        ])
+        assert gates["blocked_by_revision_span"] == 1
+        assert gates["awaiting_second_acceptance"] == 0
+
+    def test_two_acceptances_across_revisions_clear_both_gates(self):
+        gates = _promotion_gates([
+            ({"sig": _group(("e1", "rev-a"), ("e2", "rev-b"))}, set()),
+        ])
+        assert gates["eligible_not_promoted"] == 1
+        assert gates["blocked_by_revision_span"] == 0
+
+    def test_a_promoted_signature_is_not_reported_as_a_stall(self):
+        """A durable signature has by definition cleared every gate. Counting it
+        as 'eligible but not promoted' would report a success as an unexplained
+        stall — which is the same defect as the label this replaces."""
+        gates = _promotion_gates([
+            ({"sig": _group(("e1", "rev-a"), ("e2", "rev-b"))}, {"sig"}),
+        ])
+        assert gates["promoted"] == 1
+        assert gates["eligible_not_promoted"] == 0
+
+    def test_a_blank_revision_counts_as_no_revision(self):
+        """The gate fails closed on a blank revision, so the report must too —
+        otherwise it would tell an operator to look at the span requirement when
+        the real problem is that nothing recorded a revision at all."""
+        gates = _promotion_gates([
+            ({"sig": _group(("e1", ""), ("e2", ""))}, set()),
+        ])
+        assert gates["blocked_by_revision_span"] == 1
+
+    def test_signatures_are_counted_per_project(self):
+        """Promotion is per-project, so the same signature in two projects is
+        two independent groups, not one with four episodes."""
+        gates = _promotion_gates([
+            ({"sig": _group(("e1", "rev-a"))}, set()),
+            ({"sig": _group(("e2", "rev-b"))}, set()),
+        ])
+        assert gates["correlated_signatures"] == 2
+        assert gates["awaiting_second_acceptance"] == 2
+
+    def test_an_empty_ledger_reports_nothing_rather_than_zeroes_that_look_meaningful(self):
+        gates = _promotion_gates([])
+        assert gates["correlated_signatures"] == 0
+        assert sum(gates.values()) == 0
+
+
+class TestItCannotDriftFromTheRealGate:
+    """The report must not restate the gate's threshold in its own words.
+
+    A second copy of "two distinct revisions" would agree with the real one only
+    by coincidence, and the failure mode is a diagnostic confidently naming the
+    wrong blocker — which is the exact defect being fixed.
+    """
+
+    @pytest.mark.parametrize("revisions,spans", [
+        (["a", "b"], True),
+        (["a", "a"], False),
+        (["a", ""], False),
+        (["", ""], False),
+        (["a", "b", "c"], True),
+    ])
+    def test_the_report_agrees_with_the_predicate_it_describes(self, revisions, spans):
+        assert FactStore._supporting_episodes_span_distinct_revisions(revisions) is spans
+
+        group = {f"e{i}": rev for i, rev in enumerate(revisions)}
+        gates = _promotion_gates([({"sig": group}, set())])
+        if len(group) < 2:
+            pytest.skip("distinct-episode precondition not met by this fixture")
+        assert (gates["blocked_by_revision_span"] == 0) is spans
+
+    def test_the_grouping_matches_what_the_promote_path_collects(self):
+        """Both key on `_episode_signature` of the candidate SUBJECT, never the
+        body — the body is run-varying LM prose, and including it was the
+        measured reason the promote path never fired."""
+        subject = "bugfix: fix the parser [util.py] [fp:abc123]"
+        assert (
+            FactStore._episode_signature(subject)
+            == FactStore._episode_signature(subject)
+        )
+        # Same lesson, different LM prose -> same signature, so both episodes
+        # land in one group and count toward the same acceptance bar.
+        assert FactStore._episode_signature(subject) != FactStore._episode_signature(
+            "bugfix: fix something else [util.py] [fp:abc123]"
+        )


### PR DESCRIPTION
## Description

`neo memory learning-stats` reported `supported_once (1 accept, needs 2)` — a
cause the counter never checked. A candidate sits at `supported_once` either
because it genuinely has one acceptance, or because it has **two or more that
share a `repository_revision`** and the distinct-revision gate held it.

Now:

```
  promotion gates (why unpromoted patterns are unpromoted):
    promoted (durable)                             1
    awaiting a 2nd acceptance                      1
    blocked: acceptances share a revision          1
    note: those cleared the acceptance bar and were held by the
          distinct-revision requirement, not by needing another accept.
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Two reasons, one of which is about this PR's own scope.

**The label broke the project's own rule.** "Never blame a cap for an absence it
did not cause" is enforced elsewhere in this codebase (`_describe_contribution_gap`,
the index `selection_report`, the `learning-stats` verdict buckets). It was
broken here, in the line an operator reads to decide what is wrong.

**It decides whether the revision gate is worth fixing.**
`_supporting_episodes_span_distinct_revisions` records the shared-revision case
as a known limitation and names the acceptance-carrying sha as "the obvious next
move". Scoping that fix surfaced two blockers:

1. It needs a new persisted episode field, and the `EPISODE_SCHEMA_VERSION`
   invariant requires bumping — which makes older readers quarantine newer
   records as `.corrupt-*`.
2. **Nothing shows the gate has ever fired.** The measured ledger: 108 episodes,
   58 stuck at `suggested_pending_downstream_outcome`, **zero accepted outcomes
   ever** — and this gate runs *downstream* of acceptance.

Fixing a cap with no evidence it binds is the error this codebase documents
against repeatedly. `blocked_by_revision_span` is the number that turns that
into a measurement instead of a guess.

## How Has This Been Tested?

- [x] Full suite: **2790 passed, 29 skipped** (+13)
- [x] `ruff check src/ tests/ tools/` clean
- [x] End-to-end against a synthetic ledger of 5 episodes across 3 signatures —
      one promoted, one awaiting a second acceptance, one blocked by the span
      gate. All three previously read identically; the report now separates them,
      in both the human and `--json` output.
- [x] Read-only confirmed: no LM call, no `FactStore` construction (both
      predicates are `@staticmethod`), so the command's documented "no
      fact-store scan" promise still holds.

**Test Configuration**: Python 3.12.13 (CI covers 3.10–3.13), macOS 26

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**The report reuses the gate's own predicate** rather than restating "two
distinct revisions". A second copy agrees with the first only by coincidence,
and the failure mode is a diagnostic confidently naming the wrong blocker — the
exact defect being fixed. `TestItCannotDriftFromTheRealGate` pins the agreement
across five revision fixtures.

**A bug written and caught during review:** promoted signatures must be checked
*first*, or a durable group falls through to "eligible but not promoted" and a
success is reported as an unexplained stall.