### PR TITLE
Release v0.52.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Two caps that were not caps. `neo --index` spent its whole file budget on tests 
 
   Only the *specific* bucket honoured the ceiling, and it does so by construction — it returns `default_max`. The one branch that could not fail was the only one a specific prompt exercised, which is why nothing caught it. Now `min(floor, default_max)`. **No behaviour change at the shipped default** (every bucket is already ≤ 30), and the cap *bounds* the heuristic rather than replacing it: a vague prompt with `--max-files 500` still gets 15. Pinned in the Guard-invariant battery beside the other no-silent-caps checks.
 
+- **A performance test measured process warmup, not the code under test.** `test_consolidation_performance_with_all_boosts` timed the *first* call to `_merge_cluster`, so one-time process costs dominated: cold n=5 reads ~18ms, warm n=5 reads **0.06ms**, and cold n=40 reads 2.8ms — eight times the work in a seventh of the time. A performance assertion whose reading falls as the input grows is measuring startup.
+
+  It flapped for the same reason (18ms against a 100ms bound is 5× headroom, so ordinary full-suite load tripped it, and the bound had already been raised 50ms → 100ms once). Fixed by warming up outside the measurement, giving ~870× headroom while keeping the assertion live — injecting a 150ms slowdown still fails it. Per the rule adopted in #183: no assertion may depend on how fast the machine running it is.
+
 ### Added
 
 - **`tools/rank_baseline_eval.py`** — scores four naive rankers (`random`, `recency`, `size`, `filename`, `grep`) over the *identical* candidate set, queries and ground truth that `rank_mine_eval.py` uses, so the ranking rule is the only thing that differs. Absolute R@k figures have no comparator and cannot answer "is this working"; this supplies one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.52.0] - 2026-08-30
+
+Two caps that were not caps. `neo --index` spent its whole file budget on tests before examining a single source file, and `--max-files` — whose help calls it a "Cap on files" — could be exceeded threefold. Both are fixed, and this release also adds the tooling that found them: neo's retrieval is now measured against naive baselines rather than reported as bare absolutes.
+
+### Fixed
+
+- **`neo --index` built a catalog of 100% test files on any `src/` + `tests/` repo** ([#213](https://github.com/Parslee-ai/neo/issues/213)). `ProjectIndex._select_files` ranked shallowest-path-first, and depth is a proxy for centrality that **inverts** on the conventional Python layout: with `src/<pkg>/…` beside `tests/…`, every test sits at depth 2 and every source file at depth 3, so the whole test tree sorted ahead of the whole source tree and `--max-files` was spent before one source file was examined.
+
+  Measured on this repo: 131 Python files at depth 2, and the existing catalog held 52 files of which 43 (82%) were tests. Rebuilt after the fix, same language scope: **94 files, 100% source**. The build reported success either way, and the selection report was truthful that the cap bound — nothing said the files it kept were all tests.
+
+  The sort key is now `(is_test, depth, path)`. Tests are **demoted, not excluded** — they fill the slots source does not need, so a test-only repository still indexes. `is_test_path` is **imported** from `context_gatherer` rather than restated, so its careful cases hold (`testdata/` and `testing/` stay ordinary source; `Foo.Tests/` does not).
+
+  Worth recording: this module already treated "tests outrank the source they test" as a failure mode — `_embed_chunks` embeds a structured summary instead of the raw body for exactly that reason. That mitigation runs at *embedding* time and never got a chance, because selection had spent the budget one stage earlier.
+
+- **`--max-files` was not a cap.** `calculate_adaptive_limit` picks a file budget from prompt specificity and returned its three broad-prompt buckets verbatim, ignoring the caller's ceiling — so `--max-files 5` on a vague prompt delivered **15 files**, three times what was asked.
+
+  | prompt | `--max-files=5` | `=10` | `=30` |
+  |---|---|---|---|
+  | "review this" | **15** | **15** | 15 |
+  | "review this codebase" | **20** | **20** | 20 |
+  | "refactor memory delete synthesis" | **25** | **25** | 25 |
+  | "review ProjectIndex.retrieve() in src/…" | 5 | 10 | 30 |
+
+  Only the *specific* bucket honoured the ceiling, and it does so by construction — it returns `default_max`. The one branch that could not fail was the only one a specific prompt exercised, which is why nothing caught it. Now `min(floor, default_max)`. **No behaviour change at the shipped default** (every bucket is already ≤ 30), and the cap *bounds* the heuristic rather than replacing it: a vague prompt with `--max-files 500` still gets 15. Pinned in the Guard-invariant battery beside the other no-silent-caps checks.
+
+### Added
+
+- **`tools/rank_baseline_eval.py`** — scores four naive rankers (`random`, `recency`, `size`, `filename`, `grep`) over the *identical* candidate set, queries and ground truth that `rank_mine_eval.py` uses, so the ranking rule is the only thing that differs. Absolute R@k figures have no comparator and cannot answer "is this working"; this supplies one.
+
+  The load-bearing baseline is **`grep`** — prompt-token counts over file *content* — because the mining leak (a file holds the commit's terms because that commit put them there) helps any content-reading ranker and does nothing for `size` or `recency`. Comparing only against content-blind baselines would let the leak masquerade as ranker quality.
+
+- **`rank_mine_eval.py --max-files N`** — sweeps the delivery cap, which was unmeasurable until the cap fix above.
+
+### Measured
+
+Recorded in `docs/`, with limits stated rather than left to be rediscovered:
+
+- **Effectiveness** (`effectiveness-evidence-2026-08-30.md`): neo's selection beats the strongest naive baseline on three repos — pooled over 150 cases, **81 better / 37 worse / 32 tied, p = 6.3 × 10⁻⁵** — and the margin grows with repo size (1.3× → 2.4×). Controlled experiments show retrieval is causally necessary both for a patch that *applies* (3/3 vs 0/3) and for project-specific correctness priors cannot supply (2/2 vs 0/2), where the failure mode is **refusal, not hallucination**.
+- **Semantic lane** (`semantic-lane-remeasurement-2026-08-30.md`): pooled across three repos the `--semantic` flag is **null** (18 better / 18 worse, p = 1.000). Its value tracks **catalog coverage**, tested causally by starving neo's own catalog 49.5% → 14.7%, which collapses a significant effect (p = 0.022) to nothing (p = 0.832). The lane is starved, not weak; the lever is the catalog cap, not the weight.
+- **Delivery cap** (`delivery-cap-sweep-2026-08-30.md`): the knee is **~10 files** on repos 29× apart in size. Cap 30 vs cap 10 over 100 cases is 6 better / 2 worse / 92 tied (p = 0.289) while costing **15–50% more context bytes**. The default is deliberately **unchanged** — that evidence is retrieval-only, and R@k cannot see whether the extra files help the model reason.
+
 ## [0.51.0] - 2026-08-30
 
 The edit-recording hook has been writing a ledger since it shipped and nothing read it. Now `collect_outcomes` does — and the first thing that falls out is that a suggestion to create a **new file** was never verifiable at all.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.51.0"
+version = "0.52.0"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -285,14 +285,28 @@ class TestPerformanceIntegration:
             entry.embedding = np.random.rand(768).astype(np.float32)
             entries.append(entry)
 
-        # Measure consolidation time
+        # Warm up OUTSIDE the measurement. Without this the test does not
+        # measure `_merge_cluster` at all: the first call pays one-time
+        # process costs, and they dominate completely. Measured — cold n=5
+        # takes ~18ms while WARM n=5 takes 0.06ms, and cold n=40 takes 2.8ms,
+        # i.e. eight times the work in a seventh of the time. A "performance"
+        # assertion whose reading falls as the input grows is measuring
+        # startup, not the algorithm.
+        #
+        # That is also why it flapped: 18ms against a 100ms bound is 5x
+        # headroom, so ordinary full-suite load failed it (it did, blocking a
+        # release), and the bound had already been raised 50ms -> 100ms once
+        # for the same reason. Warming first gives ~870x headroom at the worst
+        # of 12 observed runs, so the bound now needs a real algorithmic
+        # regression to trip rather than a busy machine — which is the rule
+        # this repo already adopted in #183: no assertion may depend on how
+        # fast the machine running it is.
+        memory._merge_cluster(list(entries))
+
         start = time.perf_counter()
         merged = memory._merge_cluster(entries)
         elapsed_ms = (time.perf_counter() - start) * 1000
 
-        # Should complete quickly (<100ms for 5 entries — loose bound so the
-        # assertion catches algorithmic regressions without flapping on
-        # shared CI runners, where 50ms drifts under load).
         assert elapsed_ms < 100, f"Consolidation took {elapsed_ms:.1f}ms, expected <100ms"
         assert merged.merge_count == 5
 


### PR DESCRIPTION
## Description

Release v0.52.0. Two caps that were not caps, the tooling that found them, and the measurements that resulted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

Fixes #213.

## Motivation and Context

**`neo --index` built a catalog of 100% test files on any `src/` + `tests/` repo (#213).** Depth is a proxy for centrality that inverts on the conventional Python layout — every test at depth 2, every source file at depth 3 — so the whole test tree sorted ahead of the whole source tree and `--max-files` was spent before one source file was examined. This repo's own catalog was 52 files, 82% tests; rebuilt after the fix, 94 files, **100% source**.

**`--max-files` was not a cap.** `calculate_adaptive_limit` returned its three broad-prompt buckets verbatim, so `--max-files 5` on a vague prompt delivered 15. The only bucket honouring the ceiling was the specific one, which does so *by construction* — the one branch that could not fail was the only one a specific prompt exercised. Found while trying to measure the delivery cap, which was unmeasurable until this was fixed: sweeping below 25 moved nothing for any prompt that was not highly specific.

**A performance test measured process warmup rather than the code under test**, and blocked this release's first bump attempt. It timed the *first* call to `_merge_cluster`: cold n=5 reads ~18ms, warm n=5 reads 0.06ms, and cold n=40 reads 2.8ms — eight times the work in a seventh of the time. An assertion whose reading falls as the input grows is measuring startup.

## How Has This Been Tested?

- [x] Full suite green via the pre-commit hook (same ruff + pytest invocation as CI): **2953 passed, 29 skipped**.
- [x] #213 fix is **mutation-verified** — reverting the one-line sort key fails 2 of the 5 new tests. `test_tests_are_demoted_not_excluded` uses a budget that *binds* (50 slots for 30 source + 60 tests); at 90 the whole repo fits and the assertion could not fail.
- [x] The cap fix is **mutation-verified** — reverting `min(floor, default_max)` fails 9 of its 26 cases. It lives in the Guard-invariant battery beside the other no-silent-caps checks, so it runs on every PR.
- [x] The perf-test fix keeps its assertion **live**: injecting a 150ms slowdown into `_merge_cluster` still fails it at 154.2ms.
- [x] Measured end-to-end on three repositories; tables and limits in `docs/`.
- [x] `tools/sync_version.py --check` all four files in sync at 0.52.0; parity suite 68 passed; wheel + sdist build clean.

**Test Configuration**:
- Python version: 3.12.13 (pre-commit), 3.10–3.13 (CI matrix)
- OS: macOS 15.6 (Darwin 25.6.0)
- Neo version: 0.52.0

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**A default that measurement says is wrong was deliberately left alone.** The delivery-cap sweep puts the knee at ~10 files on repos 29× apart in size, with cap 30 vs cap 10 at 6 better / 2 worse / 92 tied (p = 0.289) while costing 15–50% more context bytes. That evidence is *retrieval-only*, and R@k cannot see whether the extra files help the model reason — so changing a shipped default on it would be measuring one thing and acting on another. The doc records what validating it would take.

**A published finding was corrected rather than amended.** The semantic-lane re-measurement was first written up from neo alone (+0.063 MRR, p = 0.022) and read as "the flag now helps". Extending to all three flagships makes it **null** (18/18, p = 1.000), with catalog coverage as the mechanism — tested causally by starving neo's own catalog 49.5% → 14.7%, which collapses the effect to p = 0.832. Both the doc and CLAUDE.md now lead with the null.

**Measurement bugs found and fixed in the tooling itself**, each of which would have produced a confident wrong number: `random` seeded from Python's per-process-salted `hash()` (unreproducible); `recency` perturbed because the harness lives in the repo it measures; a metric reading a key that does not exist; and a validity check that discarded the evidence it was checking by sending stderr to `/dev/null`.
