### PR TITLE
feat(config): read a provider key from CAR's secret store when nothing else has it

### DIFF
--- a/src/neo/config.py
+++ b/src/neo/config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 import tempfile
 from dataclasses import MISSING, dataclass, field, fields
@@ -22,8 +23,85 @@ logger = logging.getLogger(__name__)
 _SECRET_FIELDS = frozenset({"api_key"})
 
 
+#: Provider -> the environment variable that carries its key. Single-sourced:
+#: this was duplicated at both resolution sites, and a third copy was about to
+#: be added for the CAR fallback below.
+PROVIDER_ENV_VAR = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "azure": "AZURE_OPENAI_API_KEY",
+}
+
+#: What CAR calls the same key, where it differs. CAR names the Gemini key
+#: `GEMINI_API_KEY`; neo calls the provider `google`. Anything absent here uses
+#: `PROVIDER_ENV_VAR`, and both names are tried, so a key stored under either
+#: is found.
+_CAR_KEY_ALIASES = {"google": "GEMINI_API_KEY"}
+
+_CAR_SECRET_SERVICE = "car"
+_CAR_LOOKUP_TIMEOUT_SECONDS = 5.0
+
+
 def _keychain_service(provider: str) -> str:
     return f"{KEYCHAIN_SERVICE_PREFIX}:{provider}:api_key"
+
+
+def _car_key_names(provider: str) -> list:
+    """Names CAR might hold this provider's key under, in preference order."""
+    names = []
+    for name in (_CAR_KEY_ALIASES.get(provider.lower()),
+                 PROVIDER_ENV_VAR.get(provider.lower())):
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def load_api_key_from_car(provider: str) -> Optional[str]:
+    """Read this provider's key from CAR's secret store, if CAR is installed.
+
+    Neo already treats CAR as a first-class backend — `car-runtime` is an
+    extra, `CarAdapter` is a provider, `neo serve` hosts on car-server, and the
+    observer runs under CAR's supervisor. On a machine where CAR holds the
+    credential, neo refusing to look was an oversight rather than a boundary:
+    the two stores use disjoint names for the same key in the same keychain
+    (`car`/`OPENAI_API_KEY` against `neo-reasoner:openai:api_key`), so both
+    tools truthfully reported "no key" while the key sat between them.
+
+    Delegates to the `car` CLI rather than reading the keychain directly. That
+    keeps CAR's naming in CAR, and it is the only portable route: neo's own
+    `keychain_available()` is `platform.system() == "Darwin"`, while CAR's store
+    covers Keychain, Credential Manager and Secret Service. So this also gives
+    neo credential storage on Windows and Linux, which it has none of today.
+
+    Last in the chain by design — it forks a subprocess, so it must never run
+    when an env var or neo's own keychain already answered. Quiet on every
+    failure: no CAR, no entry, a timeout, a broken install. Opt out with
+    `NEO_CAR_SECRETS=0`.
+    """
+    if not provider or os.environ.get("NEO_CAR_SECRETS") == "0":
+        return None
+    car = shutil.which("car")
+    if not car:
+        return None
+    for name in _car_key_names(provider):
+        try:
+            result = subprocess.run(
+                [car, "secrets", "get", "--service", _CAR_SECRET_SERVICE, name],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_CAR_LOOKUP_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode == 0:
+            # `secrets get` prints the value with a trailing newline; the stored
+            # value itself must not be assumed to carry one either way.
+            key = result.stdout.strip()
+            if key:
+                return key
+    return None
 
 
 def keychain_available() -> bool:
@@ -209,13 +287,7 @@ class NeoConfig:
 
         # API keys. NEO_API_KEY is the explicit generic override; otherwise
         # choose the provider-specific key for the selected provider only.
-        provider_key_env = {
-            "openai": "OPENAI_API_KEY",
-            "anthropic": "ANTHROPIC_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "azure": "AZURE_OPENAI_API_KEY",
-        }
-        provider_key = provider_key_env.get(config.provider.lower())
+        provider_key = PROVIDER_ENV_VAR.get(config.provider.lower())
         config.api_key = os.environ.get("NEO_API_KEY")
         if config.api_key is None and provider_key:
             config.api_key = os.environ.get(provider_key)
@@ -287,12 +359,7 @@ class NeoConfig:
             if env_name in os.environ:
                 setattr(config, field_name, getattr(env_config, field_name))
 
-        provider_key_env = {
-            "openai": "OPENAI_API_KEY",
-            "anthropic": "ANTHROPIC_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "azure": "AZURE_OPENAI_API_KEY",
-        }.get(config.provider.lower())
+        provider_key_env = PROVIDER_ENV_VAR.get(config.provider.lower())
         if "NEO_API_KEY" in os.environ or (
             provider_key_env is not None and provider_key_env in os.environ
         ):
@@ -304,6 +371,10 @@ class NeoConfig:
 
         if not config.api_key:
             config.api_key = load_api_key_from_keychain(config.provider)
+        if not config.api_key:
+            # Last: CAR's store. Forks a subprocess, so it runs only once
+            # everything cheaper has missed.
+            config.api_key = load_api_key_from_car(config.provider)
 
         return config
 

--- a/tests/test_car_secret_fallback.py
+++ b/tests/test_car_secret_fallback.py
@@ -1,0 +1,156 @@
+"""Neo reads a provider key from CAR's secret store when nothing cheaper has it.
+
+The two tools used disjoint names for the same key in the same keychain —
+`car`/`OPENAI_API_KEY` against `neo-reasoner:openai:api_key` — so on a machine
+where CAR held the credential, both truthfully reported "no key" and neo could
+not reach a model. Neo already treats CAR as a first-class backend (`car-runtime`
+extra, `CarAdapter` provider, `neo serve` on car-server, the observer under CAR's
+supervisor); not consulting its store was an oversight, not a boundary.
+
+Two properties matter beyond "it finds the key":
+
+- **Ordering.** The lookup forks a subprocess. It must never run when an
+  environment variable or neo's own keychain already answered, or every neo
+  invocation pays a fork for nothing.
+- **Silence on absence.** No CAR, no entry, a timeout, a broken install — all
+  must return None rather than raise, because this sits on the path that builds
+  every adapter.
+"""
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from neo import config as cfg
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_keys(monkeypatch):
+    for name in ("NEO_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                 "GOOGLE_API_KEY", "AZURE_OPENAI_API_KEY", "NEO_CAR_SECRETS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _car_returning(value, returncode=0):
+    def _run(argv, **kwargs):
+        return MagicMock(returncode=returncode, stdout=value)
+    return _run
+
+
+class TestLookup:
+    def test_reads_the_key_car_holds(self, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _car_returning("sk-from-car\n"))
+        assert cfg.load_api_key_from_car("openai") == "sk-from-car"
+
+    def test_the_trailing_newline_is_stripped(self, monkeypatch):
+        """`car secrets get` prints the value with a newline. A key stored with
+        one attached would fail auth in a way that reads as a bad credential."""
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _car_returning("  sk-x  \n\n"))
+        assert cfg.load_api_key_from_car("openai") == "sk-x"
+
+    def test_asks_car_for_the_name_car_uses(self, monkeypatch):
+        """CAR calls the Gemini key `GEMINI_API_KEY`; neo calls the provider
+        `google`. Asking for neo's name alone would miss it."""
+        seen = []
+
+        def _run(argv, **kwargs):
+            seen.append(argv[-1])
+            return MagicMock(returncode=1, stdout="")
+
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _run)
+        cfg.load_api_key_from_car("google")
+        assert seen[0] == "GEMINI_API_KEY"
+        assert "GOOGLE_API_KEY" in seen, "neo's own name must also be tried"
+
+    def test_a_key_under_neos_name_is_still_found(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _run(argv, **kwargs):
+            calls["n"] += 1
+            if argv[-1] == "GOOGLE_API_KEY":
+                return MagicMock(returncode=0, stdout="sk-google\n")
+            return MagicMock(returncode=1, stdout="")
+
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _run)
+        assert cfg.load_api_key_from_car("google") == "sk-google"
+
+
+class TestQuietOnAbsence:
+    """This runs while building every adapter. None of it may raise."""
+
+    def test_no_car_installed(self, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: None)
+        assert cfg.load_api_key_from_car("openai") is None
+
+    def test_no_entry(self, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _car_returning("", returncode=1))
+        assert cfg.load_api_key_from_car("openai") is None
+
+    def test_an_empty_value_is_not_a_key(self, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run", _car_returning("   \n"))
+        assert cfg.load_api_key_from_car("openai") is None
+
+    @pytest.mark.parametrize("boom", [
+        OSError("exec failed"),
+        subprocess.TimeoutExpired(cmd="car", timeout=5),
+        subprocess.SubprocessError("broken"),
+    ])
+    def test_a_broken_car_install_does_not_raise(self, boom, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+
+        def _run(*a, **k):
+            raise boom
+
+        monkeypatch.setattr(cfg.subprocess, "run", _run)
+        assert cfg.load_api_key_from_car("openai") is None
+
+    def test_an_unknown_provider_asks_car_nothing(self, monkeypatch):
+        monkeypatch.setattr(cfg.shutil, "which", lambda _: "/usr/local/bin/car")
+        monkeypatch.setattr(cfg.subprocess, "run",
+                            lambda *a, **k: pytest.fail("must not fork"))
+        assert cfg.load_api_key_from_car("some-local-thing") is None
+
+    def test_opt_out(self, monkeypatch):
+        monkeypatch.setenv("NEO_CAR_SECRETS", "0")
+        monkeypatch.setattr(cfg.shutil, "which",
+                            lambda _: pytest.fail("must not even look for car"))
+        assert cfg.load_api_key_from_car("openai") is None
+
+
+class TestItIsLastInTheChain:
+    """The lookup forks a subprocess. Anything cheaper that can answer, must."""
+
+    def test_an_env_var_wins_and_car_is_never_asked(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        monkeypatch.setattr(cfg, "load_api_key_from_car",
+                            lambda p: pytest.fail("forked despite an env var"))
+        monkeypatch.setattr(cfg, "load_api_key_from_keychain", lambda p: None)
+        assert cfg.NeoConfig.load().api_key == "sk-from-env"
+
+    def test_neos_own_keychain_wins_and_car_is_never_asked(self, monkeypatch):
+        monkeypatch.setattr(cfg, "load_api_key_from_keychain", lambda p: "sk-from-neo")
+        monkeypatch.setattr(cfg, "load_api_key_from_car",
+                            lambda p: pytest.fail("forked despite neo's keychain"))
+        assert cfg.NeoConfig.load().api_key == "sk-from-neo"
+
+    def test_car_answers_only_when_both_have_missed(self, monkeypatch):
+        monkeypatch.setattr(cfg, "load_api_key_from_keychain", lambda p: None)
+        monkeypatch.setattr(cfg, "load_api_key_from_car", lambda p: "sk-from-car")
+        assert cfg.NeoConfig.load().api_key == "sk-from-car"
+
+
+def test_the_provider_env_map_is_single_sourced():
+    """It was duplicated at both resolution sites and a third copy was about to
+    be added here. A map that disagrees with itself sends one lookup to the
+    right variable and another to nothing."""
+    source = (cfg.__file__ and open(cfg.__file__).read()) or ""
+    assert source.count('"anthropic": "ANTHROPIC_API_KEY"') == 1, (
+        "provider->env-var mapping appears more than once in config.py"
+    )


### PR DESCRIPTION
## Description

Neo and CAR used **disjoint names for the same key in the same keychain**:

| | service | account |
|---|---|---|
| neo looks for | `neo-reasoner:openai:api_key` | `openai` |
| car stores at | `car` | `OPENAI_API_KEY` |

On a machine where CAR held the credential, both tools truthfully reported "no
key" and neo could not reach a model. `car keys list` said `—`, neo said
`OpenAI API key required`, and the key was sitting between them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Neo already treats CAR as a first-class backend — `car-runtime` is an extra,
`CarAdapter` is a provider, `neo serve` hosts on car-server, the observer runs
under CAR's supervisor. An install with `car` on PATH *knows* CAR is present.
Not consulting its secret store was an oversight, not a boundary.

It delegates to the `car` CLI rather than reading the keychain directly. That
keeps CAR's naming inside CAR, and it is the only portable route: neo's
`keychain_available()` is `platform.system() == "Darwin"`, while CAR's store
spans Keychain, Credential Manager and Secret Service. **So this also gives neo
credential storage on Windows and Linux, which it has none of today.**

Related: [Parslee-ai/car#1013](https://github.com/Parslee-ai/car/issues/1013) is
the same defect one level down — `car keys list` won't surface a key stored
under a neighbouring name in its own store.

## How Has This Been Tested?

- [x] Full suite: **2812 passed, 29 skipped** (+16)
- [x] `ruff check src/ tests/ tools/` clean
- [x] **End-to-end with no `OPENAI_API_KEY` in the environment** — `neo --json`
      completes a real run against OpenAI (exit 0) using the key CAR holds.
      This is the check that matters: an earlier unit-level pass coexisted with
      a failing real invocation, because the binary on PATH was the released
      build rather than the working tree.
- [x] **Mutation-verified ordering**: moving the CAR lookup above neo's own
      keychain fails `test_neos_own_keychain_wins_and_car_is_never_asked`.

**Test Configuration**: Python 3.12.13 (CI covers 3.10–3.13), macOS 26, car 0.49.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**It is last in the chain, deliberately and test-pinned.** The lookup forks a
subprocess; it must never run when an env var or neo's own keychain already
answered, or every invocation pays a fork for nothing.

**Both names are tried**, because they diverge: CAR calls the Gemini key
`GEMINI_API_KEY` while neo calls the provider `google`.

**Also single-sources the provider→env-var map.** It was duplicated at both
resolution sites and this change was about to add a third copy. A map that
disagrees with itself sends one lookup to the right variable and another to
nothing; a test now fails on a second definition.

Opt out with `NEO_CAR_SECRETS=0`.