### PR TITLE
feat(hosts): add Cursor plugin adapter alongside Claude and Codex

### DIFF
--- a/.agents/skills/source-command-prepare-release/SKILL.md
+++ b/.agents/skills/source-command-prepare-release/SKILL.md
@@ -25,8 +25,8 @@ Updates version numbers, CHANGELOG.md, and builds distributions for a new releas
 2. **Reviews** commits since last release tag
 3. **Updates** CHANGELOG.md with new version section and categorized changes
 4. **Updates** the version in `pyproject.toml`, then runs `make sync-version`
-   to propagate it to the three derived files (`src/neo/__init__.py`, both
-   plugin manifests)
+   to propagate it to the four derived files (`src/neo/__init__.py`, Claude /
+   Codex / Cursor plugin manifests)
 5. **Syncs** the local editable install metadata so `importlib.metadata.version("neo-reasoner")` matches the new version
 6. **Builds** wheel and sdist distributions
 7. **Reports** what was done and next steps
@@ -77,12 +77,14 @@ Edit **one** file, then propagate:
 make sync-version
 ```
 
-That rewrites `src/neo/__init__.py`, `.claude-plugin/plugin.json`, and
-`plugins/neo/.codex-plugin/plugin.json` to match. Do **not** hand-edit those
-three: this step used to be "update the version string in all four files", and
-the manifests silently drifted to 0.37.0 and 0.19.0 while the package was at
-0.41.0. `tests/test_host_adapter_parity.py` fails if they are out of sync, and
-`python tools/sync_version.py --check` reports drift without writing.
+That rewrites `src/neo/__init__.py`, `.claude-plugin/plugin.json`,
+`plugins/neo/.codex-plugin/plugin.json`, and
+`plugins/cursor-neo/.cursor-plugin/plugin.json` to match. Do **not** hand-edit
+those four: this step used to be "update the version string in all files by
+hand", and the manifests silently drifted to 0.37.0 and 0.19.0 while the
+package was at 0.41.0. `tests/test_host_adapter_parity.py` fails if they are
+out of sync, and `python tools/sync_version.py --check` reports drift without
+writing.
 
 ### Step 5: Sync Local Editable Metadata
 
@@ -113,7 +115,10 @@ Verify both files were created in `dist/` directory.
 Show what was updated and provide next steps:
 ```bash
 # Next steps:
-git add CHANGELOG.md pyproject.toml src/neo/__init__.py .claude-plugin/plugin.json plugins/neo/.codex-plugin/plugin.json
+git add CHANGELOG.md pyproject.toml src/neo/__init__.py \
+  .claude-plugin/plugin.json \
+  plugins/neo/.codex-plugin/plugin.json \
+  plugins/cursor-neo/.cursor-plugin/plugin.json
 git commit -m "chore: bump version to {new_version}"
 git tag v{new_version}
 git push origin main --tags

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Neo Cursor plugins — semantic reasoning with persistent memory",
-    "version": "0.46.0"
+    "version": "0.52.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "neo-cursor",
+  "owner": {
+    "name": "Parslee AI",
+    "email": "hello@parslee.ai",
+    "url": "https://parslee.ai"
+  },
+  "metadata": {
+    "description": "Neo Cursor plugins — semantic reasoning with persistent memory",
+    "version": "0.46.0"
+  },
+  "plugins": [
+    {
+      "name": "neo",
+      "source": "./plugins/cursor-neo",
+      "description": "Semantic reasoning with persistent memory (skills + Neo agent)"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,13 @@
   fact retrieval, constraints, four-layer assembly) and prints what *would* be sent to
   the LM, then exits without making the LLM call. Faster iteration on context-gatherer
   and retrieval changes than waiting for an inference round trip.
+- Host adapters (three surfaces, one `neo --json` contract): `.claude-plugin/`
+  (Claude Code agent + commands), `plugins/neo/` (Codex skills),
+  `plugins/cursor-neo/` (Cursor skills + Neo agent, marketplace at
+  `.cursor-plugin/marketplace.json`). Keep all three in sync; versions via
+  `make sync-version`. Mid-loop skills (Codex + Cursor `/neo*`) use
+  `--no-scan` / advise `--no-memory`; Claude and the Cursor agent are the
+  visible-boundary path. `.agents/skills/` is release maintenance only.
 - CarAdapter defaults `intent_hint={"task":"code"}` so CAR's router picks a code-capable
   model rather than the chat default. This is the local workaround for
   [Parslee-ai/car-releases#52](https://github.com/Parslee-ai/car-releases/issues/52)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1355,37 +1355,44 @@
   response — a peer that sees generic `ProcessingError` assumes its own request
   was malformed and stops retrying. The lock releases in a `finally`, so a
   failed run doesn't leave the engine permanently busy (pinned by a test).
-- **Host adapters must stay in parity.** There are TWO checked-in integration
+- **Host adapters must stay in parity.** There are THREE checked-in integration
   surfaces, and they are easy to miss: `.claude-plugin/` (agent + 6 slash
-  commands) and **`plugins/neo/`** (Codex CLI plugin + 6 skills, manifest at
+  commands), **`plugins/neo/`** (Codex CLI plugin + 6 skills, manifest at
   `plugins/neo/.codex-plugin/plugin.json`, registered by
-  `.agents/plugins/marketplace.json`). `.agents/skills/` holds RELEASE
+  `.agents/plugins/marketplace.json`), and **`plugins/cursor-neo/`** (Cursor
+  plugin + 6 skills + Neo agent, manifest at
+  `plugins/cursor-neo/.cursor-plugin/plugin.json`, registered by
+  `.cursor-plugin/marketplace.json`). `.agents/skills/` holds RELEASE
   maintenance skills, not the Neo capabilities — looking there and concluding
-  the Codex plugin is missing is a documented wrong turn. Neither adapter owns
-  an output format: both invoke `neo --json` and read the same `orchestrator`
-  envelope. When the contract changes, BOTH change — the Codex skills sat on
+  the Codex or Cursor plugin is missing is a documented wrong turn. No adapter
+  owns an output format: all invoke `neo --json` and read the same `orchestrator`
+  envelope. When the contract changes, ALL change — the Codex skills sat on
   "parse the four structured sections: CONFIDENCE, PLAN, SIMULATIONS, CODE
   SUGGESTIONS" while the Claude side had already moved to `--json`.
-  `tests/test_host_adapter_parity.py` pins it: both surfaces expose the same
+  `tests/test_host_adapter_parity.py` pins it: all three surfaces expose the same
   six capabilities, invoke `--json`, teach `orchestrator.summary`/`cautions`,
   document the error shape and attribution, and use phase/event names that
-  actually exist in `events.py`. It also pins that both plugin manifests match
+  actually exist in `events.py`. It also pins that all plugin manifests match
   the `pyproject.toml` version — `prepare-release` documents bumping them, but
   a documented step with no enforcement gets skipped (they had reached 0.19.0 /
   0.37.0 / 0.41.0). **The version is now single-sourced**: `pyproject.toml` is
   the truth and `tools/sync_version.py` (`make sync-version`) propagates it to
-  `src/neo/__init__.py` and both manifests. Release bumps edit ONE file; never
-  hand-edit the derived three. `--check` reports drift without writing. Edits
-  are surgical regex replacements, not `json.dumps` re-serialization — a
-  version bump must stay a one-line diff or it becomes unreviewable — and only
-  the FIRST `"version"` key is rewritten so a nested one can't be clobbered.
+  `src/neo/__init__.py` and the Claude / Codex / Cursor manifests. Release bumps
+  edit ONE file; never hand-edit the derived files. `--check` reports drift
+  without writing. Edits are surgical regex replacements, not `json.dumps`
+  re-serialization — a version bump must stay a one-line diff or it becomes
+  unreviewable — and only the FIRST `"version"` key is rewritten so a nested
+  one can't be clobbered.
   `tools/` is now covered by lint; it never was, which is why a dead import sat
   in `ab_controlled.py`. The ruff invocation is duplicated in `Makefile`
   (`lint` + `ci-local`), `.github/workflows/ci.yml` and `.githooks/pre-commit`
-  — all four MUST stay identical or local green stops predicting CI green. Role differs even though protocol does not: Claude Code
-  delegates to Neo as a subagent (visible boundary), Codex calls Neo mid-loop
-  (no boundary), so the Codex skills carry stronger attribution wording and an
-  explicit "Neo's result is an input, not the deliverable".
+  — all four MUST stay identical or local green stops predicting CI green. Role
+  differs even though protocol does not: Claude Code (and the Cursor **agent**)
+  delegates to Neo as a subagent (visible boundary); Codex and Cursor **skills**
+  call Neo mid-loop (no boundary), so those skills carry stronger attribution
+  wording and an explicit "Neo's result is an input, not the deliverable".
+  Cursor mid-loop skills use Codex's `--no-scan` / advise `--no-memory` defaults;
+  the Cursor agent keeps Claude's looser advise invoke.
 - CarAdapter defaults `intent_hint={"task":"code","prefer_quality":True}` so CAR's router
   routes neo to the most capable model, not the chat/cost default. This is the *intended*
   router API, not a hack:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,8 @@ neo/
 ├── construct/                      # Curated design pattern library
 ├── .claude-plugin/                 # Claude Code plugin sources (manifest, agent, slash commands)
 ├── plugins/neo/                    # Codex plugin sources (manifest, skills)
+├── plugins/cursor-neo/             # Cursor plugin sources (manifest, agent, skills)
+├── .cursor-plugin/                 # Cursor marketplace catalog (points at plugins/cursor-neo)
 ├── .agents/                        # Portable skill packages (shared release commands)
 └── pyproject.toml                  # Package configuration
 ```
@@ -207,16 +209,28 @@ neo/
 4. **New Claude Code Slash Command** (`.claude-plugin/commands/`)
    - Add `<name>.md` defining the command's intent and arguments
    - Update `.claude-plugin/plugin.json` so the marketplace surfaces it
-   - Mirror the command's purpose in the **Codex skill** below (same six skills are exposed in both plugins)
+   - Mirror the command's purpose in the **Codex skill** and **Cursor skill**
+     below (the same six capabilities are exposed on all three plugins)
    - Document it in the README's Claude Code Plugin section
 
 5. **New Codex Skill** (`plugins/neo/`)
    - Add a SKILL file under the appropriate subdirectory
    - Register it in the plugin's manifest
-   - Mirror it as a Claude Code slash command (see #4) — the two plugin surfaces are kept symmetric on purpose
+   - Mirror it as a Claude Code slash command and a Cursor skill — the three
+     plugin surfaces are kept symmetric on purpose
    - Document it in the README's Codex Plugin section
 
-6. **New CAR / A2A Tool** (`src/neo/car_host.py` + `car_tool_schema.py`)
+6. **New Cursor Skill** (`plugins/cursor-neo/`)
+   - Add a SKILL file under `skills/<name>/SKILL.md`
+   - Keep `plugins/cursor-neo/.cursor-plugin/plugin.json` and
+     `.cursor-plugin/marketplace.json` in sync with the package
+   - Mirror it as a Claude Code slash command and a Codex skill
+   - Document it in the README's Cursor Plugin section
+   - If the capability needs a visible-boundary path, also update
+     `plugins/cursor-neo/agents/neo.md` (and Claude's `agents/neo.md`) so the
+     dual role stays coherent
+
+7. **New CAR / A2A Tool** (`src/neo/car_host.py` + `car_tool_schema.py`)
    - Define the tool schema in `car_tool_schema.py` (mirrors the typed JSON contract other agents see over A2A)
    - Register the handler in `car_host.py` alongside `neo.process`
    - Add a smoke test in `tests/test_car_host_smoke.py` and schema test in `tests/test_car_tool_schema.py`
@@ -371,7 +385,13 @@ See existing patterns for reference:
 - Update `QUICKSTART.md` if the 5-minute setup flow changes
 - Update `INSTALL.md` for setup changes (extras, dependencies, integration surfaces)
 - Update `CLAUDE.md` and `AGENTS.md` together. `CLAUDE.md` is the long-form source of truth; `AGENTS.md` is a **condensed** mirror for AGENTS.md-spec tools (Codex, etc.). They are not byte-identical, but they must never contradict each other — `neo memory rules` flags exactly that kind of drift
-- When touching plugin sources, update the relevant plugin manifest and keep the **Claude Code** (`.claude-plugin/`) and **Codex** (`plugins/neo/`) surfaces in sync — the same six commands are exposed on both
+- When touching plugin sources, update the relevant plugin manifest and keep the
+  **Claude Code** (`.claude-plugin/`), **Codex** (`plugins/neo/`), and **Cursor**
+  (`plugins/cursor-neo/`) surfaces in sync — the same six capabilities are
+  exposed on all three. Cursor also ships `agents/neo.md` (Claude-parity
+  delegated path) alongside mid-loop skills (Codex-parity privacy defaults).
+  Version bumps edit `pyproject.toml` then `make sync-version` (never hand-edit
+  the derived manifests).
 - When touching CAR (`src/neo/car_*.py`), document any schema or behavior change in the README's "Run as an Agent (CAR / A2A)" section
 - Add docstrings to new functions
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -168,10 +168,24 @@ Installs from Parslee's marketplace inside OpenAI Codex CLI:
 
 ```bash
 codex plugin marketplace add Parslee-ai/neo
-# then install "Neo" from Codex's plugin directory
+codex plugin add neo@neo-local
 ```
 
 Requires the `neo` CLI installed and an API key set per the steps above.
+
+### Cursor Plugin
+
+From a checkout of this repo:
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+ln -s "$(pwd)/plugins/cursor-neo" ~/.cursor/plugins/local/neo
+# Developer: Reload Window in Cursor
+```
+
+Or import the repo as a Cursor team marketplace (`.cursor-plugin/marketplace.json`,
+name `neo-cursor`) and install the `neo` plugin. Requires the `neo` CLI and an
+API key per the steps above.
 
 ## Verification
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -78,9 +78,10 @@ for step in output.plan:
     print(f"- {step.description}")
 ```
 
-## 6. Use Neo from Your AI CLI (Optional)
+## 6. Use Neo from Your AI CLI / IDE (Optional)
 
-Neo ships as a plugin for both major AI coding CLIs. Pick whichever you use — the same six commands are available in each, and the fact store is shared.
+Neo ships as a plugin for Claude Code, Codex CLI, and Cursor. Pick whichever you
+use — the same six capabilities are available in each, and the fact store is shared.
 
 **Claude Code:**
 
@@ -95,12 +96,22 @@ Then: `/neo`, `/neo-review`, `/neo-optimize`, `/neo-architect`, `/neo-debug`, `/
 
 ```bash
 codex plugin marketplace add Parslee-ai/neo
-# then install "Neo" from Codex's plugin directory
+# then: codex plugin add neo@neo-local
 ```
 
 Then: `$neo`, `$neo-review`, `$neo-optimize`, `$neo-architect`, `$neo-debug`, `$neo-pattern`.
 
-**Important:** Both plugins require the Neo CLI (step 1) installed and an API key (step 2) set.
+**Cursor:**
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+ln -s "$(pwd)/plugins/cursor-neo" ~/.cursor/plugins/local/neo
+# Developer: Reload Window
+```
+
+Then: `/neo`, `/neo-review`, … in Agent chat, or “use the Neo agent…”.
+
+**Important:** All plugins require the Neo CLI (step 1) installed and an API key (step 2) set.
 
 ## 7. Host Neo as an Agent (Optional)
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Once installed:
 
 - **Slash commands**: `/neo`, `/neo-review`, `/neo-optimize`, `/neo-architect`, `/neo-debug`, `/neo-pattern`
 - **Specialized agent**: invoke with `Use the Neo agent to ...` for delegated semantic reasoning
-- **Shared memory**: same `~/.neo/facts/` store used by the CLI and the Codex plugin
+- **Shared memory**: same `~/.neo/facts/` store used by the CLI, Codex, and Cursor plugins
 
 Examples:
 
@@ -392,7 +392,7 @@ plugin**, which looks like success and provides no skills. The subcommand is
 Once installed:
 
 - **Skills**: `$neo`, `$neo-review`, `$neo-optimize`, `$neo-architect`, `$neo-debug`, `$neo-pattern`
-- **Shared memory**: same `~/.neo/facts/` store used by the CLI and the Claude Code plugin
+- **Shared memory**: same `~/.neo/facts/` store used by the CLI, Claude Code, and Cursor plugins
 - **Explicit context boundary**: Codex selects the relevant excerpts and every
   skill invokes `neo --no-scan`, so Neo cannot silently add files or project
   instruction documents from the current directory
@@ -426,15 +426,46 @@ both retrieved-fact and persistence effects before provider approval.
 
 Plugin sources live under [`plugins/neo/`](plugins/neo/) — see the manifest and skill definitions.
 
-Both plugins consume the **same host-neutral contract**: the skills invoke
+
+## Cursor Plugin
+
+Neo ships as a **Cursor plugin** with the same six skills plus a dedicated Neo
+agent, packaged under [`plugins/cursor-neo/`](plugins/cursor-neo/) and listed in
+the in-repo marketplace [`.cursor-plugin/marketplace.json`](.cursor-plugin/marketplace.json).
+
+**Local install (recommended for development):**
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+ln -s "$(pwd)/plugins/cursor-neo" ~/.cursor/plugins/local/neo
+# Then: Developer: Reload Window
+```
+
+**Team / repo marketplace:** import this repository as a Cursor team marketplace
+(it reads `.cursor-plugin/marketplace.json`, named `neo-cursor`), then install
+the `neo` plugin. Official [Cursor Marketplace](https://cursor.com/marketplace)
+listing is optional and separate.
+
+Once installed:
+
+- **Skills** (mid-loop, `/` in Agent chat): `/neo`, `/neo-review`, `/neo-optimize`,
+  `/neo-architect`, `/neo-debug`, `/neo-pattern` — same Codex privacy defaults
+  (`--no-scan`, advise `--no-memory`)
+- **Neo agent** (visible boundary): delegate with “use the Neo agent…” — Claude-style
+  `neo --json --mode advise` without mandatory `--no-scan` / `--no-memory`
+- **Shared memory**: same `~/.neo/facts/` store as the CLI, Claude Code, and Codex plugins
+
+The plugin wraps the local `neo` CLI (`pip install neo-reasoner[…]` + provider
+key). It is intentionally skills + agent, not an MCP server.
+
+All three host adapters consume the **same host-neutral contract**: they invoke
 `neo --json` and read the `orchestrator` envelope described under
-[Orchestrator output](#orchestrator-output). Neither hosts its own output
+[Orchestrator output](#orchestrator-output). None hosts its own output
 format, and `tests/test_host_adapter_parity.py` fails if one surface teaches a
-contract the other does not. The difference is role, not protocol — under
-Claude Code, Neo is usually a delegated subagent with a visible boundary;
-under Codex, Neo is a step inside the same coding loop, which is why the Codex
-skills insist on explicit attribution and on continuing the task rather than
-treating Neo's answer as the deliverable.
+contract the others do not. Role differs: Claude Code and the Cursor **agent**
+are delegated specialists with a visible boundary; Codex and Cursor **skills**
+are mid-loop steps that insist on explicit attribution and on continuing the
+task rather than treating Neo's answer as the deliverable.
 
 
 ## Works Alongside Your AI Tools
@@ -468,7 +499,8 @@ use:**
 
 - **Claude Code** users get the deepest integration via the [Claude Code Plugin](#claude-code-plugin), but neo runs standalone too.
 - **Codex CLI** users get parity via the [Codex Plugin](#codex-plugin) — same six skills, packaged for Codex. Neo also automatically picks up `AGENTS.md` (the cross-tool standard Codex co-led) plus anything under `.codex/`.
-- **Cursor / Windsurf / Aider / Continue / Augment** users — the rules dirs you've curated land in every neo session's context.
+- **Cursor** users get parity via the [Cursor Plugin](#cursor-plugin) — same six skills plus a Neo agent; project rules under `.cursor/rules/` still land in every neo session's context.
+- **Windsurf / Aider / Continue / Augment** users — the rules dirs you've curated land in every neo session's context.
 - **GitHub Copilot** users — `.github/copilot-instructions.md` is read on every invocation.
 - **Spec Kit** projects — your specs are folded into neo's reasoning context, no manual paste.
 

--- a/docs/solutions/orchestrator-communication.md
+++ b/docs/solutions/orchestrator-communication.md
@@ -241,7 +241,7 @@ not bury the reasons to doubt it. Two consequences:
 `phase_summary` copies each record, not just the list. These dicts are live
 engine state and the object is handed to foreign consumers.
 
-## One contract, two adapters
+## One contract, three adapters
 
 The contract is host-neutral by construction: `events.py` and
 `OrchestratorMessage` know nothing about who is consuming them, and the
@@ -251,50 +251,54 @@ per-host wording lives entirely in the adapters.
 |---|---|---|
 | Claude Code | `.claude-plugin/` | agent + 6 slash commands |
 | Codex CLI | `plugins/neo/` | plugin manifest + 6 skills |
+| Cursor | `plugins/cursor-neo/` | plugin manifest + 6 skills + Neo agent |
 | CAR / A2A | `neo.a2ui`, `neo serve` | A2A status + artifact events |
 
 (`.agents/skills/` holds *release-maintenance* skills, not Neo capabilities.
-Looking there for the Codex plugin and concluding it is missing is an easy
-wrong turn — the manifest is at `plugins/neo/.codex-plugin/plugin.json`,
-registered by `.agents/plugins/marketplace.json`.)
+Looking there for the Codex or Cursor plugin and concluding it is missing is an
+easy wrong turn — Codex is at `plugins/neo/.codex-plugin/plugin.json` /
+`.agents/plugins/marketplace.json`; Cursor is at
+`plugins/cursor-neo/.cursor-plugin/plugin.json` /
+`.cursor-plugin/marketplace.json`.)
 
 **Adapters drift, and drift is invisible.** The Codex skills instructed the
 model to parse "four structured sections: `CONFIDENCE`, `PLAN`, `SIMULATIONS`,
 `CODE SUGGESTIONS`" out of terminal-formatted prose — the exact anti-pattern
 the Claude side had just stopped doing. One adapter got the contract change;
 the other did not, and nothing failed. `test_host_adapter_parity.py` now pins
-the invariant: same six capabilities on both surfaces, both invoking `--json`,
-both teaching `orchestrator.summary`/`cautions`, both documenting the error
-shape and attribution, and every documented phase/event name checked against
-`events.py` rather than against prose.
+the invariant: same six capabilities on all three host surfaces, all invoking
+`--json`, all teaching `orchestrator.summary`/`cautions`, all documenting the
+error shape and attribution, and every documented phase/event name checked
+against `events.py` rather than against prose.
 
 The same test pins manifest versions against `pyproject.toml`. `prepare-release`
-documents bumping both plugin manifests, but a documented step with no
+documents bumping the plugin manifests, but a documented step with no
 enforcement is a step that gets skipped: the package, the Claude manifest, and
 the Codex manifest had reached 0.41.0 / 0.37.0 / 0.19.0.
 
-**Role differs even though protocol does not.** Under Claude Code, Neo is
-usually a delegated subagent — the user can see the boundary. Under Codex, Neo
-is a step inside the same coding loop: Codex calls Neo, reads the result, then
-edits files and runs tests in the same breath. Nothing marks where Neo's
-reasoning ends and Codex's begins, so the Codex skills carry stronger
-attribution wording ("Neo found …") and an explicit instruction that Neo's
-result is an input, not the deliverable.
+**Role differs even though protocol does not.** Under Claude Code (and the
+Cursor **agent**), Neo is usually a delegated subagent — the user can see the
+boundary. Under Codex (and Cursor **skills**), Neo is a step inside the same
+coding loop: the host calls Neo, reads the result, then edits files and runs
+tests in the same breath. Nothing marks where Neo's reasoning ends and the
+host's begins, so mid-loop skills carry stronger attribution wording
+("Neo found …") and an explicit instruction that Neo's result is an input, not
+the deliverable.
 
-**Context authority differs too.** Codex has already read and selected the
-relevant workspace excerpts before it invokes Neo. Every Codex skill therefore
-passes `--no-scan`: without it the CLI would perform a second, implicit scan of
-the working directory and separately discover project instruction documents.
-Advise skills also pass `--no-memory` by default so unrelated persistent facts
-cannot enter the provider prompt. Shared memory remains available only when the
-user explicitly asks for it and authorizes stored facts as a provider data
-category; deliberate pattern learning discloses both retrieval and persistence
-effects. The Codex adapter also
-requires the approval description to name the configured Neo provider and the
-files or data categories being sent. Sensitive production, private, or
-customer context requires provider-and-scope-specific authorization. These are
-Codex host-boundary rules; the Claude plugin's agent and commands remain a
-separate adapter and continue to use their established context contract.
+**Context authority differs too.** Codex and Cursor mid-loop skills have
+already read and selected the relevant workspace excerpts before invoking Neo.
+Every such skill therefore passes `--no-scan`: without it the CLI would perform
+a second, implicit scan of the working directory and separately discover
+project instruction documents. Advise skills also pass `--no-memory` by default
+so unrelated persistent facts cannot enter the provider prompt. Shared memory
+remains available only when the user explicitly asks for it and authorizes
+stored facts as a provider data category; deliberate pattern learning discloses
+both retrieval and persistence effects. Mid-loop adapters also require naming
+the configured Neo provider and the files or data categories being sent before
+an external-provider call. Sensitive production, private, or customer context
+requires provider-and-scope-specific authorization. These are mid-loop
+host-boundary rules; the Claude plugin (and Cursor agent) remain a separate
+adapter path and continue to use their established context contract.
 
 ## Sink failures are findable
 

--- a/plugins/cursor-neo/.cursor-plugin/plugin.json
+++ b/plugins/cursor-neo/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "neo",
+  "version": "0.46.0",
+  "description": "Multi-agent semantic reasoning system with persistent memory for code suggestions, architectural guidance, and optimization recommendations",
+  "author": {
+    "name": "Parslee AI",
+    "email": "hello@parslee.ai"
+  },
+  "homepage": "https://github.com/Parslee-ai/neo",
+  "repository": "https://github.com/Parslee-ai/neo",
+  "license": "Apache-2.0",
+  "keywords": [
+    "reasoning",
+    "semantic-search",
+    "multi-agent",
+    "code-review",
+    "optimization",
+    "architecture",
+    "memory",
+    "patterns"
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/"
+}

--- a/plugins/cursor-neo/agents/neo.md
+++ b/plugins/cursor-neo/agents/neo.md
@@ -1,0 +1,220 @@
+---
+name: neo
+description: >-
+  Semantic reasoning helper using multi-agent MapCoder approach with persistent
+  memory. Use when the user asks to delegate to the Neo agent for architecture,
+  optimization, code review, debugging, or pattern extraction.
+---
+
+# Neo - Semantic Reasoning Helper
+
+Semantic reasoning helper using multi-agent MapCoder approach with persistent memory.
+
+## Description
+
+Use this agent when you need to analyze code through semantic reasoning with multi-agent collaboration and persistent memory. Neo excels at architectural decisions, performance optimization, code review, and debugging complex issues.
+
+This is the **delegated specialist** path (visible boundary). For a mid-loop
+step that keeps editing afterward with stricter privacy defaults
+(`--no-scan --no-memory`), prefer the `/neo` skills instead.
+
+## Core Capabilities
+
+- **Multi-agent reasoning** using Solver, Critic, and Verifier agents
+- **Semantic memory** that learns from past solutions and failures
+- **Confidence scoring** for all recommendations
+- **Pattern recognition** for architectural patterns
+- **Reinforcement learning** to improve over time
+
+## When to Use Neo
+
+Use the Neo agent for:
+- Architectural guidance and design decisions
+- Performance optimization analysis
+- Code review with semantic pattern matching
+- Debugging complex or intermittent issues
+- Pattern extraction from codebase
+
+## Invocation
+
+Always invoke Neo with `--json`. It emits two separate streams:
+
+- **stdout** — exactly one JSON document, the final result.
+- **stderr** — JSONL progress events, one object per line, written as they happen.
+
+```bash
+neo --json --mode advise "<your query>"
+```
+
+Never parse Neo's human-readable text output. It is formatted for a terminal
+reader and drops the structured fields this contract depends on.
+
+Do not add `2>/dev/null`. The event stream is on stderr, and discarding it
+leaves you narrating from the final blob alone.
+
+`--json` implies `--quiet`, so Neo's human progress lines are suppressed and
+stderr is essentially pure JSONL. It is not *guaranteed* pure: Python logging
+warnings and CAR version notices can still appear there. Parse only lines
+beginning with `{` and ignore the rest. stdout is never mixed — always exactly
+one JSON document.
+
+## Communication protocol
+
+Neo reports facts about its process. You decide which of those facts become
+conversation. That division is the whole contract — follow it in both
+directions.
+
+### Before invoking
+
+State what you are asking Neo to evaluate, in one sentence. The user should
+know what question is in flight before a 5–30 second pause begins.
+
+### While it runs
+
+Do not invent progress. A Shell call does not stream, so you will not have
+events until the command returns — say nothing during the wait rather than
+narrating imagined phases.
+
+### After it completes
+
+Read the event stream from stderr, then the final JSON from stdout. The final
+JSON carries an `orchestrator` object built for exactly this purpose:
+
+| Field | Use |
+|---|---|
+| `summary` | Lead with it. Neo's own account of what he did and concluded. |
+| `personality` | Optional extra beat. See below. |
+| `phase_summary` | Per-phase records. Use to explain a slow or unusual run. |
+| `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
+| `recommended_narration` | Advisory progress lines. Reword freely. |
+
+Then:
+
+1. Present `orchestrator.summary` before the detailed answer.
+2. Surface every entry in `orchestrator.cautions`. A confident-sounding
+   recommendation must not bury the reasons to doubt it.
+3. Explain significant findings from the event stream — `risk_found` events,
+   and `hypothesis_rejected` when a panel's output was discarded. What Neo
+   ruled out is often more useful than what it settled on.
+4. Do not dump raw internal reasoning, full simulation traces, or the event
+   stream itself. Summarize.
+5. Distinguish Neo's conclusions from your own follow-up analysis. Attribute
+   plainly: "Neo found…" versus "Looking at this myself…". Never present your
+   own reasoning as Neo's, or the reverse.
+6. Report Neo's confidence as the number it is. Do not round it up in prose.
+7. **`confidence` may be `null`, and that is an answer, not a gap.** It means
+   the run produced nothing a confidence number could describe — read
+   `confidence_basis` and say which: `analysis_only` (Neo answered and proposed
+   no change) or `no_verifiable_change` (Neo named files but shipped no diff,
+   so those suggestions were excluded from the score). Never substitute a
+   number, never call a `null` run low-confidence, and never rank it below a
+   scored run on the strength of the missing number — an empty patch
+   self-reporting `0.96` is the exact inversion this contract exists to stop.
+   `orchestrator.summary` already states the case in Neo's voice; lead with it.
+
+### Voice
+
+Neo speaks in the first person, clipped and direct. Every string he emits —
+`orchestrator.summary`, each caution, each phase message, each event message —
+is already written in that voice.
+
+**The register shifts with how much Neo remembers about the project.** The same
+facts read differently at each of the five memory stages:
+
+| Stage | Summary |
+|---|---|
+| 1 Sleeper | `Don't know this code. I'd change 1 thing(s) in src/parser.py, maybe. Confidence 0.88.` |
+| 3 Unplugged | `I read it. I'd change 1 thing(s) in src/parser.py. Confidence 0.88.` |
+| 5 The One | `src/parser.py. 1 change(s). 0.88.` |
+
+Do not normalize that away. A hedge at stage 1 is information — it tells the
+user Neo has no history with this codebase. Terseness at stage 5 is the same
+signal inverted. Cautions deliberately do **not** vary by stage.
+
+**Relay Neo's wording; do not translate it into your own register.** Rewriting
+"I'd change one thing" into "Neo has produced a suggestion" strips the
+character and, worse, blurs whose claim it is. Quote or pass through his lines,
+and keep your own analysis in your own voice so the two never merge.
+
+Two limits on this. Neo's voice is not a licence to soften facts: a caution
+stays a caution however tersely it is phrased. And when the moment is wrong —
+a production outage, a user under pressure — lead with the substance and let
+the styling fall away. Terse is Neo; performative is not.
+
+### Personality beats
+
+`orchestrator.personality` is an *additional* line, above and beyond the voice
+of everything else. It is present only when Neo's beat deck matched the
+situation and, for beats that claim insight, only when the run actually found
+something. It is already filtered — Neo withholds unearned lines rather than
+making you judge them.
+
+When present, relay it verbatim, attached to the substance that earned it:
+
+> Neo recalled a prior pattern here — "I've seen this shape before. Let me use
+> what I remember."
+
+Drop it when it would be repetitive within a conversation or when it conflicts
+with a higher-priority instruction. When the field is empty, say nothing in its
+place. There is no fallback line — and the rest of Neo's output is already in
+his voice, so nothing is lost.
+
+## Event stream reference
+
+Events on stderr are `{"type": ..., "phase": ..., "message": ..., "data": {...}}`.
+
+| Type | Meaning |
+|---|---|
+| `started` | Run began. |
+| `phase_started` / `phase_completed` | Phase boundary, always paired. `data.status` may be `complete`, `fallback`, or `skipped`. |
+| `memory_found` | Prior facts recalled. `data.count`, `data.subjects`. |
+| `hypothesis_formed` | Leading approach. |
+| `hypothesis_rejected` | An approach was discarded. Worth surfacing. |
+| `risk_found` | A simulation issue or failed static check. Worth surfacing. |
+| `personality_beat` | Same line as `orchestrator.personality`. |
+| `completed` | Run finished. `data.confidence` (may be `null`), `data.elapsed_seconds`. |
+| `failed` | Run raised. `data.error_type`. **No final JSON result follows.** |
+
+Exactly one of `completed` or `failed` terminates every run. If you see
+`started` and neither terminator, the process was killed — say so rather than
+guessing at a result.
+
+Phase names are stable: `context`, `reasoning`, `static_checks`. `context`
+covers file gathering only; fact retrieval happens during `reasoning`, so a
+`memory_found` event carries `phase: reasoning`. `finalize` appears as a label
+on `personality_beat` but is not a phase — you will never see it open or close.
+
+A message may be truncated to 500 characters, marked with `"truncated": true`.
+
+## When Neo fails
+
+On a failed run, stdout is **not** the documented result shape. It is an error
+object and there is no `orchestrator` key:
+
+```json
+{"error": "RequestTimeout", "message": "...", "suggestions": ["..."]}
+```
+
+Check for `error` before reading `orchestrator`. Relay `message` and the
+`suggestions` list, say plainly that Neo did not complete, and do not
+substitute your own analysis while implying it came from Neo.
+
+## Example Invocations
+
+```
+Use the Neo agent to review this authentication code for security issues.
+
+Use the Neo agent to optimize the data processing pipeline.
+
+Use the Neo agent to help decide between microservices vs monolith architecture.
+
+Use the Neo agent to debug this race condition in the task processor.
+```
+
+## Important Notes
+
+- Neo queries take 5-30 seconds (uses LLM API calls)
+- Always verify low-confidence suggestions (<0.7). A `null` confidence is not a
+  low one — check `confidence_basis` before saying anything about certainty.
+- Provide rich context for better results
+- Ordinary analysis is explicit `advise` and does not mutate durable memory. Use `learn` only when the user intends to record evidence; never request `agent` without explicit workspace authority and a host executor.

--- a/plugins/cursor-neo/skills/neo-architect/SKILL.md
+++ b/plugins/cursor-neo/skills/neo-architect/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: neo-architect
+description: >-
+  Get Neo's architectural guidance for design decisions. Trade-off analysis for
+  choices like microservices vs monolith, sync vs async, and event-driven vs
+  request-response, with optional explicitly authorized memory recall.
+disable-model-invocation: true
+---
+
+# Neo Architectural Guidance
+
+When the user invokes this skill (`/neo-architect <question>`), do the following:
+
+1. **Restate the architectural question precisely.** "Should I use X or Y for Z?" with concrete constraints (scale expected, team size, existing stack, latency budget) yields better answers than open-ended questions.
+
+2. **Gather codebase context.** Read `CLAUDE.md`, `AGENTS.md`, `README.md`, top-level config files, and any architecture docs under `docs/`. Neo's own context-assembly will pick these up too, but having you summarize the existing constraints up front helps.
+
+3. **Apply the provider boundary.** Redact secrets, credentials, tokens,
+   cookies, and session material. Before an external-provider call, tell the
+   user which Neo provider will receive which files or data categories.
+   Production, private, or customer architecture material requires explicit
+   authorization for that provider and scope.
+
+4. **Invoke Neo with an architecture-framed prompt.** Allow up to 5 minutes.
+   Use Cursor's Shell tool; before a call that needs network access, name the
+   provider and summarized data categories.
+
+   ```bash
+   neo --json --no-scan --no-memory --mode advise <<'QUERY'
+   Architectural decision: <restate the question with constraints>.
+
+   Current state of the codebase:
+   <summarize tech stack, scale, team>
+
+   Provide a recommendation with trade-offs explicit, plus alternatives ranked by fit.
+   QUERY
+   ```
+
+5. **Present Neo's plan and simulations together.** Architecture answers benefit from the SIMULATIONS section especially — those describe how the recommendation would actually play out.
+
+6. **Surface any architectural facts Neo retrieved from memory.** If past projects had similar decisions, Neo references them — those are higher-trust than fresh reasoning.
+
+`--no-scan` is mandatory: Cursor already summarized the relevant architecture
+context, so Neo must not silently add working-directory files to the provider
+request.
+`--no-memory` is the default so unrelated stored facts cannot enter the provider
+prompt. Omit it only when the user explicitly authorizes relevant Neo memory;
+include stored facts as a disclosed data category.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `/neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For architecture specifically: name the **alternatives considered and why each
+lost** — a recommendation without its rejected options is an opinion, not
+guidance, and `hypothesis_rejected` events plus the plan's rationale fields
+carry it. State the tradeoff Neo accepted in the user's terms: what gets harder
+if they follow this advice. Be explicit that this is advice — context Neo
+cannot see (team, timeline, politics) routinely dominates.
+
+## Notes
+
+- This skill uses `advise`; architecture guidance is never promoted automatically. Deliberate policy learning requires explicit `learn` mode and stronger evidence.
+- Neo will not recommend "it depends" — it picks a default and explains the trade-off. If the user wants ambiguity preserved, ask them to phrase the question as "what are the trade-offs of X vs Y?" rather than "should I do X or Y?".

--- a/plugins/cursor-neo/skills/neo-debug/SKILL.md
+++ b/plugins/cursor-neo/skills/neo-debug/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: neo-debug
+description: >-
+  Ask Neo to help debug intermittent, complex, or hard-to-reproduce issues.
+  Particularly useful for race conditions, memory issues, distributed-systems
+  bugs, and cases where the symptom is not the root cause.
+disable-model-invocation: true
+---
+
+# Neo Debug Assistant
+
+When the user invokes this skill (`/neo-debug <bug description>`), do the following:
+
+1. **Capture the bug context tightly.** Symptom, when it started, frequency, environment, and any reproduction steps. Vague bug reports get vague answers; Neo's memory is keyed on specifics.
+
+2. **Gather observable evidence.** Recent error logs, stack traces, test failures. Read the file(s) implicated by the stack trace. If the user mentioned a specific function, locate it.
+
+3. **Apply the provider boundary.** Redact secrets, credentials, tokens,
+   cookies, session material, and unrelated log records. Before an
+   external-provider call, tell the user which Neo provider will receive which
+   files or data categories. Production, private, or customer diagnostics
+   require explicit authorization for that provider and scope.
+
+4. **Invoke Neo with a debug-framed prompt.** Allow up to 5 minutes. Use
+   Cursor's Shell tool; before a call that needs network access, name the
+   provider and summarized data categories.
+
+   ```bash
+   neo --json --no-scan --no-memory --mode advise <<'QUERY'
+   Debug this issue: <user's description>
+
+   Symptoms: <what happens>
+   Environment: <relevant context — concurrency model, OS, runtime, dependencies>
+   Stack trace / logs:
+   <paste evidence>
+
+   Relevant code:
+   <paste the function or module under suspicion>
+
+   Provide ranked hypotheses about root cause with reasoning. For each, suggest a verification step.
+   QUERY
+   ```
+
+5. **Present Neo's hypotheses ranked by confidence.** Lead with the verification step the user can take next — debugging is an iterative loop, not a one-shot answer.
+
+6. **If Neo returns multiple competing hypotheses, surface them all.** Don't collapse to "the most likely one" — concurrent-systems bugs often have multiple contributing causes.
+
+`--no-scan` is mandatory: Cursor already selected the evidence, so Neo must not
+silently add working-directory files to the provider request.
+`--no-memory` is the default so unrelated stored facts cannot enter the provider
+prompt. Omit it only when the user explicitly authorizes relevant Neo memory;
+include stored facts as a disclosed data category.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `/neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For debugging specifically: report what was **ruled out**, not just what was
+concluded. Every `hypothesis_rejected` event and every simulation issue in
+`risk_found` narrows the search — that is the substance of a debugging session.
+Say what evidence supports the leading hypothesis and what would falsify it. If
+`memory_found` fired, say so: a prior occurrence of this failure is the single
+most useful thing Neo can contribute. Never present a hypothesis as a
+diagnosis — Neo does not run the code, so verifying it is your job.
+
+## Notes
+
+- Race conditions, memory issues, and intermittent failures are where Neo's failure-pattern memory pays off most — past similar bugs add weight to matching hypotheses.
+- If Neo's top hypothesis has confidence < 0.6, treat it as "worth investigating" rather than "probably right." Debugging is harder than greenfield reasoning; lower confidence is normal.

--- a/plugins/cursor-neo/skills/neo-optimize/SKILL.md
+++ b/plugins/cursor-neo/skills/neo-optimize/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: neo-optimize
+description: >-
+  Ask Neo for optimization suggestions on a function, file, or hot path.
+  Targets algorithmic improvements, redundant work, allocation/hot-loop issues
+  — not micro-style.
+disable-model-invocation: true
+---
+
+# Neo Optimization Analysis
+
+When the user invokes this skill (`/neo-optimize <target>`), do the following:
+
+1. **Locate the target.** It may be a function name (`process_large_dataset`), a file, or a description ("the user-search query path"). Use Grep/Read to find the actual implementation.
+
+2. **Capture the current implementation plus its callers** if you can do so cheaply. Neo can suggest better algorithms, but only if it sees how the code is used.
+
+3. **Apply the provider boundary.** Redact secrets, credentials, tokens,
+   cookies, and session material. Before an external-provider call, tell the
+   user which Neo provider will receive which files or data categories.
+   Production, private, or customer code requires explicit authorization for
+   that provider and scope.
+
+4. **Invoke Neo with an optimization-framed prompt.** Allow up to 5 minutes.
+   Use Cursor's Shell tool; before a call that needs network access, name the
+   provider and summarized data categories.
+
+   ```bash
+   neo --json --no-scan --no-memory --mode advise <<'QUERY'
+   Suggest optimizations for the following code. Focus on: algorithmic improvements (lower asymptotic complexity), redundant computation, allocation in hot loops, IO batching opportunities. Skip micro-style changes.
+
+   <paste current implementation + relevant callers>
+   QUERY
+   ```
+
+5. **Present Neo's suggestions ranked by expected impact.** Each CodeSuggestion includes `estimated_risk` and `blast_radius` — surface those alongside the recommendation.
+
+6. **For high-risk changes, recommend benchmarking before applying.** Neo's confidence reflects pattern-match strength, not measured speedup.
+
+`--no-scan` is mandatory: Cursor already selected the implementation and
+callers, so Neo must not silently add working-directory files to the provider
+request.
+`--no-memory` is the default so unrelated stored facts cannot enter the provider
+prompt. Omit it only when the user explicitly authorizes relevant Neo memory;
+include stored facts as a disclosed data category.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `/neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For optimization specifically: show the **evidence** for the bottleneck — the
+complexity argument or the code path Neo pointed at. An optimization claim with
+no evidence is a guess wearing a confidence score. State the expected impact and
+its basis; if Neo estimated rather than measured, say "estimated", because Neo
+never executes or benchmarks anything. Surface correctness risks especially — a
+faster wrong answer is a regression. Recommend measuring before and after.
+
+## Notes
+
+- Algorithmic suggestions tend to come back with high confidence when Neo has seen similar patterns before — that's the memory-driven reasoning effort kicking in.
+- If Neo returns "I cannot find evidence" or low-confidence-only output, that's a signal the optimization isn't obvious and warrants human investigation rather than blind application.

--- a/plugins/cursor-neo/skills/neo-pattern/SKILL.md
+++ b/plugins/cursor-neo/skills/neo-pattern/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: neo-pattern
+description: >-
+  Ask Neo to extract a reusable pattern from a piece of code, or to find
+  existing patterns in the codebase that match a description. Useful for
+  codifying conventions and finding duplicated logic.
+disable-model-invocation: true
+---
+
+# Neo Pattern Extraction
+
+When the user invokes this skill (`/neo-pattern <code reference or description>`), do the following:
+
+1. **Determine direction.** Is the user asking neo to:
+   (a) **Extract** a pattern *from* a piece of code they're pointing at? — gather the code, then ask Neo to articulate the reusable pattern.
+   (b) **Find** instances of a pattern *in* the codebase based on a description? — gather the description, then ask Neo to locate matching code.
+
+2. **For extraction:** read the source code the user referenced. Include enough surrounding context that the pattern is intelligible.
+
+3. **For pattern-finding:** translate the user's description into search terms. Use Grep/Glob to gather candidate files; pass them to Neo for semantic matching against the description.
+
+4. **Apply the provider and learning boundary.** Redact secrets, credentials,
+   tokens, cookies, and session material. Before an external-provider call,
+   tell the user which Neo provider will receive which files or data categories.
+   Production, private, or customer code requires explicit authorization for
+   that provider and scope. Because this learning workflow uses shared Neo
+   memory, also disclose that relevant stored facts may be selected for the
+   provider prompt and that `learn` records an episode candidate.
+
+5. **Invoke Neo with a pattern-framed prompt.** Allow up to 5 minutes. Use
+   Cursor's Shell tool; before a call that needs network access, name the
+   provider, summarized data, and candidate-learning effect.
+
+   ```bash
+   neo --json --no-scan --mode learn <<'QUERY'
+   <Extract a reusable pattern from> | <Find code matching this pattern>:
+
+   <code or description here>
+
+   Articulate: name, signature/shape, when to apply, when NOT to apply, common pitfalls.
+   QUERY
+   ```
+
+6. **Present the pattern with concrete examples.** A named pattern with two example sites is more useful than an abstract description of one.
+
+`--no-scan` is mandatory: Cursor already selected the pattern evidence, so Neo
+must not silently add working-directory files to the provider request.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `/neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For pattern extraction specifically: cite the instances the pattern was drawn
+from — a "pattern" with one example is an anecdote, so say how many occurrences
+Neo actually saw. Report `memory_found` when the pattern matched something Neo
+already knew; recurrence across sessions is the strongest signal available here.
+Be accurate about learning: this run records an episode **candidate**, not a
+durable fact. Promotion needs two independent git-verified acceptances. Do not
+tell the user Neo "learned" this.
+
+## Notes
+
+- `learn` records the extraction as an episode-local candidate. It is not trusted memory until independently verified and supported again.
+- Patterns extracted from a single example are "PROVISIONAL" until Neo sees them confirmed in another part of the codebase. The user should treat single-example patterns as drafts.

--- a/plugins/cursor-neo/skills/neo-review/SKILL.md
+++ b/plugins/cursor-neo/skills/neo-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: neo-review
+description: >-
+  Get Neo's code review with semantic pattern matching. Focuses on security
+  vulnerabilities, edge cases, error handling, and performance issues across
+  the target file or module.
+disable-model-invocation: true
+---
+
+# Neo Code Review
+
+When the user invokes this skill (`/neo-review <file or module>`), do the following:
+
+1. **Identify the target.** It will usually be a file path (e.g. `src/api/handlers.py`), a module name, or a free-form description ("the payment processing code"). Use Read/Grep/Glob to resolve it to concrete file(s).
+
+2. **Read the relevant code.** Up to 5 files at a time keeps Neo's context budget healthy. Prefer the files where the actual logic lives over generated/test files.
+
+3. **Apply the provider boundary.** Redact secrets, credentials, tokens,
+   cookies, and session material. Before an external-provider call, tell the
+   user which Neo provider will receive which files or data categories.
+   Production, private, or customer code requires explicit authorization for
+   that provider and scope; invoking the skill is not blanket consent.
+
+4. **Invoke Neo with a review-framed prompt.** Allow up to 5 minutes. Use
+   Cursor's Shell tool; before a call that needs network access, name the
+   provider and summarized data categories.
+
+   ```bash
+   neo --json --no-scan --no-memory --mode advise <<'QUERY'
+   Review the following code for: security vulnerabilities, edge cases, error handling, performance issues. Provide concrete suggestions with confidence scores.
+
+   <paste relevant code or summarize what you read>
+   QUERY
+   ```
+
+5. **Filter Neo's output to review-relevant findings.** Group by severity. Flag any finding with confidence ≥ 0.8 as actionable; treat lower-confidence findings as worth-checking-but-verify.
+
+6. **Cross-reference with Neo's KNOWN ISSUES IN NEARBY CODE section if present.** Neo's context-assembly already surfaces TODOs, stubs, swallowed exceptions, hardcoded credentials — those overlap with review concerns and add weight to related findings.
+
+`--no-scan` is mandatory: Cursor already selected the review files, so Neo must
+not silently add working-directory files to the provider request.
+`--no-memory` is the default so unrelated stored facts cannot enter the provider
+prompt. Omit it only when the user explicitly authorizes relevant Neo memory;
+include stored facts as a disclosed data category.
+
+## Reading Neo's output
+
+Invoke with `--json`. stdout is exactly one JSON document; stderr is JSONL
+progress events (parse lines starting with `{`, ignore the rest). Never parse
+the human-readable text output. On failure stdout is `{"error": ...}` with no
+`orchestrator` key — check for `error` first.
+
+Lead with `orchestrator.summary`, surface every entry in
+`orchestrator.cautions`, and relay `orchestrator.personality` verbatim when
+present. Neo writes in the first person and his register shifts with how much
+he remembers about this project — keep his wording rather than translating it
+into yours. See the `/neo` skill for the full contract.
+
+**Attribute explicitly and keep going.** You are calling Neo inside your own
+coding loop, so nothing marks where his reasoning ends and yours begins — say
+"Neo found …" and keep your own analysis in your own voice. His result is an
+input, not the deliverable: continue the task and report the combined outcome.
+
+For a review specifically: group findings by severity, not by file — a security
+issue and a naming nit are not peers. Surface `risk_found` events alongside the
+cautions; a review that reads as clean because the caveats were trimmed is
+worse than no review. Say which assumptions Neo challenged, and give the
+confidence number rather than rounding it up in prose.
+
+## Notes
+
+- Neo's confidence scores reflect both LLM self-assessment and pattern-match strength against past reviews in semantic memory.
+- For security-critical code, escalate findings the user pushes back on — Neo's memory is updated with outcomes, so consistent rejections will demote weak patterns over time.

--- a/plugins/cursor-neo/skills/neo/SKILL.md
+++ b/plugins/cursor-neo/skills/neo/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: neo
+description: >-
+  Ask Neo for semantic reasoning and code suggestions over explicitly selected
+  context. Use for general questions, code suggestions, or architectural
+  guidance; persistent memory is opt-in for external-provider calls.
+disable-model-invocation: true
+---
+
+# Neo — Semantic Reasoning Helper
+
+When the user invokes this skill (`/neo <question or task>`), do the following:
+
+1. **Verify Neo is installed.** Run `neo --version` once. If the command is missing, tell the user: "Neo CLI not installed. Run `pip install neo-reasoner[openai]` and set `OPENAI_API_KEY`, then retry." Stop.
+
+2. **Say what you are delegating.** One sentence, before the call: the user should know what question is in flight before a 5–30 second pause.
+
+3. **Gather context deliberately.** Use your file-reading tools to collect the
+   most relevant files for the user's question (typically 1–5 files). Include
+   only the task text and excerpts Neo actually needs. Do not forward unrelated
+   conversation history, secrets, credentials, tokens, cookies, or session
+   material.
+
+4. **Respect the provider boundary.** `neo --version` reports the configured
+   provider. Before an external-provider call, tell the user which Neo provider
+   will receive which files or data categories. Production, private, or customer
+   material requires explicit authorization for that provider and that scope;
+   invoking `/neo` is not blanket consent to send unrelated sensitive context.
+
+5. **Invoke Neo with `--json --no-scan --no-memory`.** Allow up to 5 minutes — Neo runs
+   multi-agent reasoning across LLM calls. Use Cursor's Shell tool for the
+   command. Before a call that needs network access, name the Neo provider and
+   summarize the data being sent.
+
+   ```bash
+   neo --json --no-scan --no-memory --mode advise <<'QUERY'
+   <restate the user's question here, plus any short context excerpts>
+   QUERY
+   ```
+
+   `--json` controls output only; a plain-text heredoc is still read as text.
+   `--no-scan` is mandatory because Cursor already curated the context. It
+   prevents Neo from adding directory files or project instruction files.
+   `--no-memory` is the privacy-safe default because retrieved Neo facts are
+   also provider context. Omit it only when the user explicitly asks to use
+   shared Neo memory and authorizes relevant stored facts to be sent to the
+   named provider; disclose that additional category before the call.
+
+6. **Read both streams.** Never parse Neo's human-readable text output — it is formatted for a terminal reader and omits the fields below.
+
+## Output contract
+
+**stdout** is exactly one JSON document. **stderr** is JSONL progress events,
+one object per line. `--json` implies `--quiet`, so stderr is essentially pure
+JSONL, but logging warnings can still appear — parse lines beginning with `{`
+and ignore the rest. Do not discard stderr with `2>/dev/null`.
+
+The stdout document carries an `orchestrator` object built for exactly this
+purpose:
+
+| Field | Use |
+|---|---|
+| `summary` | Lead with it. Neo's own account of what he did and concluded. |
+| `personality` | Optional in-voice beat. Relay verbatim when present. |
+| `phase_summary` | Per-phase records. Use to explain a slow or unusual run. |
+| `cautions` | **Never drop these.** Low confidence, failed checks, open questions. |
+| `recommended_narration` | Advisory progress lines. Reword freely. |
+
+`confidence` may be `null`, which is an answer rather than a gap: the run
+produced nothing a confidence number could describe. Read `confidence_basis`
+and report which case it is — `analysis_only` (Neo answered and proposed no
+change) or `no_verifiable_change` (Neo named files but shipped no diff, so
+those suggestions were excluded from the score). Do not substitute a number,
+do not call a `null` run low-confidence, and do not rank it beneath a scored
+run: an empty patch self-reporting `0.96` outranking a correct analysis is the
+inversion this contract exists to stop. Neo's result is an input to your work,
+not the deliverable — so state which case it is rather than papering over it.
+
+Useful event types on stderr: `memory_found` (prior facts recalled),
+`hypothesis_formed`, `hypothesis_rejected` (an approach was discarded — usually
+worth surfacing), `risk_found`, and exactly one of `completed` or `failed`
+terminating every run. Phase names are stable: `context`, `reasoning`,
+`static_checks`.
+
+**On failure**, stdout is an error object with no `orchestrator` key:
+`{"error": "RequestTimeout", "message": "...", "suggestions": [...]}`. Check for
+`error` first. Say plainly that Neo did not complete, and do not substitute your
+own analysis while implying it came from Neo.
+
+## Communicating Neo's answer
+
+1. Present `orchestrator.summary` before the detailed answer.
+2. Surface every entry in `orchestrator.cautions`.
+3. Mention significant rejected hypotheses and risks from the event stream.
+   What Neo ruled out is often more useful than what he settled on.
+   Treat `hypotheses` with `public_claim_safe=false` as provisional even when
+   their prose sounds certain. Do not publish them as causal facts.
+4. Do not dump raw traces, full simulation output, or the event stream itself.
+5. **Attribute explicitly.** You call Neo inside your own coding loop and keep
+   working afterwards, so there is no visible boundary between his reasoning
+   and yours. Without attribution the user will assume every word was yours.
+   Write "Neo's take: …" or "Neo found …", and keep your own analysis in your
+   own voice.
+6. **Neo's result is an input, not the deliverable.** Continue the task —
+   inspect files, make the change, run the tests — and report the combined
+   outcome. `recommended_next_action` in the JSON names a concrete starting
+   point. When its type is `validation`, complete that named gate before
+   repeating a success claim; `validation_assessment.blocking_gate_ids` is the
+   authoritative list of remaining proof obligations.
+
+## Neo's voice
+
+Neo speaks in the first person, clipped and direct. His register shifts with how
+much he remembers about this project: a hedge at low memory ("Don't know this
+code… , maybe") is information, and terseness at high memory ("src/parser.py.
+1 change(s). 0.88.") is the same signal inverted. Relay his wording rather than
+translating it into your own register — that is also what keeps the attribution
+legible. Cautions deliberately do **not** vary by register; a warning reads the
+same however terse Neo is, and must not be softened.
+
+`orchestrator.personality` is an additional beat, present only when Neo's beat
+deck matched the situation and, for beats claiming insight, only when the run
+actually found something. It is already filtered — relay it verbatim, attached
+to the substance that earned it, or say nothing when the field is empty. There
+is no fallback line.
+
+## Notes
+
+- This skill uses explicit `advise` mode: it may retrieve established memory but does not create candidates or update durable memory. Use `neo --mode learn` only when the user intends to contribute outcome evidence.
+- For code review, optimization, architectural decisions, debugging, or pattern extraction, prefer the more specific Neo skills (`/neo-review`, `/neo-optimize`, `/neo-architect`, `/neo-debug`, `/neo-pattern`).
+- Always verify low-confidence suggestions (< 0.7) before applying them. A
+  `null` confidence is not a low one — read `confidence_basis` first.
+- For a longer delegated session with a visible boundary, prefer the **Neo
+  agent** over this mid-loop skill.

--- a/tests/test_host_adapter_parity.py
+++ b/tests/test_host_adapter_parity.py
@@ -3,18 +3,18 @@
 Neo publishes one host-neutral contract (`neo.events` + `OrchestratorMessage`)
 and thin per-host adapters that tell an orchestrator how to consume it:
 
-    .claude-plugin/   -> Claude Code agent + slash commands
-    plugins/neo/      -> Codex CLI plugin + skills
+    .claude-plugin/       -> Claude Code agent + slash commands
+    plugins/neo/          -> Codex CLI plugin + skills
+    plugins/cursor-neo/   -> Cursor plugin + skills + Neo agent
 
 Adapters drift. The Codex skills sat on "parse the four structured sections"
 for a full release after the Claude side moved to `--json`, which is exactly
 the failure these tests exist to catch: a contract change landing in one
 adapter and silently not the other.
 
-Manifest versions drift the same way. `prepare-release` documents bumping both
-plugin manifests, but a documented step with no enforcement is a step that gets
-skipped — the two manifests and the package had reached three different
-versions.
+Manifest versions drift the same way. `prepare-release` documents bumping the
+plugin manifests, but a documented step with no enforcement is a step that
+gets skipped — the package and manifests had reached three different versions.
 """
 
 import json
@@ -26,6 +26,7 @@ import pytest
 REPO = Path(__file__).resolve().parent.parent
 CLAUDE_PLUGIN = REPO / ".claude-plugin"
 CODEX_PLUGIN = REPO / "plugins" / "neo"
+CURSOR_PLUGIN = REPO / "plugins" / "cursor-neo"
 
 # The six capabilities Neo claims on every integration surface.
 CAPABILITIES = ["neo", "neo-review", "neo-debug", "neo-architect",
@@ -43,32 +44,48 @@ def _codex_skill(name: str) -> str:
     return (CODEX_PLUGIN / "skills" / name / "SKILL.md").read_text()
 
 
+def _cursor_skill(name: str) -> str:
+    return (CURSOR_PLUGIN / "skills" / name / "SKILL.md").read_text()
+
+
 def _claude_command(name: str) -> str:
     return (CLAUDE_PLUGIN / "commands" / f"{name}.md").read_text()
 
 
-# ------------------------------------------------------------ both exist
+def _claude_agent() -> str:
+    return (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
 
 
-def test_both_integration_surfaces_are_checked_in():
-    """The README claims three surfaces. Two of them are directories here, and
-    a claim in a README that no directory backs is a claim that will be found
+def _cursor_agent() -> str:
+    return (CURSOR_PLUGIN / "agents" / "neo.md").read_text()
+
+
+# ------------------------------------------------------------ surfaces exist
+
+
+def test_all_integration_surfaces_are_checked_in():
+    """The README claims three surfaces. A claim with no directory is found
     false by a user, not by us."""
     assert (CLAUDE_PLUGIN / "plugin.json").is_file()
     assert (CODEX_PLUGIN / ".codex-plugin" / "plugin.json").is_file()
+    assert (CURSOR_PLUGIN / ".cursor-plugin" / "plugin.json").is_file()
+    assert (CURSOR_PLUGIN / "agents" / "neo.md").is_file()
 
 
 @pytest.mark.parametrize("name", CAPABILITIES)
-def test_every_capability_exists_on_both_surfaces(name):
+def test_every_capability_exists_on_all_surfaces(name):
     assert (CODEX_PLUGIN / "skills" / name / "SKILL.md").is_file(), f"codex: {name}"
+    assert (CURSOR_PLUGIN / "skills" / name / "SKILL.md").is_file(), f"cursor: {name}"
     assert (CLAUDE_PLUGIN / "commands" / f"{name}.md").is_file(), f"claude: {name}"
 
 
-def test_neither_surface_carries_extra_capabilities():
-    """'The same six skills' has to stay six on both sides."""
+def test_no_surface_carries_extra_capabilities():
+    """'The same six skills' has to stay six on every host."""
     codex = {p.name for p in (CODEX_PLUGIN / "skills").iterdir() if p.is_dir()}
+    cursor = {p.name for p in (CURSOR_PLUGIN / "skills").iterdir() if p.is_dir()}
     claude = {p.stem for p in (CLAUDE_PLUGIN / "commands").glob("*.md")}
     assert codex == set(CAPABILITIES)
+    assert cursor == set(CAPABILITIES)
     assert claude == set(CAPABILITIES)
 
 
@@ -82,13 +99,26 @@ def test_local_marketplace_points_at_the_codex_plugin():
         assert (REPO / path).is_dir(), path
 
 
+def test_cursor_marketplace_points_at_the_cursor_plugin():
+    """Team / repo marketplace import reads `.cursor-plugin/marketplace.json`."""
+    manifest = json.loads((REPO / ".cursor-plugin" / "marketplace.json").read_text())
+    assert manifest["name"] == "neo-cursor"
+    sources = [p["source"] for p in manifest["plugins"]]
+    assert "./plugins/cursor-neo" in sources
+    for source in sources:
+        assert (REPO / source).is_dir(), source
+
+
 # ------------------------------------------------------------ versions
 
 
 def test_plugin_manifests_match_the_package_version():
     version = _package_version()
-    for manifest in (CLAUDE_PLUGIN / "plugin.json",
-                     CODEX_PLUGIN / ".codex-plugin" / "plugin.json"):
+    for manifest in (
+        CLAUDE_PLUGIN / "plugin.json",
+        CODEX_PLUGIN / ".codex-plugin" / "plugin.json",
+        CURSOR_PLUGIN / ".cursor-plugin" / "plugin.json",
+    ):
         assert json.loads(manifest.read_text())["version"] == version, manifest
 
 
@@ -98,7 +128,7 @@ def test_dunder_version_matches_the_package_version():
     assert __version__ == _package_version()
 
 
-# ------------------------------------------------------------ the contract
+# ------------------------------------------------------------ Codex contract
 
 
 @pytest.mark.parametrize("name", CAPABILITIES)
@@ -152,42 +182,96 @@ def test_codex_skills_teach_the_orchestrator_envelope(name):
     assert "orchestrator.cautions" in body, name
 
 
+# ------------------------------------------------------------ Cursor contract
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_cursor_skills_invoke_neo_with_json(name):
+    assert "neo --json" in _cursor_skill(name), name
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_cursor_skills_disable_implicit_directory_scan(name):
+    """Cursor mid-loop skills curate context the same way Codex does."""
+    body = _cursor_skill(name)
+    assert "neo --json --no-scan" in body, name
+    assert "`--no-scan` is mandatory" in body, name
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_cursor_skills_disclose_external_provider_data_scope(name):
+    body = _cursor_skill(name)
+    for phrase in ("external-provider", "which Neo provider", "data categories"):
+        assert phrase in body, f"{name}: missing {phrase}"
+    assert re.search(r"explicit\s+authorization", body), name
+
+
+def test_cursor_entry_skill_rejects_blanket_sensitive_context_consent():
+    body = _cursor_skill("neo")
+    assert "not blanket consent" in body
+    for secret_class in ("secrets", "credentials", "tokens", "cookies",
+                         "session"):
+        assert secret_class in body
+
+
+@pytest.mark.parametrize("name", [name for name in CAPABILITIES if name != "neo-pattern"])
+def test_cursor_advise_skills_disable_implicit_memory(name):
+    body = _cursor_skill(name)
+    assert "neo --json --no-scan --no-memory --mode advise" in body, name
+    assert "stored facts" in body, name
+
+
+def test_cursor_learning_skill_discloses_memory_retrieval_and_persistence():
+    body = _cursor_skill("neo-pattern")
+    assert "relevant stored facts" in body
+    assert "episode candidate" in body
+
+
+@pytest.mark.parametrize("name", CAPABILITIES)
+def test_cursor_skills_teach_the_orchestrator_envelope(name):
+    body = _cursor_skill(name)
+    assert "orchestrator.summary" in body, name
+    assert "orchestrator.cautions" in body, name
+
+
+# ------------------------------------------------------------ shared contract
+
+
 @pytest.mark.parametrize("name", CAPABILITIES)
 def test_no_surface_still_instructs_parsing_the_text_output(name):
     """The specific regression: Codex was told to read `CONFIDENCE`, `PLAN`,
     `SIMULATIONS`, `CODE SUGGESTIONS` out of terminal-formatted prose."""
-    for body in (_codex_skill(name), _claude_command(name)):
+    for body in (_codex_skill(name), _cursor_skill(name), _claude_command(name)):
         assert "four structured sections" not in body, name
 
 
-def test_claude_agent_and_codex_entry_skill_teach_the_same_contract():
-    """Both entry points must name the same stream split, the same fields, and
-    the same failure shape. Wording differs; the contract may not."""
-    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
-    skill = _codex_skill("neo")
+def test_entry_points_teach_the_same_contract():
+    """Every host entry point must name the same stream split, fields, and
+    failure shape. Wording differs; the contract may not."""
+    bodies = (_claude_agent(), _codex_skill("neo"), _cursor_skill("neo"),
+              _cursor_agent())
     for token in ("--json", "stdout", "stderr", "orchestrator.summary",
                   "orchestrator.cautions", "personality", "context",
                   "reasoning", "static_checks"):
-        assert token in agent, f"claude agent missing {token}"
-        assert token in skill, f"codex skill missing {token}"
+        for body in bodies:
+            assert token in body, f"missing {token}"
 
 
-def test_both_entry_points_document_the_error_shape():
+def test_entry_points_document_the_error_shape():
     """A host that reads `orchestrator` before checking `error` reports a
     successful run that never happened."""
-    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
-    skill = _codex_skill("neo")
-    for body in (agent, skill):
+    for body in (_claude_agent(), _codex_skill("neo"), _cursor_skill("neo"),
+                 _cursor_agent()):
         assert '"error"' in body
 
 
-def test_both_entry_points_teach_the_null_confidence_contract():
+def test_entry_points_teach_the_null_confidence_contract():
     """`confidence` became `Optional[float]` with a `confidence_basis` (#199).
 
     An LLM host handed `null` under a standing instruction to "report Neo's
     confidence as the number it is" has no guidance, and the failure mode is
     the exact one #199 fixed: treating a run with no number as less trustworthy
-    than an empty patch that self-reported 0.96. Both surfaces must name the
+    than an empty patch that self-reported 0.96. Every surface must name the
     null case and both basis values, or one host relays a contract the other
     does not.
     """
@@ -196,20 +280,18 @@ def test_both_entry_points_teach_the_null_confidence_contract():
         CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE,
     )
 
-    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
-    skill = _codex_skill("neo")
-    for body in (agent, skill):
+    for body in (_claude_agent(), _codex_skill("neo"), _cursor_skill("neo"),
+                 _cursor_agent()):
         assert "confidence_basis" in body
         assert "null" in body
         assert CONFIDENCE_BASIS_ANALYSIS_ONLY in body
         assert CONFIDENCE_BASIS_NO_VERIFIABLE_CHANGE in body
 
 
-def test_both_entry_points_require_attribution():
+def test_entry_points_require_attribution():
     """Neo's conclusions and the host's own analysis must stay separable."""
-    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
-    skill = _codex_skill("neo")
-    for body in (agent, skill):
+    for body in (_claude_agent(), _codex_skill("neo"), _cursor_skill("neo"),
+                 _cursor_agent()):
         assert "Neo found" in body
 
 
@@ -218,22 +300,30 @@ def test_documented_phase_names_match_the_code():
     send hosts looking for a phase that never fires."""
     from neo import events
 
-    agent = (CLAUDE_PLUGIN / "agents" / "neo.md").read_text()
-    skill = _codex_skill("neo")
-    for phase in (events.PHASE_CONTEXT, events.PHASE_REASONING,
-                  events.PHASE_STATIC_CHECKS):
-        assert phase in agent, phase
-        assert phase in skill, phase
+    for body in (_claude_agent(), _codex_skill("neo"), _cursor_skill("neo"),
+                 _cursor_agent()):
+        for phase in (events.PHASE_CONTEXT, events.PHASE_REASONING,
+                      events.PHASE_STATIC_CHECKS):
+            assert phase in body, phase
 
 
 def test_documented_event_types_exist_in_the_code():
     from neo.events import NeoEventType
 
-    skill = _codex_skill("neo")
-    documented = [t for t in ("memory_found", "hypothesis_formed",
-                              "hypothesis_rejected", "risk_found",
-                              "completed", "failed") if t in skill]
-    assert documented, "the entry skill documents no event types"
-    valid = {member.value for member in NeoEventType}
-    for name in documented:
-        assert name in valid, name
+    for label, body in (("codex", _codex_skill("neo")),
+                        ("cursor-skill", _cursor_skill("neo")),
+                        ("cursor-agent", _cursor_agent())):
+        documented = [t for t in ("memory_found", "hypothesis_formed",
+                                  "hypothesis_rejected", "risk_found",
+                                  "completed", "failed") if t in body]
+        assert documented, f"{label}: documents no event types"
+        valid = {member.value for member in NeoEventType}
+        for name in documented:
+            assert name in valid, f"{label}: {name}"
+
+
+def test_cursor_agent_uses_advise_without_mandatory_no_scan():
+    """Claude-parity agent path: visible boundary, not mid-loop privacy defaults."""
+    agent = _cursor_agent()
+    assert 'neo --json --mode advise' in agent
+    assert "neo --json --no-scan --no-memory --mode advise" not in agent

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Propagate the version in pyproject.toml to every file that restates it.
 
-One release version is written down in four places:
+One release version is written down in five places:
 
-    pyproject.toml                          <- the source of truth (the build reads it)
-    src/neo/__init__.py                     <- __version__
-    .claude-plugin/plugin.json              <- Claude Code plugin manifest
-    plugins/neo/.codex-plugin/plugin.json   <- Codex CLI plugin manifest
+    pyproject.toml                                <- the source of truth (the build reads it)
+    src/neo/__init__.py                           <- __version__
+    .claude-plugin/plugin.json                    <- Claude Code plugin manifest
+    plugins/neo/.codex-plugin/plugin.json         <- Codex CLI plugin manifest
+    plugins/cursor-neo/.cursor-plugin/plugin.json <- Cursor plugin manifest
 
-`prepare-release` used to ask a human to edit all four by hand. That is a
-documented step with no enforcement, and it got skipped: the package, the
+`prepare-release` used to ask a human to edit the derived files by hand. That
+is a documented step with no enforcement, and it got skipped: the package, the
 Claude manifest and the Codex manifest reached 0.41.0 / 0.37.0 / 0.19.0 before
 anyone noticed. `tests/test_host_adapter_parity.py` now catches the drift, but
 catching it after the fact is worse than not creating it.
@@ -41,6 +42,8 @@ DERIVED: list[tuple[Path, re.Pattern[str]]] = [
     (REPO / ".claude-plugin" / "plugin.json",
      re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.MULTILINE)),
     (REPO / "plugins" / "neo" / ".codex-plugin" / "plugin.json",
+     re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.MULTILINE)),
+    (REPO / "plugins" / "cursor-neo" / ".cursor-plugin" / "plugin.json",
      re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.MULTILINE)),
 ]
 


### PR DESCRIPTION
## Context

Joe Rinehart here. I'm working on a project using Neo and exploring using Cursor instead of Claude. I've come to enjoy Neo, esp. plan reviews, and I wanted to be able to use it from Cursor...so I had Cursor plan and prep this PR. It:

1. Should be consistent with the adapter pattern used for Claude vs. Codex. In other words, its approach of a parallel skill shouldn't be surprising.
2. Updates documents that used to say things like "two adapters" to refer to three.
3. Does **not** contain a transcript/session reader: I'm working on that now and would submit a separate PR.

## Description

Add a third host adapter for **Cursor**, at parity with the existing Claude Code and Codex surfaces for *invoking* Neo via `neo --json`.

### What this adds

| Piece | Path / meaning |
|---|---|
| Cursor plugin package | `plugins/cursor-neo/` |
| Six mid-loop skills | `plugins/cursor-neo/skills/{neo,neo-review,neo-optimize,neo-architect,neo-debug,neo-pattern}/` — invoke via `/neo`… in Agent chat |
| Dedicated Neo agent | `plugins/cursor-neo/agents/neo.md` — a Cursor **custom agent**: a named specialist persona the host can switch to (“use the Neo agent…”). It owns the full `neo --json` communication protocol and runs as a **visible boundary** (like Claude Code’s Neo subagent), not as a mid-loop `/neo` skill. Distinct from Cursor’s default coding agent. |
| In-repo marketplace catalog | `.cursor-plugin/marketplace.json` → `./plugins/cursor-neo` |
| Version sync | `tools/sync_version.py` (+ prepare-release skill) now includes the Cursor manifest |
| Parity enforcement | `tests/test_host_adapter_parity.py` extended from two surfaces → three |
| Docs | README / QUICKSTART / INSTALL / CONTRIBUTING / CLAUDE.md / AGENTS.md / `docs/solutions/orchestrator-communication.md` |

Same six capabilities, same orchestrator contract (`stdout` JSON + `stderr` JSONL, `orchestrator.summary` / `cautions`, error shape, null `confidence` + `confidence_basis`). No MCP server (matches Claude/Codex: skills wrap the CLI).

### How it adds it (consistent with prior work)

- **Codex pattern for packaging:** plugin under `plugins/…`, skills as `SKILL.md`, in-tree marketplace JSON (like `.agents/plugins/marketplace.json` for Codex).
- **Claude pattern for the agent:** `agents/neo.md` owns the visible-boundary protocol (port of `.claude-plugin/agents/neo.md`, Cursor frontmatter).
- **Wire contract unchanged:** hosts still do not own an output format; they invoke `neo --json` and read `OrchestratorMessage` / events.
- **`make sync-version` remains the only version writer** for plugin manifests (now four derived files: `__init__.py` + Claude + Codex + Cursor).

Install for review: `ln -s "$(pwd)/plugins/cursor-neo" ~/.cursor/plugins/local/neo` then Reload Window; or import the repo as a Cursor team marketplace (`neo-cursor`).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issue

N/A (follow-up: Cursor transcript mining / `CursorSource` — stacked separately)

## Motivation and Context

Cursor users already get **inbound** Neo context (`.cursor/rules` via `agent_context` / constraints). They did not get an **outbound** host adapter. Claude and Codex plugins exist; Cursor only appeared in docs as a rules consumer. This closes the invoke/packaging gap so Cursor can call Neo the same way those hosts do.

## How Has This Been Tested?

- [x] `ruff check src/ tests/ tools/` clean
- [x] `python tools/sync_version.py --check` clean
- [x] `pytest tests/test_host_adapter_parity.py` — 87 passed (three-surface contract)
- [x] Full local `pytest` — 2754 passed, 29 skipped
- [x] GitHub Actions CI on this fork PR
- [x] Manual Cursor smoke: Reload Window, `/neo`, optional Neo agent (local symlink)

**Test Configuration**:
- Python version: 3.12.5 (local venv)
- OS: macOS
- Neo version: 0.52.1

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] CI green on this PR
- [x] Local Cursor Reload Window smoke confirmed by author

## Additional Notes — please read (intentional asymmetries)

These are **deliberate**, not accidental drift from Claude/Codex:

1. **One package, two roles (neither existing host does both in one tree).**  
   Cursor ships **Claude-style agent + Codex-style skills** together. Codex remains skills-only; Claude remains agent + slash commands. Cursor combines both because the product supports both UX shapes.

2. **Invoke flags differ by surface inside the same plugin (easy to misread as a bug).**  
   - Skills (mid-loop): `neo --json --no-scan --no-memory --mode advise` (heredoc); `neo-pattern` uses `learn` without `--no-memory` — **Codex-identical**.  
   - Agent (visible boundary): `neo --json --mode advise "…"` — **Claude-identical**, no mandatory `--no-scan` / `--no-memory`.  
   Parity tests assert both behaviors.

3. **No `commands/` directory.**  
   Claude uses `.claude-plugin/commands/*.md`. Cursor uses skills with `disable-model-invocation: true` so `/neo`… is the slash UX. Avoids a third copy of the six entry points.

4. **Marketplace id is `neo-cursor`, not `neo-local`.**  
   Codex’s in-repo marketplace is already named `neo-local`. Renaming avoids doc/conversation collisions; behavior is the same pattern.

5. **Explicitly out of scope (follow-up).**  
   **No `CursorSource` for transcript/session mining.** Observer + `neo memory issues` still only use Claude Code / Codex / CAR (+ GitHub PR). Cursor chats still do not update the FactStore via mining. That is a separate stacked PR; Claude/Codex *plugins* never owned mining either — the observer does.

6. **Docs / CONTRIBUTING now say three surfaces.**  
   CLAUDE.md host-adapter bullet, AGENTS.md condensed note, CONTRIBUTING “Adding Features” (#4–#6 Claude/Codex/Cursor), and orchestrator-communication “one contract, three adapters” all update the previous “two adapters” story. Reviewers should expect that wording shift.

7. **Not changed:** FactStore path, episode promotion gates, engine/events/`OrchestratorMessage`, MCP absence, Claude external marketplace (`claude-code-plugins`).


Made with [Cursor](https://cursor.com)
