### PR TITLE
fix(hook): close two escapes an `except Exception` cannot catch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1383,7 +1383,15 @@
   followed by another Neo run. Three rules, two of them mutation-pinned:
   (1) **it never fails** — `run_hook` returns 0 on every path *by construction*,
   including an unknown action, because a hook exiting non-zero reports an error
-  against a tool call that already succeeded; (2) **it stays cheap** —
+  against a tool call that already succeeded. That means `except BaseException`,
+  not `except Exception`: `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` walk
+  straight out of the narrower handler, and the failure-REPORTING path is
+  guarded too (a closed stderr, or a custom `__str__` that raises, would defeat
+  the guarantee from inside the code announcing it). Both gaps were found by
+  running `neo` against this module and by no test — every case in
+  `TestNeverFails` raised an `Exception` subclass, so none of them could
+  distinguish the two handlers. Only SIGKILL and a library `os._exit` remain
+  outside its reach, and the docstring says so; (2) **it stays cheap** —
   `import neo.cli` is 0.04s but `neo --version` is 0.36s, and the whole
   difference is `FactStore` construction, so `cli.main` dispatches to it before
   argument parsing, the update check and the observer autostart

--- a/src/neo/hook.py
+++ b/src/neo/hook.py
@@ -10,7 +10,11 @@ case for it: `docs/solutions/host-hooks-for-outcome-detection.md`.
 Three rules govern everything in this module.
 
 **It never fails.** `run_hook` returns 0 on every path, by construction — not by
-catching the errors we thought of. A `PostToolUse` hook that exits non-zero
+catching the errors we thought of. That means `BaseException`, and it means the
+failure-reporting path is guarded too. Two things remain outside its reach and
+are stated rather than papered over: a signal that terminates the process
+(SIGKILL), and a library calling `os._exit`. Neither is reachable from this
+module's own code. A `PostToolUse` hook that exits non-zero
 reports an error against a tool call that already succeeded. CAR's equivalent
 hook documents exactly this intent and still has a hole: an unrecognized
 subcommand dies in argument parsing before any fail-open code runs, which wedged
@@ -59,9 +63,31 @@ def _debug(message: str) -> None:
 
     A hook writing to stderr on every edit would be noise in the host's UI, but
     a hook that fails silently forever is undiagnosable.
+
+    Swallows everything, including `BaseException`. This runs *inside* the
+    handler that exists to keep the hook from failing, so a closed or full
+    stderr here would defeat the whole guarantee by way of the code reporting
+    it. Neo found this one in review; no test covered it.
     """
-    if os.environ.get("NEO_HOOK_DEBUG") == "1":
+    if os.environ.get("NEO_HOOK_DEBUG") != "1":
+        return
+    try:
         print(f"[neo hook] {message}", file=sys.stderr)
+    except BaseException:
+        pass
+
+
+def _debug_failure(exc: BaseException) -> None:
+    """Report a swallowed failure, totally.
+
+    Formatting an exception can itself raise — a custom `__str__` is under no
+    obligation to succeed — so the interpolation is guarded too, not just the
+    write.
+    """
+    try:
+        _debug(f"{type(exc).__name__}: {exc}")
+    except BaseException:
+        pass
 
 
 def _head(cwd: str) -> str:
@@ -165,6 +191,18 @@ def run_hook(argv: list) -> int:
         if record is None:
             return 0
         append(record)
-    except Exception as exc:
-        _debug(f"{type(exc).__name__}: {exc}")
+    except BaseException as exc:
+        # `BaseException`, not `Exception`. `KeyboardInterrupt`, `SystemExit`
+        # and `GeneratorExit` bypass an `Exception` handler, and the docstring
+        # above claims this returns 0 on every path BY CONSTRUCTION — a
+        # stronger claim than `except Exception` delivers. Neo caught the gap;
+        # every test in `TestNeverFails` raised an `Exception` subclass, so
+        # none of them could have.
+        #
+        # Swallowing `KeyboardInterrupt` is normally wrong. It is right here:
+        # this process lives ~60ms, does one append, and is spawned by the host
+        # rather than a terminal. The tool call it reports on has ALREADY
+        # succeeded, so exiting non-zero would annotate a successful edit with a
+        # failure — worse than losing one telemetry line.
+        _debug_failure(exc)
     return 0

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -210,3 +210,72 @@ def test_the_ledger_is_registered_for_home_isolation():
     from tests.conftest import HOME_PATH_CONSTANTS
 
     assert ("neo.hook", "HOOK_LEDGER", ".neo/sessions/host_events.jsonl") in HOME_PATH_CONSTANTS
+
+
+# ------------------------------------------ escapes an `except Exception` misses
+
+
+class TestBaseExceptionCannotEscape:
+    """The gap Neo found reviewing this module, and the reason it was invisible.
+
+    `TestNeverFails` above is thorough about *inputs* and blind to *exception
+    class*: every case it raises is an `Exception` subclass, so an
+    `except Exception` handler passes all of them while `KeyboardInterrupt`,
+    `SystemExit` and `GeneratorExit` walk straight out. The docstring claimed
+    "returns 0 on every path, by construction" — a stronger claim than the code
+    delivered, and no test could tell the difference.
+    """
+
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt, SystemExit, GeneratorExit])
+    def test_base_exception_subclasses_are_swallowed(self, exc, monkeypatch, tmp_path):
+        monkeypatch.setattr(hook, "HOOK_LEDGER", tmp_path / "l.jsonl")
+        monkeypatch.setattr(sys, "stdin", __import__("io").StringIO(json.dumps(_payload())))
+        monkeypatch.setattr(hook, "build_record", lambda *a, **k: (_ for _ in ()).throw(exc()))
+        assert hook.run_hook(["record"]) == 0
+
+    def test_a_broken_stderr_in_the_reporting_path_does_not_escape(self, monkeypatch, tmp_path):
+        """The reporting path runs INSIDE the handler that exists to stop the
+        hook failing. A closed stderr there defeats the guarantee by way of the
+        code announcing it."""
+        monkeypatch.setenv("NEO_HOOK_DEBUG", "1")
+        monkeypatch.setattr(hook, "HOOK_LEDGER", tmp_path / "l.jsonl")
+        monkeypatch.setattr(sys, "stdin", __import__("io").StringIO("not json"))
+
+        class _Dead:
+            def write(self, *a):
+                raise ValueError("I/O operation on closed file")
+            def flush(self, *a):
+                raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr(sys, "stderr", _Dead())
+        assert hook.run_hook(["record"]) == 0
+
+    def test_an_exception_whose_str_raises_does_not_escape(self, monkeypatch, tmp_path):
+        """Formatting the failure can itself fail — a custom `__str__` is under
+        no obligation to succeed, and it runs inside the guard."""
+        class _Hostile(Exception):
+            def __str__(self):
+                raise RuntimeError("__str__ is hostile")
+
+        monkeypatch.setenv("NEO_HOOK_DEBUG", "1")
+        monkeypatch.setattr(hook, "HOOK_LEDGER", tmp_path / "l.jsonl")
+        monkeypatch.setattr(sys, "stdin", __import__("io").StringIO(json.dumps(_payload())))
+        monkeypatch.setattr(
+            hook, "build_record", lambda *a, **k: (_ for _ in ()).throw(_Hostile())
+        )
+        assert hook.run_hook(["record"]) == 0
+
+    def test_debug_itself_never_raises(self, monkeypatch):
+        """Called directly, not only through `run_hook` — a future caller must
+        inherit the same guarantee."""
+        monkeypatch.setenv("NEO_HOOK_DEBUG", "1")
+
+        class _Dead:
+            def write(self, *a):
+                raise OSError("no space left on device")
+            def flush(self, *a):
+                raise OSError("no space left on device")
+
+        monkeypatch.setattr(sys, "stderr", _Dead())
+        hook._debug("anything")          # must not raise
+        hook._debug_failure(ValueError("x"))


### PR DESCRIPTION
## Description

`run_hook`'s docstring claims it returns 0 on every path **by construction**. It
did not. Two escapes:

1. **`except Exception` misses `BaseException` subclasses.**
   `KeyboardInterrupt`, `SystemExit` and `GeneratorExit` walked straight out.
2. **The failure-reporting path could itself raise.** `_debug` writes to stderr
   from *inside* the handler that exists to stop the hook failing — a closed or
   full stderr defeats the guarantee by way of the code announcing it. So can
   formatting the exception; a custom `__str__` need not succeed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

A `PostToolUse` hook that exits non-zero reports an error against a tool call
that **already succeeded**. That is the whole reason for the exit-0 contract,
and the contract was written stronger than the code delivered.

Swallowing `KeyboardInterrupt` is normally wrong and is right here: the process
lives ~60ms, does one append, and is spawned by the host rather than a terminal.
Losing one telemetry line beats annotating a successful edit with a failure.
Only SIGKILL and a library `os._exit` remain outside reach, and the docstring now
says so instead of repeating a claim it cannot keep.

**Why no test caught it.** `TestNeverFails` is thorough about *inputs* —
malformed stdin, unknown actions, an unwritable ledger, opt-out — and blind to
exception **class**. Every case it raises is an `Exception` subclass, so both
handlers pass all of them identically and no assertion could distinguish them.
A suite can be exhaustive along the axis it was written for and silent on the
one that matters.

## How Has This Been Tested?

- [x] Full suite: **2796 passed, 29 skipped** (+6)
- [x] `ruff check src/ tests/ tools/` clean
- [x] **Mutation-verified, both fixes:**
  - reverting (1) lets the `KeyboardInterrupt` escape `run_hook` and **abort the
    pytest session itself**
  - reverting (2) fails `test_debug_itself_never_raises`; the through-`run_hook`
    case still passes because `_debug_failure` is a second layer — two guards,
    each pinned by the test that can see it

**Test Configuration**: Python 3.12.13 (CI covers 3.10–3.13), macOS 26

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Found by Neo reviewing its own repository** — `neo --json` over
`src/neo/hook.py`, on the first successful Neo run on this machine. Worth
recording how it reported: confidence **`null`**, basis `no_verifiable_change`,
because it named a file and produced no diff, plus a caution that it had *"hit 3
problem(s) with my own approach"*. It offered leads, explicitly not a patch, and
declined to attach a number it had not earned. The leads were right; the patch
is mine.