### PR TITLE
Release v0.52.1 — retract the delivery-cap knee

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.52.1] - 2026-08-30
+
+Documentation only. **Retracts a measurement claim published in 0.52.0.** No code changed; no behaviour changed.
+
+### Corrected
+
+- **"The delivery-cap knee is ~10 files; the default of 30 costs 15–50% more for nothing" was wrong**, and is retracted.
+
+  The error was the metric. That conclusion rested on R@10 and MRR, which are **structurally blind to ranks 11+**: a correct answer delivered at rank 15 cannot move a top-ten metric at any cap. Those numbers read flat from cap 10 to cap 50 because they *could not vary*, not because the extra files carried nothing. Using recall@10 to size a cap larger than 10 measures nothing about the files the cap admits.
+
+  Rescored over everything the model actually receives, recall rises monotonically — neo 0.523 / 0.654 / 0.776 / **0.813** / 0.869 and m365dotnet 0.571 / 0.652 / 0.714 / **0.741** / 0.750 at caps 5/10/20/30/50. Ground truth sits at **rank 11–30 for 15% of neo's answer files and 11% of m365dotnet's**, so a cap of 10 would drop **23 of 107** and **14 of 112** answer files respectively — concretely `src/neo/cli.py` at rank 14 and `src/neo/index/project_index.py` at rank 12.
+
+  **The shipped default of 30 is well chosen and should not be cut.** Going 10 → 30 buys +24% relative recall on neo and +14% on m365dotnet for +50% context bytes; 30 → 50 buys only +7% / +1% for a further +28% bytes *and* degrades the top of the list (MRR 0.763 → 0.752, R@1 0.403 → 0.377), so extra files begin to dilute the ranking they extend. 30 sits where the returns flatten without that dilution.
+
+  **No 0.52.0 code is affected**: the default was deliberately left unchanged at the time, and the `--max-files`-is-not-a-cap fix is independent and stands. The v0.52.0 release notes carry the same correction.
+
 ## [0.52.0] - 2026-08-30
 
 Two caps that were not caps. `neo --index` spent its whole file budget on tests before examining a single source file, and `--max-files` — whose help calls it a "Cap on files" — could be exceeded threefold. Both are fixed, and this release also adds the tooling that found them: neo's retrieval is now measured against naive baselines rather than reported as bare absolutes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,24 +524,30 @@
   `rank_mine_eval.py --max-files N`). `--max-files` (default 30) had never been
   measured, and could not be until it was fixed: `calculate_adaptive_limit`
   returned its three broad-prompt buckets VERBATIM, so `--max-files 5` on a
-  vague prompt delivered 15 — the only bucket honouring the ceiling was the
-  specific one, which returns `default_max` by construction. Sweeping below 25
-  therefore moved nothing for any prompt that was not highly specific.
-  **The knee is ~10 files and the shape replicates across repos 29x apart in
-  size** (neo 99 candidates, m365dotnet 2,882): R@10 and H@10 both peak at cap
-  10 and improve nowhere beyond. Pooled paired over 100 cases, **cap 30 vs cap
-  10: 6 better, 2 worse, 92 tied, p = 0.289** — tripling the delivered files
-  changes 8 outcomes in 100, in both directions, while costing **+50% context
-  bytes on neo (131 KB -> 197 KB) and +15% on m365dotnet**. Below 10 there IS
-  loss (neo 5->10: 6/0, p = 0.031). Byte cost is **not monotonic in file
-  count** — cap 5 spends MORE than cap 10 (142 KB vs 131 KB) while retrieving
-  worse, because `--max-bytes` is apportioned across whatever is admitted, so
-  10 is both the quality saturation point and the cost minimum.
-  **The default was deliberately NOT changed**: this evidence is retrieval-only,
-  and R@k cannot see whether the other 20 files help the model REASON (the
-  effectiveness doc's §2b shows context presence is causally necessary for a
-  usable patch). Validating 10 needs an answer-quality arm — the planted-bug
-  design at cap 10 vs 30 — which has not been run.
+  vague prompt delivered 15, and sweeping below 25 moved nothing for any prompt
+  that was not highly specific.
+  **The default of 30 is well chosen and must not be cut to 10.** Rescored over
+  everything the model receives: recall(delivered) rises monotonically —
+  neo 0.523 / 0.654 / 0.776 / **0.813** / 0.869 and m365dotnet 0.571 / 0.652 /
+  0.714 / **0.741** / 0.750 at caps 5/10/20/30/50. Going 10 -> 30 buys +24%
+  relative recall on neo and +14% on m365dotnet for +50% context bytes; 30 -> 50
+  buys +7% / +1% for a further +28% bytes AND degrades the top of the list
+  (MRR 0.763 -> 0.752, R@1 0.403 -> 0.377), so extra files dilute the ranking
+  they extend. 30 sits where returns flatten without that dilution.
+  **Footgun, and the reason a first pass concluded the opposite:** R@10 and MRR
+  are **structurally blind to ranks 11+**, so a correct answer delivered at rank
+  15 cannot move either number at any cap. They read flat from cap 10 to 50
+  because they COULD NOT VARY, and the first analysis published "the knee is ~10,
+  the default costs 15-50% for nothing" in v0.52.0's changelog and release notes
+  before this was caught. Measured properly, **truth sits at rank 11-30 for 15%
+  of neo's answer files and 11% of m365dotnet's**, so a cap of 10 would drop 23
+  of 107 and 14 of 112 respectively (concretely: `src/neo/cli.py` at rank 14,
+  `project_index.py` at rank 12). **A delivery question needs recall over the
+  DELIVERED set, never recall@10** — using a top-k metric to size a cap larger
+  than k measures nothing about the files the cap admits.
+  Byte cost is **not monotonic in file count** — cap 5 spends MORE than cap 10
+  (142 KB vs 131 KB) while delivering less, because `--max-bytes` is apportioned
+  across whatever is admitted. Below 10 there is real loss on both metrics.
 - **Effectiveness evidence** (`docs/effectiveness-evidence-2026-08-30.md`,
   `tools/rank_baseline_eval.py`). Absolute R@k figures have no comparator and
   cannot answer "is neo effective". The baseline harness scores four naive

--- a/docs/delivery-cap-sweep-2026-08-30.md
+++ b/docs/delivery-cap-sweep-2026-08-30.md
@@ -1,102 +1,84 @@
 # How many files should neo deliver?
 
-**Date:** 2026-08-30 · **Code:** `68223a7` · **Harness:** `tools/rank_mine_eval.py --max-files N`
+**Date:** 2026-08-30 (corrected same day) · **Harness:** `tools/rank_mine_eval.py --max-files N`
 
-The delivery cap (`--max-files`, default 30) had never been measured. This is the
-sweep, on two repositories three orders of magnitude apart in candidate count.
+> ## Correction
+>
+> The first version of this document concluded **"the knee is ~10 files; the
+> default of 30 costs 15–50% more for nothing."** That was **wrong**, and it
+> shipped in v0.52.0's changelog and release notes.
+>
+> The error was the metric. R@10 and MRR only look at the top ten results, so
+> they are **structurally blind to ranks 11+** — a correct answer delivered at
+> rank 15 cannot move either number, no matter what the cap is. Those metrics
+> were flat from cap 10 to cap 50 because they *could not vary*, not because
+> extra files carried nothing. Measuring recall@10 to answer a question about
+> delivery@30 is the same category of error this repo documents elsewhere:
+> measuring one thing and concluding about another.
+>
+> Rescored over everything the model actually receives, the conclusion inverts:
+> **the default of 30 is well chosen, and cutting to 10 would drop 13–21% of the
+> answer files neo currently delivers.**
 
-## First, the knob did not work
+## Where the answer actually ranks
 
-The first sweep produced an incoherent curve — R@10 *higher* at cap 10 than at
-the default 30, which cannot happen if the cap is a cap. It was not:
-`calculate_adaptive_limit` returned its three broad-prompt buckets verbatim,
-ignoring the caller's ceiling.
+Position of each ground-truth file in the delivered list, cap 50, 50 cases:
 
-| prompt | `--max-files=5` | `=10` | `=30` |
-|---|---|---|---|
-| "review this" | **15** | **15** | 15 |
-| "review this codebase" | **20** | **20** | 20 |
-| "refactor memory delete synthesis" | **25** | **25** | 25 |
-| "review ProjectIndex.retrieve() in src/…" | 5 | 10 | 30 |
+| rank band | neo (107 truth files) | m365dotnet (112) |
+|---|---|---|
+| 1–10 | 70 (65%) | 70 (62%) |
+| **11–30** | **17 (15%)** | **13 (11%)** |
+| 31+ | 6 (5%) | 1 (0%) |
+| never delivered | 14 (13%) | 28 (25%) |
 
-Only the *specific* bucket honoured the ceiling, and it does so by construction
-(it returns `default_max`) — which is why nothing caught it. Fixed in `68223a7`
-(`min(floor, default_max)`), with no behaviour change at the default. Sweep
-points taken before that fix were discarded rather than reported: a curve
-measured across two code versions is not a curve.
+**A cap of 10 would drop 23 of 107 answer files on neo and 14 of 112 on
+m365dotnet.** Concretely, on neo: `src/neo/cli.py` at rank 14 and rank 23, and
+`src/neo/index/project_index.py` at rank 12 — real answers, silently outside a
+top-10 metric's field of view.
 
-## The curves
+## Recall over everything delivered
 
-**neo** — 99 candidate files, 50 cases:
+The metric a delivery question requires: what fraction of the answer files does
+the model actually receive?
 
-| cap | R@10 | MRR | H@10 | mean context bytes |
-|---|---|---|---|---|
-| 5 | 0.620 | 0.739 | 0.880 | 142,440 |
-| **10** | **0.720** | 0.762 | **0.980** | **131,521** |
-| 15 | 0.720 | 0.761 | 0.980 | — |
-| 20 | 0.720 | 0.761 | 0.980 | — |
-| 30 *(default)* | 0.720 | 0.763 | 0.980 | 197,382 |
-| 50 | 0.720 | 0.752 | 0.980 | 253,296 |
+| cap | neo recall | neo hit-rate | m365 recall | m365 hit-rate | neo bytes |
+|---|---|---|---|---|---|
+| 5 | 0.523 | 0.88 | 0.571 | 0.76 | 142,440 |
+| 10 | 0.654 | 0.98 | 0.652 | 0.80 | 131,521 |
+| 20 | 0.776 | 0.98 | 0.714 | 0.84 | — |
+| **30** *(default)* | **0.813** | 0.98 | **0.741** | 0.88 | 197,382 |
+| 50 | 0.869 | 0.98 | 0.750 | 0.90 | 253,296 |
 
-**m365dotnet** — 2,882 candidate files, 50 cases:
+Monotonic on both repos, with diminishing returns rather than a knee:
 
-| cap | R@10 | MRR | H@10 | mean context bytes |
-|---|---|---|---|---|
-| 5 | 0.607 | 0.528 | 0.760 | — |
-| **10** | **0.678** | 0.532 | **0.800** | **201,796** |
-| 20 | 0.678 | 0.534 | 0.800 | — |
-| 30 *(default)* | 0.668 | 0.536 | 0.800 | 231,202 |
-| 50 | 0.656 | 0.545 | 0.780 | — |
+- **10 → 30**: recall 0.654 → 0.813 on neo (+24% relative) and 0.652 → 0.741 on
+  m365dotnet (+14%), for +50% context bytes. A real trade, not "nothing".
+- **30 → 50**: +7% relative recall on neo, +1% on m365dotnet, for a further
+  +28% bytes — and top-of-list quality gets slightly *worse* (MRR 0.763 → 0.752
+  on neo, R@1 0.403 → 0.377), so the extra files dilute the ranking they extend.
 
-## What the numbers say
+**The shipped default of 30 sits where the returns flatten without the dilution
+that shows up by 50.** It was not measured when it was chosen; it is now, and it
+holds up.
 
-**The knee is ~10 files, and the shape replicates on a repo 29× larger.** R@10
-and hit-rate@10 both peak at cap 10 on both repos and improve nowhere beyond it.
+## What survives from the first analysis
 
-**Tripling the cap to the shipped default buys nothing measurable.** Pooled
-paired over 100 cases, cap 30 vs cap 10: **6 better, 2 worse, 92 tied,
-sign p = 0.289.** Tripling the delivered files changes the outcome in 8 cases
-out of 100, in both directions.
-
-**It costs real budget**: +50% context bytes on neo (131 KB → 197 KB), +15% on
-m365dotnet (202 KB → 231 KB), on every invocation.
-
-**Below 10 there is genuine loss.** neo 5 → 10 is 6 better / 0 worse,
-**p = 0.031** (R@10 0.620 → 0.720, H@10 0.880 → 0.980). m365dotnet moves the
-same direction (R@10 0.607 → 0.678) without reaching significance at n=50.
-
-**Byte cost is not monotonic in file count.** cap 5 spends *more* bytes than
-cap 10 on neo (142 KB vs 131 KB) while retrieving worse, because `--max-bytes`
-(300 KB) is apportioned across whatever is admitted — five files each take a
-large share. So 10 is simultaneously the saturation point of the quality curve
-and the minimum of the cost curve.
-
-## The default was NOT changed, and that is deliberate
-
-The evidence above is retrieval-only. R@k asks whether the needed file is in the
-delivered list; it cannot see whether the other 20 files help the model *reason*
-about the task. `docs/effectiveness-evidence-2026-08-30.md` §2b shows context
-presence is causally necessary for a usable patch — so cutting delivery could
-degrade answers in a way this instrument is blind to.
-
-Changing a shipped default on retrieval-only evidence would be measuring one
-thing and acting on another. What is established:
-
-- 10 files suffice **for retrieval** on both repos measured;
-- the default of 30 costs 15–50% more context bytes for no measurable retrieval
-  gain;
-- 5 is too few.
-
-Validating a change to 10 needs an answer-quality arm — the planted-bug design
-in the effectiveness doc, run at cap 10 vs cap 30 — which has not been run.
+- **`--max-files` was not a cap**, and fixing it was a genuine prerequisite:
+  `calculate_adaptive_limit` returned its broad-prompt buckets verbatim, so
+  `--max-files 5` on a vague prompt delivered 15. Sweeping the knob below 25 did
+  nothing for any prompt that was not highly specific. Fixed and released in
+  v0.52.0; that part of the finding is unaffected.
+- **Byte cost is not monotonic in file count** — cap 5 spends *more* than cap 10
+  (142 KB vs 131 KB) while delivering less, because `--max-bytes` is apportioned
+  across whatever is admitted and five files each take a large share.
+- **Below 10 there is real loss**, which both metrics agreed on.
 
 ## Limits
 
-- Two repos, 50 cases each. `aieweb` was not swept.
-- Every caveat in the harness docstring applies: absolutes are upper bounds
-  (the corpus has already seen the answer), and the mined population is filtered
-  upward toward small, well-described changes.
-- "Not significantly different" with 92% ties is weak evidence *for* equivalence,
-  not proof of it. The defensible claim is that no gain was measured, not that
-  none exists.
+- Two repos, 50 cases each; `aieweb` was not swept.
+- Absolutes are upper bounds — the corpus has already seen the answer — and the
+  mined population is filtered upward toward small, well-described changes.
+- Recall over delivered files measures whether the answer *reached* the model,
+  not whether more files help it reason. A larger context can dilute as well as
+  inform, and the MRR/R@1 dip at cap 50 is the only signal here that it does.
 - Byte figures are means over 7–11 prompts, not the full case set.

--- a/plugins/neo/.codex-plugin/plugin.json
+++ b/plugins/neo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neo",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
   "author": {
     "name": "Parslee AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "neo-reasoner"
-version = "0.52.0"
+version = "0.52.1"
 description = "A self-improving code reasoning engine with persistent semantic memory"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/neo/__init__.py
+++ b/src/neo/__init__.py
@@ -2,6 +2,6 @@
 
 from neo.cli import CodeSuggestion, PlanStep, SimulationTrace, StaticCheckResult
 
-__version__ = "0.52.0"
+__version__ = "0.52.1"
 
 __all__ = ["__version__", "CodeSuggestion", "PlanStep", "SimulationTrace", "StaticCheckResult"]


### PR DESCRIPTION
## Description

Release v0.52.1 — **documentation only, retracting a measurement claim published in v0.52.0.** No code changed, no behaviour changed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issue

None.

## Motivation and Context

v0.52.0 shipped the claim *"the delivery-cap knee is ~10 files; the default of 30 costs 15–50% more context bytes for nothing."* **It was wrong.**

The error was the metric. That conclusion rested on R@10 and MRR, which are **structurally blind to ranks 11+** — an answer delivered at rank 15 cannot move a top-ten metric at any cap. Those numbers read flat from cap 10 to cap 50 because they *could not vary*, not because the extra files carried nothing. Using recall@10 to size a cap larger than 10 measures nothing about the files the cap admits.

Rescored over everything the model actually receives:

| cap | 5 | 10 | 20 | **30** | 50 |
|---|---|---|---|---|---|
| neo recall(delivered) | 0.523 | 0.654 | 0.776 | **0.813** | 0.869 |
| m365dotnet | 0.571 | 0.652 | 0.714 | **0.741** | 0.750 |

Ground truth sits at **rank 11–30 for 15% of neo's answer files and 11% of m365dotnet's**, so a cap of 10 would drop **23 of 107** and **14 of 112** answer files — concretely `src/neo/cli.py` at rank 14 and `src/neo/index/project_index.py` at rank 12.

**The shipped default of 30 is well chosen and must not be cut.**

## How Has This Been Tested?

- [x] Full suite green via the pre-commit hook: **2953 passed, 29 skipped**.
- [x] The corrected figures are recomputed from the same per-case data the original sweep produced — no re-run, no new variance, the same 100 cases rescored with a metric that can see the ranks in question.
- [x] Verified against concrete cases rather than aggregates: the specific answer files a cap of 10 drops are named, with their ranks.
- [x] `tools/sync_version.py --check` all four files in sync at 0.52.1; wheel + sdist build clean.

**Test Configuration**: Python 3.12.13 (pre-commit), 3.10–3.13 (CI); macOS 15.6; neo 0.52.1.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, docs only
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**No v0.52.0 code is affected.** The default was deliberately left unchanged when the wrong analysis was written — the one decision that happened to be right, for a weaker reason than the real one — and the `--max-files`-is-not-a-cap fix is independent and stands.

**The v0.52.0 GitHub release notes have been edited** to strike the claim and carry the correction, so a reader arriving at that tag is not misled.

**What survives from the first pass:** the cap fix itself; that byte cost is not monotonic in file count (cap 5 spends *more* than cap 10 while delivering less, because `--max-bytes` is apportioned across whatever is admitted); and that below 10 there is real loss on both metrics.
