### PR TITLE
Release v0.51.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.51.0] - 2026-08-30
+
+The edit-recording hook has been writing a ledger since it shipped and nothing read it. Now `collect_outcomes` does — and the first thing that falls out is that a suggestion to create a **new file** was never verifiable at all.
+
+### Added
+
+- **`collect_outcomes` reads the host edit ledger.** `neo hook record` appends every host Edit/Write to `~/.neo/sessions/host_events.jsonl`; `_load_host_edit_events` unions those into the git-derived `changed_files`. It ADDS evidence and removes none — git still reports everything committed or dirty.
+
+  **The concrete gap this closes is the untracked new file.** `git diff --name-only HEAD` lists tracked modifications ONLY, so a suggestion to create a new file — which `suggestion_is_verifiable` explicitly admits as legitimate, since proposing one is normal and shows up in `git log` once committed — was invisible to outcome detection until somebody committed it.
+
+  Closing it needed **both** halves, and the first alone is not enough: the ledger surfaces the path, and `_get_file_diff_since` gained a third source (`git diff --no-index` against `os.devnull`, gated on a new `_is_untracked`) so the classifier can see the content it is being asked to verify. With only the union, `_match_to_suggestions` found no diff to compare and returned UNVERIFIED — which by design mutates nothing, i.e. a file reported as changed that no diff could confirm. That was the observed behaviour of the first cut, not a prediction.
+
+  Confirmed end to end on a live run: neo suggested creating `src/validators.py`, the file was created and left untracked, an unrelated file was left dirty, and the next invocation recorded `accepted` for that path — while `git diff --name-only HEAD` never listed it and no commit occurred, so git could not have been the source.
+
+  **Attribution is by `file_path`, never by `cwd` or `head`.** Those name the directory the HOST was launched in, not the repository the edited file belongs to — measured directly: an edit to a scratch repository, made from a Claude Code session rooted in the neo checkout, recorded neo's OWN head. A record is ours when its path resolves inside `codebase_root`, which also stops one machine-wide ledger cross-attributing between projects.
+
+  The read is hoisted out of the per-session loop, for the same reason `_get_working_tree_changes` had to be — retention means many pending sessions, and a per-session re-read puts a linear cost on the request hot path. The rotated `.1` generation is read too: rotation moves the RECENT records there and leaves the active file nearly empty, so reading only the active file would lose exactly the window this exists to protect. A missing, unreadable or malformed ledger yields an empty list, and a malformed LINE is skipped rather than discarding the file — the ledger is append-only, so a torn final write is the expected corruption.
+
+  Every test in `tests/test_host_edit_ledger.py` runs against a **dirty** working tree, because a spotless one is the state neo is never actually invoked in. Both halves are separately mutation-pinned.
+
+### Known limits
+
+- A session that has already aged out at `PENDING_SESSION_TTL_SECONDS` (14 days) is gone before the ledger can help. The ledger makes a longer TTL *useful* — previously a longer window would only have retained records nothing could resolve — but the TTL itself is unchanged here.
+- A new-file acceptance classifies as `feature` → `decision` kind, which is deliberately non-promotable. The acceptance is now detected; it still does not mint a durable pattern.
+
 ## [0.50.0] - 2026-08-30
 
 The learning loop had a hard mechanical ceiling, and it was one `if`. Neo credited the facts its reasoning actually used, recorded the credit in the episode ledger, reported it in `learning-stats` — and then threw it away without writing it to disk. `neo contribute` has never been reachable on any install, and this is why.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.50.0"
+version = "0.51.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.50.0"
+__version__ = "0.51.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release v0.51.0. Version bump plus the changelog entry for `9912f11`, already on `main`.

**`collect_outcomes` now reads the host edit ledger.** `neo hook record` has been appending every host Edit/Write to `~/.neo/sessions/host_events.jsonl` since it shipped, and nothing read it. `_load_host_edit_events` unions those into the git-derived `changed_files` — adding evidence, removing none.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None. CLAUDE.md carried the design note ("Nothing reads the ledger yet… the consumer must be written against a DIRTY tree"); that entry is now corrected to describe the shipped behaviour.

## Motivation and Context

The concrete gap is the **untracked new file**. `git diff --name-only HEAD` lists tracked modifications only, so a suggestion to create a new file — which `suggestion_is_verifiable` explicitly admits as legitimate — was invisible to outcome detection until somebody committed it. Verified before writing any code: with an untracked file present, that command reports the tracked modification and not the new file, while `git status --porcelain` shows both.

Closing it needed **both** halves. The ledger surfaces the path; `_get_file_diff_since` gained a third source (`git diff --no-index` against `os.devnull`, gated on a new `_is_untracked`) so the classifier can see the content. With only the union, `_match_to_suggestions` found no diff to compare and returned UNVERIFIED — which mutates nothing by design, i.e. a file reported as changed that no diff could confirm. That was the **observed** behaviour of the first cut, not a prediction; the headline test failed until the second half landed.

## How Has This Been Tested?

- [x] Full suite green via the pre-commit hook (same ruff + pytest invocation as CI): **2922 passed, 29 skipped**.
- [x] **Confirmed end to end on a live run.** neo suggested creating `src/validators.py`; the file was created via the Write tool (firing the real hook), left untracked, with an unrelated file left dirty. The next invocation recorded `accepted` for that path — while `git diff --name-only HEAD` never listed it and no commit occurred, so git could not have been the source.
- [x] Both halves separately **mutation-pinned**: reverting the union fails four tests, reverting the untracked-diff source fails the headline one.
- [x] The headline test asserts its own **premise** (that git genuinely cannot see the file) rather than assuming it.
- [x] Every test in `tests/test_host_edit_ledger.py` runs against a **dirty working tree**, per CLAUDE.md — a spotless tree is the one state neo is never invoked in, and pristine-tree tests are what let the per-session retention bug ship.
- [x] `tools/sync_version.py --check` all four files in sync at 0.51.0; wheel + sdist build clean.

**Test Configuration**:
- Python version: 3.12.13 (pre-commit), 3.10–3.13 (CI matrix)
- OS: macOS 15.6 (Darwin 25.6.0)
- Neo version: 0.51.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Attribution is by `file_path`, never `cwd`/`head`.** Those name where the HOST was launched, not the edited file's repo — measured directly: an edit to a scratch repository from a Claude Code session rooted in the neo checkout recorded neo's OWN head. Keying on either drops the record; path-scoping also stops one machine-wide ledger cross-attributing between projects.

**Hot-path invariant.** The read is hoisted out of the per-session loop for the same reason `_get_working_tree_changes` had to be — retention means many pending sessions, and re-forking/re-reading per session measured 0.88s at 40 sessions last time this shape appeared. Pinned by its own test.

**The rotated `.1` generation is read too**, because rotation moves the RECENT records there and leaves the active file nearly empty — reading only the active file would lose exactly the window this exists to protect.

### Known limits, stated rather than discovered later

- A session already aged out at `PENDING_SESSION_TTL_SECONDS` (14 days) is gone before the ledger can help. This makes a longer TTL *useful* — previously a longer window would only have retained records nothing could resolve — but the TTL is unchanged here, since that is a retention-cost decision.
- A new-file acceptance classifies as `feature` → `decision` kind, deliberately non-promotable. The acceptance is now detected; it still does not mint a durable pattern.
- The untracked-diff source only fires for paths already in `changed_files`, which for an untracked file means the ledger surfaced it — so this does not widen git-driven classification.
