### PR TITLE
Release v0.50.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.50.0] - 2026-08-30
+
+The learning loop had a hard mechanical ceiling, and it was one `if`. Neo credited the facts its reasoning actually used, recorded the credit in the episode ledger, reported it in `learning-stats` — and then threw it away without writing it to disk. `neo contribute` has never been reachable on any install, and this is why.
+
+### Fixed
+
+- **The cited-fact credit never reached a `save()`.** `detect_implicit_feedback` credits two different populations. Linked ORIGINAL facts — a suggestion re-applying a durable fact — move `linked_count`. CITED retrieved facts, credited by `_apply_used_fact_feedback`, do not: they bump `success_count` on the live `Fact` objects and record an episode mutation, and nothing else. The single save was `if linked_count: self.save()`, so a run that credited a cited fact but had no linked original fact never wrote the store and the credit died with the process. That is the **normal** case — `suggestion_fact_ids` is empty unless the candidate already resolves to a durable fact.
+
+  The episode ledger still recorded the mutation, so `learning-stats` reported reinforcements the fact store had never received. The reporter and the data disagreed, and the reporter was the honest one.
+
+  Measured on a live install: **0 of 88 valid GLOBAL facts had ever reached `success_count > 0`**, while 64 carried a non-zero `access_count` — global facts are almost never the linked original, so theirs were the credits always dropped. PROJECT facts topped out at exactly **2**, the value promotion writes from its two supporting episodes, because the credit that would carry one past 2 never survived. Consequently **no fact among 6,613 ever cleared the `success_count >= 3` contribution bar**. `neo contribute` was mechanically unreachable, not merely starved — and restoring the suggestion→fact link, previously recorded as the cause, would not by itself have lifted it.
+
+  Reproduced live before fixing: a drill run credited one fact with `before={'success_count': 0} after={'success_count': 1}` in the ledger while the fact on disk still read 0, immediately after and later.
+
+  **Why no test caught it, and why the obvious test still doesn't.** Two neighbouring paths save for their own reasons and persist the credit as a side effect: the no-link ACCEPTED fallback calls `add_fact`, which saves, and the janitor chain under `if outcomes:` ends in `if changed: self.save()`. So the credit survived whenever either happened to fire, which made the defect load-dependent. The real modern path reaches neither — an ACCEPTED outcome carrying an episode candidate takes the candidate branch and `continue`s past the fallback, and a *first* acceptance promotes nothing. `test_cited_fact_credit_survives_the_process` is written against that path specifically: it sets `candidate_id`, pins the janitor to "changed nothing", stubs promotion to `None`, and **reloads from disk**. All four are load-bearing; two earlier cuts of that test passed against the broken code, once via `add_fact` and once via the janitor. Every other test in `TestRetrievedFactAttribution` asserts the mutated in-memory object and never reloads — which is how a suite thorough about attribution stayed silent about persistence.
+
+- **Two Codex skills claimed memory they had disabled.** Five of the six pass `--no-memory`, documented as *"Disable persistent fact retrieval AND learning for this request"* — a deliberate privacy control, since retrieved facts become provider context. The flag stays. The prose beside it was wrong in two places: `neo/SKILL.md` said the skill "may retrieve established memory", contradicting its own privacy note eleven lines earlier; and `neo-architect/SKILL.md` step 6 instructed the agent to surface "architectural facts Neo retrieved from memory… higher-trust than fresh reasoning", which under `--no-memory` is unexecutable and invites presenting reasoning-only output as informed by past projects. The other four skills documented the flag correctly and are untouched.
+
 ## [0.49.0] - 2026-08-30
 
 A diagnostic that invented a presence, and an extractor that never got to answer. `learning-stats` exists to tell an operator whether the accept-driven loop is running; on a live install it reported a healthy loop that was not running at all. And the transcript miner had been asking reasoning models for lessons in a budget they spend before they speak.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.49.0"
+version = "0.50.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.49.0"
+__version__ = "0.50.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release v0.50.0. Version bump plus the changelog entry for the fixes already on `main` (`8a072d5`, `dded42c`, `addd0e6`).

The substance is one defect with a large consequence:

**The cited-fact credit never reached a `save()`.** `detect_implicit_feedback` credits two populations — linked ORIGINAL facts, which move `linked_count`, and CITED retrieved facts, which do not. The only save was `if linked_count: self.save()`, so a run that credited a cited fact with no linked original fact never wrote the store and the credit died with the process. That is the normal case: `suggestion_fact_ids` is empty unless the candidate already resolves to a durable fact.

The episode ledger still recorded the mutation, so `learning-stats` reported reinforcements the store had never received.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None — found by auditing a live install and confirmed with a drill.

## Motivation and Context

Measured on a live install: **0 of 88 valid GLOBAL facts had ever reached `success_count > 0`** while 64 carried a non-zero `access_count`; PROJECT facts topped out at exactly **2**, the value promotion writes. So no fact among 6,613 ever cleared the `success_count >= 3` contribution bar and `neo contribute` has never been reachable on any install.

That absence was previously attributed to the `412a174` link regression. It had a second, independent cause, and restoring the link alone would not have lifted the ceiling — the credit that carries a fact past 2 was discarding its own work. Both entries in CLAUDE.md now cross-reference so a reader does not conclude the gate is fixed once the link is.

A drill reproduced it directly: one run credited a fact with `before={'success_count': 0} after={'success_count': 1}` in the ledger while the fact on disk still read 0.

## How Has This Been Tested?

- [x] Full suite green on every commit via the pre-commit hook (same ruff + pytest invocation as CI): **2914 passed, 29 skipped**.
- [x] `test_cited_fact_credit_survives_the_process` is **mutation-verified** — reverting the one-line gate makes it fail on the disk assertion.
- [x] Diagnosis was bisected, not guessed: two hypotheses were tested and **falsified** — that the credit mutates a copy (it does not; `facts_by_id` references the stored objects) and that the observer clobbers it (simulated the exact stale-peer topology; `_reconcile_fact`'s `max()` preserves it correctly).
- [x] End-to-end drill in a scratch repo proved the surrounding machinery works: acceptance → credit → candidate → promotion, with a durable PATTERN minted at `success_count: 2` from two acceptances across two revisions.
- [x] `tools/sync_version.py --check` reports all four files in sync at 0.50.0; `test_host_adapter_parity.py` 68 passed; wheel + sdist build clean.

**Test Configuration**:
- Python version: 3.12.13 (pre-commit), 3.10–3.13 (CI matrix)
- OS: macOS 15.6 (Darwin 25.6.0)
- Neo version: 0.50.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**The test took three attempts and the first two passed against the broken code.** Two neighbouring paths save for their own reasons and persist the credit incidentally — the no-link ACCEPTED fallback calls `add_fact`, which saves, and the janitor chain ends in `if changed: self.save()`. The real path reaches neither, because an ACCEPTED outcome carrying a candidate `continue`s past the fallback and a first acceptance promotes nothing. The final test therefore sets `candidate_id`, pins the janitor, stubs promotion, and reloads from disk. That is also why the bug was load-dependent, which fits the live data.

**Not fixed here, and deliberately so:** the loop remains starved. Real acceptances need learn mode, edit-shaped prompts, and applied suggestions, and 60% of recorded suggestions are still advisory answers to questions. This lifts a mechanical ceiling; it does not manufacture evidence.

**Live end-to-end confirmation of the fix is still outstanding.** Hard-citation is LM-variable (25 of 208 historical episodes, ~12%), and two post-fix drill runs did not cite, so the credit path was not exercised end to end against the real store. The mutation-verified unit test covers the identical code path; I did not fabricate a citation in the live store to close the gap.
