### PR TITLE
Release v0.49.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.49.0] - 2026-08-30
+
+A diagnostic that invented a presence, and an extractor that never got to answer. `learning-stats` exists to tell an operator whether the accept-driven loop is running; on a live install it reported a healthy loop that was not running at all. And the transcript miner had been asking reasoning models for lessons in a budget they spend before they speak.
+
+### Fixed
+
+- **`neo memory learning-stats` counted hand-run drill state as learning.** It reported `21 promoted -> interactive loop is ACTIVE` on an install whose real promotion count was **zero**. The reporter walks every directory under `~/.neo/episodes` and counts what it finds, and 50 of the 253 episodes there belonged to `testproj1234` — drill state, with subjects like `pattern: x [a.py]` and `fp:deadbeef`, in files named `crashed.json` rather than the 32-hex ids the engine mints. Its 19 `durable` candidates *were* the promotion figure.
+
+  Cross-checking the ledger against the store is what exposed it, and it is the check worth keeping: of the 7 `promoted_fact_id`s recorded, **6 named facts that exist in no fact file**, and the 7th was an already-retracted `drill_artifact_incorrect_lesson`. Removing the drill directory alone moved accepted outcomes 44 → 2, promotions 21 → 1, rollbacks 4 → 0, demotions 4 → 0.
+
+  A project id with no `facts_project_<id>.json` cannot have received a promotion, because promotion **writes** that file. The ledger walk now counts a project only when its store exists. Two things that had to be right:
+
+  `unscoped` is exempt — it is the id `LearningEpisodeStore` assigns when a run resolves no project, so its episodes are real runs (engine errors land there), and a bare fact-store test would have thrown them away. And the exclusion is **reported, never silent**, including in the empty-ledger branch: a ledger holding nothing but drill state must not read "neo has never run" when the truth is "what is here is junk". This project's rule about never blaming a cap for an absence it did not cause, applied to a diagnostic that was inventing a presence instead.
+
+  **Why no test caught it:** three existing tests build a ledger for a project with no fact store, so the suite had encoded the broken state as the expected one. That state does not occur — `FactStore.initialize` creates the file for a brand-new project before any episode can be recorded (verified directly), and on the live ledger all 11 real project dirs had a store while only the drill dir did not. The tests were modelling drill state; they now create the store the way production does.
+
+- **The transcript lesson extractor asked for 1024 max tokens, and reasoning models spent it before answering.** `TranscriptIngester._lm_json` capped output at a number that predates reasoning models, which consume the budget on reasoning tokens before emitting a visible character. The observer log shows the result: `incomplete_details.reason = max_output_tokens`, **850 of 1024 spent reasoning**, the lessons array cut mid-object, and the whole extraction discarded. Raised to 4096, the adapters' own default — this call site was the outlier, not the target.
+
+  The failure was already loud (`transcript: LM call failed` at WARNING), which is why it is a budget bug rather than a silent one; it just named the symptom and not the cause.
+
 ## [0.48.0] - 2026-08-25
 
 Two credentials problems and two silent ones. Neo could not reach a model on a machine where CAR already held the key — the two tools use disjoint names for the same entry in the same keychain, so both truthfully reported "no key" while it sat between them. The edit-recording hook promised it returns 0 on every path *by construction* and had two ways out that an `except Exception` cannot catch. And `learning-stats` named a cause it had never checked.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.48.0"
+version = "0.49.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release v0.49.0. Bumps the version in `pyproject.toml` and the three derived files (via `make sync-version`), and adds the changelog entry for the fixes already merged to `main` in b552ee9.

The substance of the release is one defect in a diagnostic and one in the transcript miner:

- **`neo memory learning-stats` counted hand-run drill state as learning.** It reported `21 promoted -> interactive loop is ACTIVE` on an install whose real promotion count was **zero** — 50 of 253 episodes under `~/.neo/episodes` belonged to a `testproj1234` drill directory, and its 19 `durable` candidates were the entire figure. Of the 7 `promoted_fact_id`s in the ledger, 6 named facts that exist in no fact file. A project id with no `facts_project_<id>.json` cannot have received a promotion, so the ledger walk now counts a project only when its store exists — with `unscoped` exempt (it is the sentinel for a run that resolved no project, so its episodes are real) and the exclusion reported rather than silently applied.

- **The transcript lesson extractor asked for 1024 max tokens.** Reasoning models spend that before emitting a visible character: the observer log shows `max_output_tokens` truncation with 850 of 1024 spent reasoning and the lessons array cut mid-object, discarding the extraction. Raised to 4096, the adapters' own default.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None — both found while auditing a live install, not from a filed issue.

## Motivation and Context

`learning-stats` exists to answer one question: is the accept-driven loop running? It was answering "yes, actively" for a loop that was not running at all, which is worse than no dashboard — it sends the operator away from the problem. This is the project's own rule about never blaming a cap for an absence it did not cause, inverted: the diagnostic was inventing a presence.

Removing the drill directory alone moved the reported numbers from 44 accepted / 21 promotions / 4 rollbacks / 4 demotions to 2 / 1 / 0 / 0 — and the surviving promotion is an already-retracted `drill_artifact_incorrect_lesson`.

## How Has This Been Tested?

- [x] Full suite green on the code commit (b552ee9) and on this bump: **2913 passed, 29 skipped**, via the pre-commit hook, which runs the same ruff + pytest invocation as CI.
- [x] CI green on `main` for b552ee9 across the 3.10–3.13 matrix plus the Guard-invariant battery ([run 33309984033](https://github.com/Parslee-ai/neo/actions/runs/33309984033)).
- [x] Three new tests, all **mutation-verified in both directions**: removing the fact-store filter fails the two exclusion tests; removing the `unscoped` exemption fails the sentinel test.
- [x] `tools/sync_version.py --check` reports all four files in sync at 0.49.0; `tests/test_host_adapter_parity.py` 68 passed.
- [x] Distributions build clean (`neo_reasoner-0.49.0` wheel + sdist).

**Test Configuration**:
- Python version: 3.12.13 (pre-commit), 3.10–3.13 (CI matrix)
- OS: macOS 15.6 (Darwin 25.6.0)
- Neo version: 0.49.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Three existing tests had to change**, which deserves scrutiny since fitting tests to code is normally a smell. They saved episodes for a project with no fact store — a state production never reaches: `FactStore.initialize` creates the file for a brand-new project before any episode can be recorded (verified directly), and on the live ledger all 11 real project dirs had a store while only the drill dir did not. They were encoding drill state as the expected shape, so they now create the store the way production does.

**The `unscoped` exemption is load-bearing.** Without it the filter discards real runs — engine errors land there — which would have traded one silent inaccuracy for another.

**Unrelated but worth flagging:** the same audit found the CAR version-skew warning names `car update` as its primary remedy, which is structurally incapable of fixing the skew it detects. Filed as [Parslee-ai/car#1050](https://github.com/Parslee-ai/car/issues/1050); no neo change needed.
